### PR TITLE
feat: マルチモーダル入出力・sealedエラー・ツール・構造化出力の全面対応

### DIFF
--- a/pkgs/ai_box/README.md
+++ b/pkgs/ai_box/README.md
@@ -22,6 +22,155 @@ An abstract class that all AI providers (such as ChatGPT, Claude, Gemini, etc.) 
 
 - `chatWithStrings()`: Chat with an array of strings
 - `generateText()`: Simple text generation
+- `generateTextStream()`: Stream text output
+- `askWithImages()`: One-shot prompt with images
+
+## Multimodal input
+
+Pass images, audio, or files as `LLMContentPart`s on any message. The same
+abstraction works across every provider — the provider converts it to the
+right wire format (OpenAI content arrays, Claude content blocks, Gemini
+`inlineData` / `fileData`).
+
+```dart
+import 'dart:typed_data';
+import 'package:ai_box/ai_box.dart';
+
+final res = await ai.chat(
+  model: 'gpt-4o',
+  messages: [
+    LLMContent.user('Describe these', attachments: [
+      LLMImagePart.bytes(pngBytes, mimeType: 'image/png'),
+      LLMImagePart.url('https://example.com/photo.jpg'),
+      LLMFilePart.bytes(pdfBytes, mimeType: 'application/pdf'),
+    ]),
+  ],
+);
+print(res.text);
+```
+
+### Just drop in a `File` (`dart:io`)
+
+```dart
+import 'package:ai_box/io.dart';
+
+final msg = LLMContent.user('What is in these?', attachments: [
+  File('photo.png').toImagePart(),
+  File('report.pdf').toFilePart(),
+  File('memo.mp3').toAudioPart(),
+]);
+```
+
+`ai_box` core stays platform-agnostic (no `dart:io`); the `File` helpers live
+in the separate `package:ai_box/io.dart` import.
+
+## Output: sealed parts cover every case
+
+`LLMContent.parts` is a list of the sealed `LLMContentPart`, so a `switch`
+is exhaustive:
+
+```dart
+for (final part in res.content.parts) {
+  switch (part) {
+    case LLMTextPart(:final text): print(text);
+    case LLMImagePart(): saveImage(part.bytes);      // generated image bytes
+    case LLMAudioPart(): saveAudio(part.bytes);      // generated audio bytes
+    case LLMFilePart(): saveFile(part.bytes);
+    case LLMToolCallPart(:final name): callTool(name, part.arguments);
+    case LLMToolResultPart(): break;
+    case LLMReasoningPart(:final text): logThinking(text);
+    case LLMCodeExecutionPart(): break;
+    case LLMCodeExecutionResultPart(): break;
+  }
+}
+```
+
+Convenience getters: `res.text`, `res.content.images`, `res.content.audioList`,
+`res.content.files`, `res.toolCalls`, `res.content.reasoning`.
+
+`res.finishReason` is the normalized `LLMFinishReason` enum
+(`stop` / `length` / `toolCalls` / `contentFilter` / `other`), and
+`res.usage` carries `inputTokens` / `outputTokens` / `cachedInputTokens` /
+`reasoningTokens`.
+
+## Error handling: sealed `LLMException`
+
+Every provider normalizes failures into a sealed `LLMException`:
+
+```dart
+try {
+  await ai.generateText(model: '...', message: 'hi');
+} on LLMException catch (e) {
+  switch (e) {
+    case LLMAuthException(): // 401 / 403
+    case LLMRateLimitException(): // 429
+    case LLMInvalidRequestException(): // 4xx
+    case LLMServerException(): // 5xx
+    case LLMNetworkException(): // connectivity
+    case LLMUnknownException():
+  }
+}
+```
+
+## Tool / function calling
+
+```dart
+final res = await ai.chat(
+  model: 'gpt-4o',
+  messages: [LLMContent.user('Weather in Tokyo?')],
+  tools: [
+    LLMTool(
+      name: 'get_weather',
+      description: 'Get current weather',
+      parameters: {
+        'type': 'object',
+        'properties': {'city': {'type': 'string'}},
+        'required': ['city'],
+      },
+    ),
+  ],
+  toolChoice: LLMToolChoice.auto,
+);
+
+for (final call in res.toolCalls) {
+  final result = await runTool(call.name, call.arguments);
+  // Send the result back on the next turn:
+  // LLMContent(role: LLMRole.user, parts: [
+  //   LLMToolResultPart(toolCallId: call.id, content: result),
+  // ])
+}
+```
+
+## Structured output (JSON Schema)
+
+```dart
+final res = await ai.chat(
+  model: 'gpt-4o',
+  messages: [LLMContent.user('Extract name and age')],
+  responseFormat: LLMResponseFormat.jsonSchema(
+    schema: {
+      'type': 'object',
+      'properties': {
+        'name': {'type': 'string'},
+        'age': {'type': 'integer'},
+      },
+      'required': ['name', 'age'],
+    },
+  ),
+);
+```
+
+## Streaming
+
+```dart
+await for (final text in ai.generateTextStream(model: '...', message: 'Hi')) {
+  stdout.write(text);
+}
+```
+
+> Note: the base `completionsStream()` currently emits the full response as a
+> single chunk (a non-incremental fallback). Providers can override it with
+> true token-by-token SSE streaming.
 
 ## Common Tests
 

--- a/pkgs/ai_box/lib/ai_box.dart
+++ b/pkgs/ai_box/lib/ai_box.dart
@@ -1,2 +1,7 @@
 export 'package:ai_box/src/ai_base.dart';
+export 'package:ai_box/src/content.dart';
+export 'package:ai_box/src/exceptions.dart';
 export 'package:ai_box/src/llm_ai_base.dart';
+export 'package:ai_box/src/request.dart';
+export 'package:ai_box/src/response.dart';
+export 'package:ai_box/src/stream.dart';

--- a/pkgs/ai_box/lib/io.dart
+++ b/pkgs/ai_box/lib/io.dart
@@ -1,0 +1,71 @@
+/// dart:io 連携ライブラリ。
+///
+/// `import 'package:ai_box/io.dart';` すると [File] から各種パーツを
+/// 1 行で生成できる拡張が使えるようになる（ファイルを「入れるだけ」）。
+///
+/// ```dart
+/// import 'package:ai_box/io.dart';
+///
+/// final msg = LLMContent.user('説明して', attachments: [
+///   File('photo.png').toImagePart(),
+///   File('doc.pdf').toFilePart(),
+/// ]);
+/// ```
+library;
+
+import 'dart:io';
+
+import 'package:ai_box/src/content.dart';
+
+/// dart:io の [File] から ai_box のパーツを生成する拡張。
+extension LLMFileParts on File {
+  /// 画像パーツを生成する（バイト列を同期読み込み）。
+  LLMImagePart toImagePart({String? mimeType}) => LLMImagePart.bytes(
+        readAsBytesSync(),
+        mimeType: mimeType ?? _mimeFromPath(path, 'image/png'),
+      );
+
+  /// 音声パーツを生成する。
+  LLMAudioPart toAudioPart({String? mimeType}) => LLMAudioPart.bytes(
+        readAsBytesSync(),
+        mimeType: mimeType ?? _mimeFromPath(path, 'audio/mpeg'),
+      );
+
+  /// 任意ファイル（PDF など）のパーツを生成する。
+  LLMFilePart toFilePart({String? mimeType}) => LLMFilePart.bytes(
+        readAsBytesSync(),
+        mimeType: mimeType ?? _mimeFromPath(path, 'application/octet-stream'),
+        filename: uri.pathSegments.isNotEmpty ? uri.pathSegments.last : null,
+      );
+}
+
+String _mimeFromPath(String path, String fallback) {
+  final dot = path.lastIndexOf('.');
+  if (dot < 0) return fallback;
+  final ext = path.substring(dot + 1).toLowerCase();
+  return _mimeByExt[ext] ?? fallback;
+}
+
+const _mimeByExt = <String, String>{
+  'png': 'image/png',
+  'jpg': 'image/jpeg',
+  'jpeg': 'image/jpeg',
+  'gif': 'image/gif',
+  'webp': 'image/webp',
+  'heic': 'image/heic',
+  'bmp': 'image/bmp',
+  'pdf': 'application/pdf',
+  'txt': 'text/plain',
+  'md': 'text/markdown',
+  'csv': 'text/csv',
+  'json': 'application/json',
+  'mp3': 'audio/mpeg',
+  'wav': 'audio/wav',
+  'ogg': 'audio/ogg',
+  'm4a': 'audio/mp4',
+  'aac': 'audio/aac',
+  'flac': 'audio/flac',
+  'mp4': 'video/mp4',
+  'mov': 'video/quicktime',
+  'webm': 'video/webm',
+};

--- a/pkgs/ai_box/lib/src/ai_base.dart
+++ b/pkgs/ai_box/lib/src/ai_base.dart
@@ -1,16 +1,24 @@
+/// すべての AI プロバイダーの基底クラス。
 abstract class AIBase {
   const AIBase({required this.apiKey});
 
   final String apiKey;
 
+  /// 利用可能なモデル一覧を取得する。
   Future<List<AIModel>> getModels();
 
+  /// 利用可能なモデル ID 一覧を取得する。
   Future<List<String>> getModelIds() async =>
       (await getModels()).map((m) => m.id).toList();
 
+  /// API キーが有効か検証する。
   Future<bool> validateKey();
 }
 
+/// 入出力のモダリティ。
+enum LLMModality { text, image, audio, video, document }
+
+/// モデル情報。
 class AIModel {
   const AIModel({
     required this.id,
@@ -18,13 +26,27 @@ class AIModel {
     this.created,
     this.description,
     this.contextLength,
+    this.maxOutputTokens,
+    this.inputModalities,
+    this.outputModalities,
   });
 
   final String id;
   final String? name;
   final DateTime? created;
   final String? description;
+
+  /// コンテキストウィンドウ（入力トークン上限）。
   final int? contextLength;
+
+  /// 最大出力トークン数。
+  final int? maxOutputTokens;
+
+  /// 入力で対応するモダリティ（判明している場合）。
+  final Set<LLMModality>? inputModalities;
+
+  /// 出力で対応するモダリティ（判明している場合）。
+  final Set<LLMModality>? outputModalities;
 
   @override
   String toString() {

--- a/pkgs/ai_box/lib/src/content.dart
+++ b/pkgs/ai_box/lib/src/content.dart
@@ -1,0 +1,305 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// 発言者のロール。
+enum LLMRole { model, user, system }
+
+/// 1 つのメッセージ（1 ロール分）を表す。
+///
+/// 本文は [parts] が唯一の真実。テキストのみを扱いたい場合は
+/// [LLMContent.text] / [LLMContent.user] などのファクトリが便利。
+/// 画像・音声・ファイルは [LLMContent.user] の `attachments` で添付する。
+///
+/// ```dart
+/// // テキストのみ
+/// LLMContent.user('こんにちは');
+///
+/// // 画像付き（バイト列）
+/// LLMContent.user('この画像を説明して', attachments: [
+///   LLMImagePart.bytes(bytes, mimeType: 'image/png'),
+/// ]);
+///
+/// // dart:io の File から（import 'package:ai_box/io.dart';）
+/// LLMContent.user('説明して', attachments: [file.toImagePart()]);
+/// ```
+class LLMContent {
+  const LLMContent({required this.role, required this.parts});
+
+  /// テキストのみのメッセージを作る。
+  factory LLMContent.text(LLMRole role, String text) =>
+      LLMContent(role: role, parts: [LLMTextPart(text)]);
+
+  /// user ロールのメッセージ。画像・音声・ファイルなどを [attachments] で添付できる。
+  factory LLMContent.user(
+    String text, {
+    List<LLMContentPart> attachments = const [],
+  }) =>
+      LLMContent(
+        role: LLMRole.user,
+        parts: [
+          if (text.isNotEmpty) LLMTextPart(text),
+          ...attachments,
+        ],
+      );
+
+  /// system ロールのメッセージ。
+  factory LLMContent.system(String text) =>
+      LLMContent.text(LLMRole.system, text);
+
+  /// model（assistant）ロールのメッセージ。
+  factory LLMContent.model(String text) => LLMContent.text(LLMRole.model, text);
+
+  final LLMRole role;
+
+  /// メッセージを構成するパーツ。テキスト・画像・音声・ファイル・ツール呼び出しなど。
+  final List<LLMContentPart> parts;
+
+  /// テキストパートを連結した文字列。マルチモーダルでもテキスト部分だけを返す。
+  String get text => parts.whereType<LLMTextPart>().map((p) => p.text).join();
+
+  /// [text] のエイリアス（後方互換）。
+  String get content => text;
+
+  /// 画像パーツを含むか。
+  bool get hasImages => parts.any((p) => p is LLMImagePart);
+
+  /// 画像パーツの一覧。
+  List<LLMImagePart> get images => parts.whereType<LLMImagePart>().toList();
+
+  /// 音声パーツを含むか。
+  bool get hasAudio => parts.any((p) => p is LLMAudioPart);
+
+  /// 音声パーツの一覧。
+  List<LLMAudioPart> get audioList => parts.whereType<LLMAudioPart>().toList();
+
+  /// ファイルパーツを含むか。
+  bool get hasFiles => parts.any((p) => p is LLMFilePart);
+
+  /// ファイルパーツの一覧。
+  List<LLMFilePart> get files => parts.whereType<LLMFilePart>().toList();
+
+  /// ツール呼び出しパーツを含むか。
+  bool get hasToolCalls => parts.any((p) => p is LLMToolCallPart);
+
+  /// ツール呼び出しパーツの一覧。
+  List<LLMToolCallPart> get toolCalls =>
+      parts.whereType<LLMToolCallPart>().toList();
+
+  /// 推論（thinking）パーツを含むか。
+  bool get hasReasoning => parts.any((p) => p is LLMReasoningPart);
+
+  /// 推論（thinking）テキストを連結した文字列。
+  String get reasoning =>
+      parts.whereType<LLMReasoningPart>().map((p) => p.text).join();
+
+  @override
+  String toString() => 'LLMContent(role: $role, parts: ${parts.length})';
+}
+
+/// メッセージを構成する 1 パーツ。入力・出力どちらにも使う sealed クラス。
+///
+/// `switch` で全ケースを網羅的に処理できる。
+sealed class LLMContentPart {}
+
+/// テキストパーツ。
+final class LLMTextPart extends LLMContentPart {
+  LLMTextPart(this.text);
+
+  final String text;
+}
+
+/// 画像パーツ（入力・出力共通）。URL またはバイト列のいずれかを保持する。
+///
+/// - 入力: `LLMImagePart.bytes(...)` / `LLMImagePart.url(...)`
+/// - 出力: プロバイダーが生成画像を [bytes] で、参照画像を [url] で返す。
+final class LLMImagePart extends LLMContentPart {
+  /// 通常の URL または `data:` URI の文字列から作る。
+  LLMImagePart.url(this.url)
+      : bytes = null,
+        mimeType = null;
+
+  /// 生のバイト列から作る。[mimeType] は `image/png` など。
+  LLMImagePart.bytes(Uint8List data, {this.mimeType = 'image/png'})
+      : bytes = data,
+        url = null;
+
+  /// `data:image/png;base64,...` 形式の data URI からバイト列を復元する。
+  /// 解析できない場合は URL として保持する。
+  factory LLMImagePart.dataUri(String dataUri) {
+    final parsed = _parseDataUri(dataUri);
+    if (parsed == null) return LLMImagePart.url(dataUri);
+    return LLMImagePart.bytes(parsed.$2, mimeType: parsed.$1);
+  }
+
+  /// 参照 URL（または data URI）。バイト列で保持する場合は null。
+  final String? url;
+
+  /// 生のバイト列。URL で保持する場合は null。
+  final Uint8List? bytes;
+
+  /// MIME タイプ（バイト列の場合）。
+  final String? mimeType;
+
+  /// バイト列を保持しているか。
+  bool get hasBytes => bytes != null;
+
+  /// URL を保持しているか。
+  bool get isUrl => url != null;
+
+  /// base64 エンコード済み文字列（バイト列を持つ場合のみ）。
+  String? get base64Data => bytes == null ? null : base64Encode(bytes!);
+
+  /// 送信用に URL もしくは data URI 文字列へ変換する。
+  String get asUrlOrDataUri =>
+      url ?? 'data:${mimeType ?? 'image/png'};base64,${base64Encode(bytes!)}';
+}
+
+/// 音声パーツ（入力・出力共通）。
+final class LLMAudioPart extends LLMContentPart {
+  /// URL から作る。
+  LLMAudioPart.url(this.url, {this.mimeType, this.transcript}) : bytes = null;
+
+  /// 生のバイト列から作る。
+  LLMAudioPart.bytes(Uint8List data, {this.mimeType, this.transcript})
+      : bytes = data,
+        url = null;
+
+  /// base64 文字列から作る。
+  factory LLMAudioPart.base64(
+    String base64Data, {
+    String? mimeType,
+    String? transcript,
+  }) =>
+      LLMAudioPart.bytes(
+        base64Decode(base64Data),
+        mimeType: mimeType,
+        transcript: transcript,
+      );
+
+  /// 参照 URL。バイト列で保持する場合は null。
+  final String? url;
+
+  /// 生のバイト列。
+  final Uint8List? bytes;
+
+  /// MIME タイプ（`audio/mp3`、`audio/wav` など）。
+  final String? mimeType;
+
+  /// 音声のテキスト書き起こし（利用可能な場合のみ）。
+  final String? transcript;
+
+  /// バイト列を保持しているか。
+  bool get hasBytes => bytes != null;
+
+  /// base64 エンコード済み文字列（バイト列を持つ場合のみ）。
+  String? get base64Data => bytes == null ? null : base64Encode(bytes!);
+}
+
+/// 任意ファイル（PDF などのドキュメント）パーツ。
+final class LLMFilePart extends LLMContentPart {
+  /// URL（または provider のファイル URI）から作る。
+  LLMFilePart.url(this.url, {this.mimeType, this.filename}) : bytes = null;
+
+  /// 生のバイト列から作る。
+  LLMFilePart.bytes(Uint8List data, {required this.mimeType, this.filename})
+      : bytes = data,
+        url = null;
+
+  /// 参照 URL。
+  final String? url;
+
+  /// 生のバイト列。
+  final Uint8List? bytes;
+
+  /// MIME タイプ（`application/pdf` など）。
+  final String? mimeType;
+
+  /// ファイル名（任意）。
+  final String? filename;
+
+  /// バイト列を保持しているか。
+  bool get hasBytes => bytes != null;
+
+  /// base64 エンコード済み文字列（バイト列を持つ場合のみ）。
+  String? get base64Data => bytes == null ? null : base64Encode(bytes!);
+}
+
+/// ツール呼び出しパーツ（出力）。モデルが関数を呼び出す際に返される。
+final class LLMToolCallPart extends LLMContentPart {
+  LLMToolCallPart({
+    required this.id,
+    required this.name,
+    required this.arguments,
+  });
+
+  final String id;
+  final String name;
+
+  /// 関数に渡す引数（パース済み）。
+  final Map<String, dynamic> arguments;
+}
+
+/// ツール実行結果パーツ（入力）。前ターンの [LLMToolCallPart] への応答を返す。
+final class LLMToolResultPart extends LLMContentPart {
+  LLMToolResultPart({
+    required this.toolCallId,
+    required this.content,
+    this.toolName,
+    this.isError = false,
+  });
+
+  /// 対応する [LLMToolCallPart.id]。
+  final String toolCallId;
+
+  /// 実行結果（文字列。JSON の場合はその文字列）。
+  final String content;
+
+  /// 関数名（Gemini など名前で紐付けるプロバイダー向け）。
+  final String? toolName;
+
+  /// 実行がエラーだったか。
+  final bool isError;
+}
+
+/// 推論（thinking / reasoning）パーツ（出力）。
+final class LLMReasoningPart extends LLMContentPart {
+  LLMReasoningPart(this.text, {this.signature});
+
+  final String text;
+
+  /// 署名付き thinking（Claude）の署名。
+  final String? signature;
+}
+
+/// コード実行パーツ（Gemini）。モデルが実行を要求したコード。
+final class LLMCodeExecutionPart extends LLMContentPart {
+  LLMCodeExecutionPart({required this.code, required this.language});
+
+  final String code;
+  final String language;
+}
+
+/// コード実行結果パーツ（Gemini）。
+final class LLMCodeExecutionResultPart extends LLMContentPart {
+  LLMCodeExecutionResultPart({required this.outcome, this.output});
+
+  /// 実行結果: ok / failed / deadline_exceeded など。
+  final String outcome;
+  final String? output;
+}
+
+/// `data:<mime>;base64,<data>` を (mimeType, bytes) に分解する。
+(String, Uint8List)? _parseDataUri(String s) {
+  if (!s.startsWith('data:')) return null;
+  final comma = s.indexOf(',');
+  if (comma < 0) return null;
+  final meta = s.substring(5, comma);
+  final dataPart = s.substring(comma + 1);
+  final mime = meta.split(';').first;
+  try {
+    final bytes = base64Decode(dataPart);
+    return (mime.isEmpty ? 'application/octet-stream' : mime, bytes);
+  } on FormatException {
+    return null;
+  }
+}

--- a/pkgs/ai_box/lib/src/exceptions.dart
+++ b/pkgs/ai_box/lib/src/exceptions.dart
@@ -1,0 +1,196 @@
+/// ai_box が投げる例外の基底 sealed クラス。
+///
+/// すべての LLM プロバイダーは API 呼び出しの失敗をこの階層へ正規化する。
+/// 呼び出し側は `switch` で全ケースを網羅的に処理できる。
+///
+/// ```dart
+/// try {
+///   await ai.generateText(model: 'gpt-4o', message: 'hi');
+/// } on LLMException catch (e) {
+///   final msg = switch (e) {
+///     LLMAuthException() => 'APIキーが無効です',
+///     LLMRateLimitException() => 'レート制限に達しました',
+///     LLMInvalidRequestException() => 'リクエストが不正です: ${e.message}',
+///     LLMServerException() => 'サーバーエラー',
+///     LLMNetworkException() => 'ネットワークエラー',
+///     LLMUnknownException() => '不明なエラー',
+///   };
+///   print(msg);
+/// }
+/// ```
+sealed class LLMException implements Exception {
+  const LLMException(
+    this.message, {
+    this.statusCode,
+    this.provider,
+    this.code,
+    this.raw,
+  });
+
+  /// HTTP ステータスコードとレスポンスボディから適切な例外型を生成する。
+  factory LLMException.fromHttp(
+    int statusCode, {
+    String? provider,
+    Object? body,
+  }) {
+    final message =
+        _extractMessage(body) ?? 'Request failed with status $statusCode';
+    final code = _extractCode(body);
+    if (statusCode == 401 || statusCode == 403) {
+      return LLMAuthException(
+        message,
+        statusCode: statusCode,
+        provider: provider,
+        code: code,
+        raw: body,
+      );
+    }
+    if (statusCode == 429) {
+      return LLMRateLimitException(
+        message,
+        statusCode: statusCode,
+        provider: provider,
+        code: code,
+        raw: body,
+      );
+    }
+    if (statusCode >= 400 && statusCode < 500) {
+      return LLMInvalidRequestException(
+        message,
+        statusCode: statusCode,
+        provider: provider,
+        code: code,
+        raw: body,
+      );
+    }
+    if (statusCode >= 500) {
+      return LLMServerException(
+        message,
+        statusCode: statusCode,
+        provider: provider,
+        code: code,
+        raw: body,
+      );
+    }
+    return LLMUnknownException(
+      message,
+      statusCode: statusCode,
+      provider: provider,
+      code: code,
+      raw: body,
+    );
+  }
+
+  /// 人間可読のエラーメッセージ。
+  final String message;
+
+  /// HTTP ステータスコード（取得できた場合）。
+  final int? statusCode;
+
+  /// 発生元プロバイダー名（'openai' / 'claude' / 'gemini' など）。
+  final String? provider;
+
+  /// プロバイダー固有のエラーコード／タイプ文字列（取得できた場合）。
+  final String? code;
+
+  /// 元の例外・レスポンスボディなど（デバッグ用）。
+  final Object? raw;
+
+  static String? _extractMessage(Object? body) {
+    if (body is Map) {
+      final error = body['error'];
+      if (error is Map && error['message'] is String) {
+        return error['message'] as String;
+      }
+      if (error is String) return error;
+      if (body['message'] is String) return body['message'] as String;
+    }
+    return null;
+  }
+
+  static String? _extractCode(Object? body) {
+    if (body is Map) {
+      final error = body['error'];
+      if (error is Map) {
+        final c = error['type'] ?? error['code'];
+        if (c != null) return c.toString();
+      }
+      final c = body['code'];
+      if (c != null) return c.toString();
+    }
+    return null;
+  }
+
+  @override
+  String toString() {
+    final p = provider != null ? '[$provider] ' : '';
+    final s = statusCode != null ? ' (HTTP $statusCode)' : '';
+    return 'LLMException: $p$message$s';
+  }
+}
+
+/// 認証エラー（HTTP 401 / 403）。APIキーが無効・権限不足など。
+final class LLMAuthException extends LLMException {
+  const LLMAuthException(
+    super.message, {
+    super.statusCode,
+    super.provider,
+    super.code,
+    super.raw,
+  });
+}
+
+/// レート制限エラー（HTTP 429）。
+final class LLMRateLimitException extends LLMException {
+  const LLMRateLimitException(
+    super.message, {
+    super.statusCode,
+    super.provider,
+    super.code,
+    super.raw,
+  });
+}
+
+/// リクエスト不正エラー（HTTP 4xx）。パラメータ誤り・モデル名誤りなど。
+final class LLMInvalidRequestException extends LLMException {
+  const LLMInvalidRequestException(
+    super.message, {
+    super.statusCode,
+    super.provider,
+    super.code,
+    super.raw,
+  });
+}
+
+/// サーバーエラー（HTTP 5xx）。
+final class LLMServerException extends LLMException {
+  const LLMServerException(
+    super.message, {
+    super.statusCode,
+    super.provider,
+    super.code,
+    super.raw,
+  });
+}
+
+/// ネットワークエラー。接続失敗・タイムアウト・レスポンス解析不能など。
+final class LLMNetworkException extends LLMException {
+  const LLMNetworkException(
+    super.message, {
+    super.statusCode,
+    super.provider,
+    super.code,
+    super.raw,
+  });
+}
+
+/// 上記いずれにも分類できない不明なエラー。
+final class LLMUnknownException extends LLMException {
+  const LLMUnknownException(
+    super.message, {
+    super.statusCode,
+    super.provider,
+    super.code,
+    super.raw,
+  });
+}

--- a/pkgs/ai_box/lib/src/llm_ai_base.dart
+++ b/pkgs/ai_box/lib/src/llm_ai_base.dart
@@ -1,22 +1,56 @@
 import 'package:ai_box/src/ai_base.dart';
+import 'package:ai_box/src/content.dart';
+import 'package:ai_box/src/request.dart';
+import 'package:ai_box/src/response.dart';
+import 'package:ai_box/src/stream.dart';
 
+/// すべての LLM プロバイダー（ChatGPT / Claude / Gemini など）が
+/// 継承すべき抽象クラス。
+///
+/// 実装すべきは [completions] / [getModels] / [validateKey] の 3 つ。
+/// [chat] / [chatWithStrings] / [generateText] / [completionsStream] などの
+/// 便利メソッドはここで提供される。
 abstract class LLMAIBase extends AIBase implements LLMAIInterface {
   const LLMAIBase({required super.apiKey});
 
   @override
   Future<LLMCompletionResponse> completions(LLMCompletionRequest request);
 
+  /// ストリーミング応答。
+  ///
+  /// 既定実装は [completions] を呼び、結果を 1 チャンクとして流す
+  /// （非インクリメンタルなフォールバック）。プロバイダーは真の SSE
+  /// ストリーミングでオーバーライドできる。
+  @override
+  Stream<LLMStreamChunk> completionsStream(
+    LLMCompletionRequest request,
+  ) async* {
+    final res = await completions(request);
+    yield LLMStreamChunk(
+      delta: res.content.text,
+      parts: res.content.parts,
+      finishReason: res.finishReason,
+      usage: res.usage,
+    );
+  }
+
   /// [completions] の簡易ラッパー。
   Future<LLMCompletionResponse> chat({
     required String model,
     required List<LLMContent> messages,
     int? maxTokens,
+    List<LLMTool>? tools,
+    LLMToolChoice? toolChoice,
+    LLMResponseFormat? responseFormat,
   }) {
     return completions(
       LLMCompletionRequest(
         model: model,
         messages: messages,
         maxTokens: maxTokens,
+        tools: tools,
+        toolChoice: toolChoice,
+        responseFormat: responseFormat,
       ),
     );
   }
@@ -31,7 +65,7 @@ abstract class LLMAIBase extends AIBase implements LLMAIInterface {
     final nowMessages = <LLMContent>[];
 
     for (final message in messages) {
-      nowMessages.add(LLMContent(role: nowAuthor, content: message));
+      nowMessages.add(LLMContent.text(nowAuthor, message));
       nowAuthor = nowAuthor == LLMRole.user ? LLMRole.model : LLMRole.user;
     }
 
@@ -39,7 +73,7 @@ abstract class LLMAIBase extends AIBase implements LLMAIInterface {
       model: model,
       messages: nowMessages,
       maxTokens: maxTokens,
-    ).then((value) => value.content.content);
+    ).then((value) => value.content.text);
   }
 
   /// 単一メッセージを送って返答文字列を得る最小ラッパー。
@@ -54,13 +88,51 @@ abstract class LLMAIBase extends AIBase implements LLMAIInterface {
       maxTokens: maxTokens,
     );
   }
+
+  /// 単一プロンプトの応答をテキストでストリーミングする。
+  Stream<String> generateTextStream({
+    required String model,
+    required String message,
+    int? maxTokens,
+  }) async* {
+    final req = LLMCompletionRequest(
+      model: model,
+      messages: [LLMContent.user(message)],
+      maxTokens: maxTokens,
+    );
+    await for (final chunk in completionsStream(req)) {
+      if (chunk.delta.isNotEmpty) yield chunk.delta;
+    }
+  }
+
+  /// 画像付きの簡易プロンプト。[images] に [LLMImagePart] を渡すだけで使える。
+  ///
+  /// ```dart
+  /// final answer = await ai.askWithImages(
+  ///   model: 'gpt-4o',
+  ///   prompt: 'この画像を説明して',
+  ///   images: [LLMImagePart.bytes(bytes, mimeType: 'image/png')],
+  /// );
+  /// ```
+  Future<String> askWithImages({
+    required String model,
+    required String prompt,
+    required List<LLMImagePart> images,
+    int? maxTokens,
+  }) {
+    return chat(
+      model: model,
+      messages: [LLMContent.user(prompt, attachments: images)],
+      maxTokens: maxTokens,
+    ).then((v) => v.content.text);
+  }
 }
 
 /// ai_box の LLM プロバイダーが実装すべき最小インターフェース。
-/// 便利メソッド (chat / chatWithStrings / generateText) は
-/// [LLMAIBase] の具象実装を使うこと。
 abstract class LLMAIInterface {
   Future<LLMCompletionResponse> completions(LLMCompletionRequest request);
+
+  Stream<LLMStreamChunk> completionsStream(LLMCompletionRequest request);
 
   Future<List<AIModel>> getModels();
 
@@ -68,175 +140,3 @@ abstract class LLMAIInterface {
 
   Future<bool> validateKey();
 }
-
-/// OpenRouter互換のチャットリクエスト
-class LLMCompletionRequest {
-  const LLMCompletionRequest({
-    required this.model,
-    required this.messages,
-    this.temperature,
-    this.topP,
-    this.maxTokens,
-    this.stop,
-    this.seed,
-    this.frequencyPenalty,
-    this.presencePenalty,
-    this.responseFormat,
-  });
-
-  final String model;
-  final List<LLMContent> messages;
-
-  /// 生成のランダム性 (0.0〜2.0)
-  final double? temperature;
-
-  /// nucleus sampling (0.0〜1.0)
-  final double? topP;
-
-  /// 最大出力トークン数
-  final int? maxTokens;
-
-  /// 生成を停止する文字列のリスト
-  final List<String>? stop;
-
-  /// 再現性のためのシード値
-  final int? seed;
-
-  /// 繰り返しを減らすペナルティ (-2.0〜2.0)
-  final double? frequencyPenalty;
-
-  /// 新しいトピックを促すペナルティ (-2.0〜2.0)
-  final double? presencePenalty;
-
-  /// 出力フォーマット
-  final LLMResponseFormat? responseFormat;
-}
-
-/// OpenRouter互換のチャットレスポンス
-class LLMCompletionResponse {
-  const LLMCompletionResponse({
-    required this.content,
-    required this.inputTokens,
-    required this.outputTokens,
-    this.finishReason,
-  });
-
-  final LLMContent content;
-  final int inputTokens;
-  final int outputTokens;
-
-  /// 生成が終了した理由 (stop / length / tool_calls など)
-  final String? finishReason;
-}
-
-/// 出力フォーマット
-class LLMResponseFormat {
-  const LLMResponseFormat({required this.type});
-
-  final LLMResponseFormatType type;
-
-  static const text = LLMResponseFormat(type: LLMResponseFormatType.text);
-  static const jsonObject =
-      LLMResponseFormat(type: LLMResponseFormatType.jsonObject);
-}
-
-enum LLMResponseFormatType {
-  text,
-  jsonObject;
-
-  /// OpenAI / Grok API に渡す snake_case 文字列に変換する。
-  String toApiString() => switch (this) {
-        LLMResponseFormatType.text => 'text',
-        LLMResponseFormatType.jsonObject => 'json_object',
-      };
-}
-
-class LLMContent {
-  const LLMContent({required this.role, required this.content, this.parts});
-
-  final LLMRole role;
-
-  /// テキストのみのレスポンスはこのフィールドに入る。
-  /// マルチモーダルの場合はテキストパートを連結した文字列になる。
-  final String content;
-
-  /// 画像などを含むマルチモーダルレスポンスのとき設定される。
-  /// テキストのみの場合は null。
-  final List<LLMContentPart>? parts;
-
-  bool get hasImages => parts?.any((p) => p is LLMImagePart) ?? false;
-  List<LLMImagePart> get images =>
-      parts?.whereType<LLMImagePart>().toList() ?? [];
-
-  bool get hasToolCalls => parts?.any((p) => p is LLMToolCallPart) ?? false;
-  List<LLMToolCallPart> get toolCalls =>
-      parts?.whereType<LLMToolCallPart>().toList() ?? [];
-
-  bool get hasAudio => parts?.any((p) => p is LLMAudioPart) ?? false;
-  List<LLMAudioPart> get audioList =>
-      parts?.whereType<LLMAudioPart>().toList() ?? [];
-}
-
-/// チャットメッセージの1パーツを表す sealed クラス。
-sealed class LLMContentPart {}
-
-/// テキストパーツ。
-class LLMTextPart extends LLMContentPart {
-  LLMTextPart(this.text);
-
-  final String text;
-}
-
-/// 画像パーツ。[url] は通常の https URL か data:image/...;base64,... 形式。
-class LLMImagePart extends LLMContentPart {
-  LLMImagePart(this.url);
-
-  final String url;
-}
-
-/// ツール呼び出しパーツ。モデルが関数を呼び出す際に返される。
-class LLMToolCallPart extends LLMContentPart {
-  LLMToolCallPart({
-    required this.id,
-    required this.name,
-    required this.arguments,
-  });
-
-  final String id;
-  final String name;
-
-  /// 関数に渡す引数。OpenAI 系は JSON 文字列をパース済み。
-  final Map<String, dynamic> arguments;
-}
-
-/// 音声パーツ。[data] は base64 エンコード済み音声データ。
-class LLMAudioPart extends LLMContentPart {
-  LLMAudioPart({required this.data, this.transcript, this.mimeType});
-
-  final String data;
-
-  /// 音声のテキスト書き起こし（利用可能な場合のみ）。
-  final String? transcript;
-
-  /// audio/mp3、audio/wav など（Gemini の inlineData 由来の場合のみ）。
-  final String? mimeType;
-}
-
-/// コード実行パーツ（Gemini のみ）。モデルが実行を要求したコード。
-class LLMCodeExecutionPart extends LLMContentPart {
-  LLMCodeExecutionPart({required this.code, required this.language});
-
-  final String code;
-  final String language;
-}
-
-/// コード実行結果パーツ（Gemini のみ）。
-class LLMCodeExecutionResultPart extends LLMContentPart {
-  LLMCodeExecutionResultPart({required this.outcome, this.output});
-
-  /// 実行結果: ok / failed / deadline_exceeded
-  final String outcome;
-  final String? output;
-}
-
-enum LLMRole { model, user, system }

--- a/pkgs/ai_box/lib/src/request.dart
+++ b/pkgs/ai_box/lib/src/request.dart
@@ -1,0 +1,183 @@
+import 'package:ai_box/src/content.dart';
+
+/// LLM へのチャット補完リクエスト。
+class LLMCompletionRequest {
+  const LLMCompletionRequest({
+    required this.model,
+    required this.messages,
+    this.temperature,
+    this.topP,
+    this.maxTokens,
+    this.stop,
+    this.seed,
+    this.frequencyPenalty,
+    this.presencePenalty,
+    this.responseFormat,
+    this.tools,
+    this.toolChoice,
+  });
+
+  /// モデル ID。
+  final String model;
+
+  /// 会話メッセージ。画像・音声・ファイル・ツール結果を含められる。
+  final List<LLMContent> messages;
+
+  /// 生成のランダム性 (0.0〜2.0)。
+  final double? temperature;
+
+  /// nucleus sampling (0.0〜1.0)。
+  final double? topP;
+
+  /// 最大出力トークン数。
+  final int? maxTokens;
+
+  /// 生成を停止する文字列のリスト。
+  final List<String>? stop;
+
+  /// 再現性のためのシード値。
+  final int? seed;
+
+  /// 繰り返しを減らすペナルティ (-2.0〜2.0)。
+  final double? frequencyPenalty;
+
+  /// 新しいトピックを促すペナルティ (-2.0〜2.0)。
+  final double? presencePenalty;
+
+  /// 出力フォーマット（text / json_object / json_schema）。
+  final LLMResponseFormat? responseFormat;
+
+  /// モデルが呼び出せるツール（関数）定義。
+  final List<LLMTool>? tools;
+
+  /// ツール選択の制御。
+  final LLMToolChoice? toolChoice;
+
+  /// 一部のフィールドを差し替えたコピーを返す。
+  LLMCompletionRequest copyWith({
+    String? model,
+    List<LLMContent>? messages,
+    double? temperature,
+    double? topP,
+    int? maxTokens,
+    List<String>? stop,
+    int? seed,
+    double? frequencyPenalty,
+    double? presencePenalty,
+    LLMResponseFormat? responseFormat,
+    List<LLMTool>? tools,
+    LLMToolChoice? toolChoice,
+  }) {
+    return LLMCompletionRequest(
+      model: model ?? this.model,
+      messages: messages ?? this.messages,
+      temperature: temperature ?? this.temperature,
+      topP: topP ?? this.topP,
+      maxTokens: maxTokens ?? this.maxTokens,
+      stop: stop ?? this.stop,
+      seed: seed ?? this.seed,
+      frequencyPenalty: frequencyPenalty ?? this.frequencyPenalty,
+      presencePenalty: presencePenalty ?? this.presencePenalty,
+      responseFormat: responseFormat ?? this.responseFormat,
+      tools: tools ?? this.tools,
+      toolChoice: toolChoice ?? this.toolChoice,
+    );
+  }
+}
+
+/// モデルに渡すツール（関数）定義。
+class LLMTool {
+  const LLMTool({
+    required this.name,
+    required this.description,
+    required this.parameters,
+  });
+
+  /// 関数名。
+  final String name;
+
+  /// 関数の説明。
+  final String description;
+
+  /// JSON Schema 形式のパラメータ定義。
+  final Map<String, dynamic> parameters;
+}
+
+/// ツール選択モード。
+enum LLMToolChoiceMode {
+  /// モデルが自動で判断する。
+  auto,
+
+  /// ツールを使わない。
+  none,
+
+  /// 必ずいずれかのツールを使う。
+  any,
+}
+
+/// ツール選択の制御。
+class LLMToolChoice {
+  const LLMToolChoice({this.mode = LLMToolChoiceMode.auto, this.toolName});
+
+  /// 特定のツールを強制する。
+  factory LLMToolChoice.tool(String name) =>
+      LLMToolChoice(mode: LLMToolChoiceMode.any, toolName: name);
+
+  /// モデルが自動で判断する。
+  static const auto = LLMToolChoice();
+
+  /// ツールを使わない。
+  static const none = LLMToolChoice(mode: LLMToolChoiceMode.none);
+
+  /// 必ずいずれかのツールを使う。
+  static const any = LLMToolChoice(mode: LLMToolChoiceMode.any);
+
+  final LLMToolChoiceMode mode;
+
+  /// [LLMToolChoice.tool] で指定された強制ツール名。
+  final String? toolName;
+}
+
+/// 出力フォーマットの種別。
+enum LLMResponseFormatType { text, jsonObject, jsonSchema }
+
+/// 出力フォーマット。
+class LLMResponseFormat {
+  const LLMResponseFormat._(
+    this.type, {
+    this.schema,
+    this.schemaName,
+    this.strict = true,
+  });
+
+  /// JSON Schema による構造化出力。
+  factory LLMResponseFormat.jsonSchema({
+    required Map<String, dynamic> schema,
+    String schemaName = 'response',
+    bool strict = true,
+  }) =>
+      LLMResponseFormat._(
+        LLMResponseFormatType.jsonSchema,
+        schema: schema,
+        schemaName: schemaName,
+        strict: strict,
+      );
+
+  /// 通常のテキスト出力。
+  static const text = LLMResponseFormat._(LLMResponseFormatType.text);
+
+  /// 任意の JSON オブジェクト出力。
+  static const jsonObject =
+      LLMResponseFormat._(LLMResponseFormatType.jsonObject);
+
+  final LLMResponseFormatType type;
+
+  /// JSON Schema（[LLMResponseFormatType.jsonSchema] のとき）。
+  final Map<String, dynamic>? schema;
+
+  /// スキーマ名。
+  final String? schemaName;
+
+  /// 厳密モード（OpenAI structured outputs）。
+  final bool strict;
+}

--- a/pkgs/ai_box/lib/src/response.dart
+++ b/pkgs/ai_box/lib/src/response.dart
@@ -1,0 +1,115 @@
+import 'package:ai_box/src/content.dart';
+
+/// LLM からのチャット補完レスポンス。
+class LLMCompletionResponse {
+  const LLMCompletionResponse({
+    required this.content,
+    required this.usage,
+    required this.finishReason,
+    this.model,
+    this.id,
+  });
+
+  /// 応答メッセージ（テキスト・画像・音声・ツール呼び出しなどを含む）。
+  final LLMContent content;
+
+  /// トークン使用量。
+  final LLMUsage usage;
+
+  /// 生成が終了した理由（正規化済み）。
+  final LLMFinishReason finishReason;
+
+  /// 実際に使われたモデル名（取得できた場合）。
+  final String? model;
+
+  /// レスポンス ID（取得できた場合）。
+  final String? id;
+
+  /// 応答本文のテキスト。
+  String get text => content.text;
+
+  /// ツール呼び出しの一覧（あれば）。
+  List<LLMToolCallPart> get toolCalls => content.toolCalls;
+
+  /// 入力トークン数（後方互換）。
+  int get inputTokens => usage.inputTokens;
+
+  /// 出力トークン数（後方互換）。
+  int get outputTokens => usage.outputTokens;
+
+  @override
+  String toString() =>
+      'LLMCompletionResponse(finishReason: $finishReason, usage: $usage, '
+      'text: ${text.length} chars)';
+}
+
+/// トークン使用量。
+class LLMUsage {
+  const LLMUsage({
+    required this.inputTokens,
+    required this.outputTokens,
+    this.cachedInputTokens,
+    this.reasoningTokens,
+  });
+
+  /// 入力（プロンプト）トークン数。
+  final int inputTokens;
+
+  /// 出力（生成）トークン数。
+  final int outputTokens;
+
+  /// キャッシュから読まれた入力トークン数（対応プロバイダーのみ）。
+  final int? cachedInputTokens;
+
+  /// 推論（thinking）に使われたトークン数（対応プロバイダーのみ）。
+  final int? reasoningTokens;
+
+  /// 入力＋出力の合計。
+  int get totalTokens => inputTokens + outputTokens;
+
+  @override
+  String toString() => 'LLMUsage(in: $inputTokens, out: $outputTokens)';
+}
+
+/// 生成が終了した理由を正規化した列挙。
+///
+/// 各プロバイダーの finish_reason / stop_reason 文字列を統一的に扱える。
+enum LLMFinishReason {
+  /// 自然に終了（stop / end_turn / STOP / stop_sequence）。
+  stop,
+
+  /// 最大トークン数に到達（length / max_tokens / MAX_TOKENS）。
+  length,
+
+  /// モデルがツール呼び出しを要求（tool_calls / tool_use / function_call）。
+  toolCalls,
+
+  /// セーフティ・コンテンツフィルタ（content_filter / SAFETY / RECITATION）。
+  contentFilter,
+
+  /// その他・不明。
+  other;
+
+  /// 各プロバイダーの finish_reason / stop_reason 文字列を正規化する。
+  static LLMFinishReason parse(String? raw) {
+    if (raw == null) return LLMFinishReason.other;
+    final v = raw.toLowerCase();
+    if (v.contains('tool') || v.contains('function')) {
+      return LLMFinishReason.toolCalls;
+    }
+    if (v.contains('max') || v == 'length') {
+      return LLMFinishReason.length;
+    }
+    if (v.contains('safety') ||
+        v.contains('filter') ||
+        v.contains('recitation') ||
+        v.contains('block') ||
+        v.contains('refus')) {
+      return LLMFinishReason.contentFilter;
+    }
+    if (v.contains('stop') || v.contains('end') || v == 'complete') {
+      return LLMFinishReason.stop;
+    }
+    return LLMFinishReason.other;
+  }
+}

--- a/pkgs/ai_box/lib/src/stream.dart
+++ b/pkgs/ai_box/lib/src/stream.dart
@@ -1,0 +1,27 @@
+import 'package:ai_box/src/content.dart';
+import 'package:ai_box/src/response.dart';
+
+/// ストリーミング応答の 1 チャンク。
+class LLMStreamChunk {
+  const LLMStreamChunk({
+    this.delta = '',
+    this.parts,
+    this.finishReason,
+    this.usage,
+  });
+
+  /// 直前からの増分テキスト。
+  final String delta;
+
+  /// 確定したパーツ（完了時などに付与される）。
+  final List<LLMContentPart>? parts;
+
+  /// 完了理由（最終チャンクのみ）。
+  final LLMFinishReason? finishReason;
+
+  /// トークン使用量（取得できた場合、通常は最終チャンク）。
+  final LLMUsage? usage;
+
+  /// このチャンクで生成が完了したか。
+  bool get isDone => finishReason != null;
+}

--- a/pkgs/ai_box/test/main_test.dart
+++ b/pkgs/ai_box/test/main_test.dart
@@ -1,5 +1,176 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:ai_box/ai_box.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('test1', () {});
+  group('LLMContent', () {
+    test('text-only user message', () {
+      final c = LLMContent.user('hello');
+      expect(c.role, LLMRole.user);
+      expect(c.text, 'hello');
+      expect(c.content, 'hello');
+      expect(c.hasImages, isFalse);
+      expect(c.parts.length, 1);
+    });
+
+    test('user message with image attachment', () {
+      final bytes = Uint8List.fromList([1, 2, 3]);
+      final c = LLMContent.user(
+        'describe',
+        attachments: [LLMImagePart.bytes(bytes, mimeType: 'image/webp')],
+      );
+      expect(c.hasImages, isTrue);
+      expect(c.images.length, 1);
+      expect(c.text, 'describe');
+      // テキスト + 画像で 2 パーツ。
+      expect(c.parts.length, 2);
+    });
+
+    test('text getter concatenates only text parts', () {
+      final c = LLMContent(
+        role: LLMRole.model,
+        parts: [
+          LLMTextPart('a'),
+          LLMImagePart.url('https://example.com/x.png'),
+          LLMTextPart('b'),
+        ],
+      );
+      expect(c.text, 'ab');
+      expect(c.images.length, 1);
+    });
+
+    test('reasoning getter', () {
+      final c = LLMContent(
+        role: LLMRole.model,
+        parts: [LLMReasoningPart('thinking'), LLMTextPart('answer')],
+      );
+      expect(c.hasReasoning, isTrue);
+      expect(c.reasoning, 'thinking');
+      expect(c.text, 'answer');
+    });
+  });
+
+  group('LLMImagePart', () {
+    test('bytes constructor exposes base64 + data uri', () {
+      final bytes = Uint8List.fromList(utf8.encode('hi'));
+      final p = LLMImagePart.bytes(bytes, mimeType: 'image/jpeg');
+      expect(p.hasBytes, isTrue);
+      expect(p.isUrl, isFalse);
+      expect(p.base64Data, base64Encode(bytes));
+      expect(p.asUrlOrDataUri, 'data:image/jpeg;base64,${base64Encode(bytes)}');
+    });
+
+    test('url constructor', () {
+      final p = LLMImagePart.url('https://example.com/a.png');
+      expect(p.isUrl, isTrue);
+      expect(p.hasBytes, isFalse);
+      expect(p.asUrlOrDataUri, 'https://example.com/a.png');
+    });
+
+    test('dataUri factory decodes bytes', () {
+      final bytes = Uint8List.fromList([10, 20, 30]);
+      final uri = 'data:image/png;base64,${base64Encode(bytes)}';
+      final p = LLMImagePart.dataUri(uri);
+      expect(p.hasBytes, isTrue);
+      expect(p.mimeType, 'image/png');
+      expect(p.bytes, bytes);
+    });
+
+    test('dataUri factory falls back to url on non-data string', () {
+      final p = LLMImagePart.dataUri('https://example.com/a.png');
+      expect(p.isUrl, isTrue);
+    });
+  });
+
+  group('LLMFinishReason.parse', () {
+    test('normalizes provider strings', () {
+      expect(LLMFinishReason.parse('stop'), LLMFinishReason.stop);
+      expect(LLMFinishReason.parse('end_turn'), LLMFinishReason.stop);
+      expect(LLMFinishReason.parse('STOP'), LLMFinishReason.stop);
+      expect(LLMFinishReason.parse('length'), LLMFinishReason.length);
+      expect(LLMFinishReason.parse('max_tokens'), LLMFinishReason.length);
+      expect(LLMFinishReason.parse('MAX_TOKENS'), LLMFinishReason.length);
+      expect(LLMFinishReason.parse('tool_calls'), LLMFinishReason.toolCalls);
+      expect(LLMFinishReason.parse('tool_use'), LLMFinishReason.toolCalls);
+      expect(
+        LLMFinishReason.parse('content_filter'),
+        LLMFinishReason.contentFilter,
+      );
+      expect(LLMFinishReason.parse('SAFETY'), LLMFinishReason.contentFilter);
+      expect(LLMFinishReason.parse(null), LLMFinishReason.other);
+      expect(LLMFinishReason.parse('weird'), LLMFinishReason.other);
+    });
+  });
+
+  group('LLMException.fromHttp', () {
+    test('maps status codes to typed exceptions', () {
+      expect(LLMException.fromHttp(401), isA<LLMAuthException>());
+      expect(LLMException.fromHttp(403), isA<LLMAuthException>());
+      expect(LLMException.fromHttp(429), isA<LLMRateLimitException>());
+      expect(LLMException.fromHttp(400), isA<LLMInvalidRequestException>());
+      expect(LLMException.fromHttp(404), isA<LLMInvalidRequestException>());
+      expect(LLMException.fromHttp(500), isA<LLMServerException>());
+      expect(LLMException.fromHttp(503), isA<LLMServerException>());
+    });
+
+    test('extracts message and code from error body', () {
+      final e = LLMException.fromHttp(
+        400,
+        provider: 'openai',
+        body: {
+          'error': {'message': 'bad request', 'type': 'invalid_request_error'},
+        },
+      );
+      expect(e.message, 'bad request');
+      expect(e.code, 'invalid_request_error');
+      expect(e.provider, 'openai');
+      expect(e.statusCode, 400);
+    });
+
+    test('is exhaustively switchable', () {
+      final LLMException e = const LLMRateLimitException('x');
+      final label = switch (e) {
+        LLMAuthException() => 'auth',
+        LLMRateLimitException() => 'rate',
+        LLMInvalidRequestException() => 'invalid',
+        LLMServerException() => 'server',
+        LLMNetworkException() => 'network',
+        LLMUnknownException() => 'unknown',
+      };
+      expect(label, 'rate');
+    });
+  });
+
+  group('LLMResponseFormat', () {
+    test('jsonSchema holds schema', () {
+      final f = LLMResponseFormat.jsonSchema(
+        schema: {'type': 'object'},
+        schemaName: 'foo',
+      );
+      expect(f.type, LLMResponseFormatType.jsonSchema);
+      expect(f.schemaName, 'foo');
+      expect(f.schema, {'type': 'object'});
+    });
+
+    test('text/jsonObject constants', () {
+      expect(LLMResponseFormat.text.type, LLMResponseFormatType.text);
+      expect(
+        LLMResponseFormat.jsonObject.type,
+        LLMResponseFormatType.jsonObject,
+      );
+    });
+  });
+
+  group('LLMToolChoice', () {
+    test('factory and constants', () {
+      expect(LLMToolChoice.auto.mode, LLMToolChoiceMode.auto);
+      expect(LLMToolChoice.none.mode, LLMToolChoiceMode.none);
+      expect(LLMToolChoice.any.mode, LLMToolChoiceMode.any);
+      final t = LLMToolChoice.tool('get_weather');
+      expect(t.toolName, 'get_weather');
+      expect(t.mode, LLMToolChoiceMode.any);
+    });
+  });
 }

--- a/pkgs/chatgpt_box/lib/src/chatgpt.dart
+++ b/pkgs/chatgpt_box/lib/src/chatgpt.dart
@@ -1,119 +1,29 @@
-import 'dart:convert';
-
 import 'package:ai_box/ai_box.dart';
-import 'package:chatgpt_box/src/core/chat_completions_core.dart';
 import 'package:chatgpt_box/src/core/models_core.dart';
-import 'package:chatgpt_box/src/freezed/chat_completion/chat_completion_object_choice_message/chat_completion_object_choice_message.dart';
-import 'package:chatgpt_box/src/freezed/chat_completion/chat_completion_request/chat_completion_request.dart';
-import 'package:chatgpt_box/src/freezed/chat_completion/chat_completion_request_message/chat_completion_request_message.dart';
+import 'package:chatgpt_box/src/openai_compat.dart';
 
 class ChatGPT extends LLMAIBase {
   ChatGPT({required super.apiKey});
+
+  static const _url = 'https://api.openai.com/v1/chat/completions';
+  static const _provider = 'openai';
 
   @override
   Future<LLMCompletionResponse> completions(
     LLMCompletionRequest request,
   ) async {
-    final chatCompletion = await ChatCompletionsCore.createChatCompletion(
+    // OpenAI の新しいモデルは max_completion_tokens を使う。
+    final body = buildOpenAiBody(
+      request,
+      maxTokensKey: 'max_completion_tokens',
+    );
+    final data = await postOpenAiJson(
+      url: _url,
       apiKey: apiKey,
-      request: ChatCompletionRequest(
-        model: request.model,
-        messages: request.messages
-            .map(
-              (e) => ChatCompletionRequestMessage(
-                role: e.role == LLMRole.model ? 'assistant' : e.role.name,
-                content: e.content,
-              ),
-            )
-            .toList(),
-        maxCompletionTokens: request.maxTokens,
-        temperature: request.temperature,
-        topP: request.topP,
-        stop: request.stop,
-        seed: request.seed,
-        frequencyPenalty: request.frequencyPenalty,
-        presencePenalty: request.presencePenalty,
-        responseFormat: request.responseFormat != null
-            ? {'type': request.responseFormat!.type.toApiString()}
-            : null,
-      ),
+      provider: _provider,
+      body: body,
     );
-    final choice = chatCompletion.choices.first;
-    return LLMCompletionResponse(
-      content: _parseMessage(choice.message),
-      inputTokens: chatCompletion.usage.promptTokens,
-      outputTokens: chatCompletion.usage.completionTokens,
-      finishReason: choice.finishReason,
-    );
-  }
-
-  LLMContent _parseMessage(ChatCompletionObjectChoiceMessage message) {
-    final parts = <LLMContentPart>[];
-    final textBuffer = StringBuffer();
-
-    // content: String | List<dynamic> | null
-    final raw = message.content;
-    if (raw is String && raw.isNotEmpty) {
-      textBuffer.write(raw);
-      parts.add(LLMTextPart(raw));
-    } else if (raw is List<dynamic>) {
-      for (final part in raw) {
-        final map = part as Map<String, dynamic>;
-        switch (map['type'] as String) {
-          case 'text':
-            final text = map['text'] as String;
-            textBuffer.write(text);
-            parts.add(LLMTextPart(text));
-          case 'image_url':
-            final url =
-                (map['image_url'] as Map<String, dynamic>)['url'] as String;
-            parts.add(LLMImagePart(url));
-        }
-      }
-    }
-
-    // tool_calls
-    final toolCalls = message.toolCalls;
-    if (toolCalls != null) {
-      for (final tc in toolCalls) {
-        final fn = tc['function'] as Map<String, dynamic>;
-        final argsRaw = fn['arguments'] as String;
-        final args =
-            argsRaw.isEmpty
-                ? <String, dynamic>{}
-                : jsonDecode(argsRaw) as Map<String, dynamic>;
-        parts.add(
-          LLMToolCallPart(
-            id: tc['id'] as String,
-            name: fn['name'] as String,
-            arguments: args,
-          ),
-        );
-      }
-    }
-
-    // audio（gpt-4o-audio 系モデル）
-    final audio = message.audio;
-    if (audio != null) {
-      parts.add(
-        LLMAudioPart(
-          data: audio['data'] as String,
-          transcript: audio['transcript'] as String?,
-        ),
-      );
-    }
-
-    if (parts.isEmpty) {
-      return const LLMContent(role: LLMRole.model, content: '');
-    }
-    if (parts.every((p) => p is LLMTextPart)) {
-      return LLMContent(role: LLMRole.model, content: textBuffer.toString());
-    }
-    return LLMContent(
-      role: LLMRole.model,
-      content: textBuffer.toString(),
-      parts: parts,
-    );
+    return parseOpenAiResponse(data);
   }
 
   @override

--- a/pkgs/chatgpt_box/lib/src/freezed/chat_completion/chat_completion_object_choice_message/chat_completion_object_choice_message.dart
+++ b/pkgs/chatgpt_box/lib/src/freezed/chat_completion/chat_completion_object_choice_message/chat_completion_object_choice_message.dart
@@ -8,11 +8,14 @@ abstract class ChatCompletionObjectChoiceMessage
     with _$ChatCompletionObjectChoiceMessage {
   factory ChatCompletionObjectChoiceMessage({
     required String role,
+
     /// テキストのみの場合は String、マルチモーダルの場合は `List<dynamic>`。
     dynamic content,
     String? refusal,
+
     /// ツール呼び出しリスト。finish_reason が tool_calls のとき設定される。
     @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls,
+
     /// 音声レスポンス（gpt-4o-audio 系モデルのみ）。
     Map<String, dynamic>? audio,
   }) = _ChatCompletionObjectChoiceMessage;

--- a/pkgs/chatgpt_box/lib/src/openai_compat.dart
+++ b/pkgs/chatgpt_box/lib/src/openai_compat.dart
@@ -1,0 +1,339 @@
+// OpenAI 互換 Chat Completions API のリクエスト構築・レスポンス解析ヘルパー。
+//
+// 画像・音声・ファイル・ツール呼び出し・構造化出力を raw JSON として
+// 組み立てる（freezed のコード生成に依存しない）。
+//
+// このファイルは src/ 配下のパッケージ内部実装であり、公開 API には含めない。
+import 'dart:convert';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:api_http/api_http.dart';
+
+/// [LLMCompletionRequest] を OpenAI 互換のリクエストボディに変換する。
+Map<String, dynamic> buildOpenAiBody(
+  LLMCompletionRequest request, {
+  required String maxTokensKey,
+}) {
+  final body = <String, dynamic>{
+    'model': request.model,
+    'messages': _toOpenAiMessages(request.messages),
+  };
+  if (request.maxTokens != null) body[maxTokensKey] = request.maxTokens;
+  if (request.temperature != null) body['temperature'] = request.temperature;
+  if (request.topP != null) body['top_p'] = request.topP;
+  if (request.stop != null) body['stop'] = request.stop;
+  if (request.seed != null) body['seed'] = request.seed;
+  if (request.frequencyPenalty != null) {
+    body['frequency_penalty'] = request.frequencyPenalty;
+  }
+  if (request.presencePenalty != null) {
+    body['presence_penalty'] = request.presencePenalty;
+  }
+  final rf = _toOpenAiResponseFormat(request.responseFormat);
+  if (rf != null) body['response_format'] = rf;
+  final tools = request.tools;
+  if (tools != null && tools.isNotEmpty) {
+    body['tools'] = [
+      for (final t in tools)
+        {
+          'type': 'function',
+          'function': {
+            'name': t.name,
+            'description': t.description,
+            'parameters': t.parameters,
+          },
+        },
+    ];
+    final tc = _toOpenAiToolChoice(request.toolChoice);
+    if (tc != null) body['tool_choice'] = tc;
+  }
+  return body;
+}
+
+List<Map<String, dynamic>> _toOpenAiMessages(List<LLMContent> messages) {
+  final out = <Map<String, dynamic>>[];
+  for (final m in messages) {
+    final role = switch (m.role) {
+      LLMRole.model => 'assistant',
+      LLMRole.system => 'system',
+      LLMRole.user => 'user',
+    };
+
+    // ツール実行結果は role: 'tool' の独立メッセージとして送る。
+    final toolResults = m.parts.whereType<LLMToolResultPart>().toList();
+    if (toolResults.isNotEmpty) {
+      for (final tr in toolResults) {
+        out.add({
+          'role': 'tool',
+          'tool_call_id': tr.toolCallId,
+          'content': tr.content,
+        });
+      }
+      continue;
+    }
+
+    // assistant のツール呼び出しエコー。
+    final toolCalls = m.parts.whereType<LLMToolCallPart>().toList();
+    if (toolCalls.isNotEmpty) {
+      out.add({
+        'role': 'assistant',
+        if (m.text.isNotEmpty) 'content': m.text,
+        'tool_calls': [
+          for (final tc in toolCalls)
+            {
+              'id': tc.id,
+              'type': 'function',
+              'function': {
+                'name': tc.name,
+                'arguments': jsonEncode(tc.arguments),
+              },
+            },
+        ],
+      });
+      continue;
+    }
+
+    final hasMedia = m.parts.any(
+      (p) => p is LLMImagePart || p is LLMAudioPart || p is LLMFilePart,
+    );
+    if (!hasMedia) {
+      out.add({'role': role, 'content': m.text});
+      continue;
+    }
+
+    out.add({'role': role, 'content': _toOpenAiContentArray(m.parts)});
+  }
+  return out;
+}
+
+List<Map<String, dynamic>> _toOpenAiContentArray(List<LLMContentPart> parts) {
+  final arr = <Map<String, dynamic>>[];
+  for (final p in parts) {
+    if (p is LLMTextPart) {
+      arr.add({'type': 'text', 'text': p.text});
+    } else if (p is LLMImagePart) {
+      arr.add({
+        'type': 'image_url',
+        'image_url': {'url': p.asUrlOrDataUri},
+      });
+    } else if (p is LLMAudioPart) {
+      arr.add({
+        'type': 'input_audio',
+        'input_audio': {
+          'data': p.base64Data ?? '',
+          'format': _audioFormat(p.mimeType),
+        },
+      });
+    } else if (p is LLMFilePart) {
+      arr.add({
+        'type': 'file',
+        'file': {
+          if (p.filename != null) 'filename': p.filename,
+          'file_data': _fileDataField(p),
+        },
+      });
+    }
+  }
+  return arr;
+}
+
+String _fileDataField(LLMFilePart f) {
+  if (f.hasBytes) {
+    final mime = f.mimeType ?? 'application/octet-stream';
+    return 'data:$mime;base64,${f.base64Data}';
+  }
+  return f.url ?? '';
+}
+
+String _audioFormat(String? mimeType) {
+  if (mimeType == null) return 'wav';
+  if (mimeType.contains('mp3') || mimeType.contains('mpeg')) return 'mp3';
+  if (mimeType.contains('wav')) return 'wav';
+  return mimeType.split('/').last;
+}
+
+Map<String, dynamic>? _toOpenAiResponseFormat(LLMResponseFormat? f) {
+  if (f == null) return null;
+  switch (f.type) {
+    case LLMResponseFormatType.text:
+      return {'type': 'text'};
+    case LLMResponseFormatType.jsonObject:
+      return {'type': 'json_object'};
+    case LLMResponseFormatType.jsonSchema:
+      return {
+        'type': 'json_schema',
+        'json_schema': {
+          'name': f.schemaName,
+          'schema': f.schema,
+          'strict': f.strict,
+        },
+      };
+  }
+}
+
+dynamic _toOpenAiToolChoice(LLMToolChoice? tc) {
+  if (tc == null) return null;
+  final toolName = tc.toolName;
+  if (toolName != null) {
+    return {
+      'type': 'function',
+      'function': {'name': toolName},
+    };
+  }
+  switch (tc.mode) {
+    case LLMToolChoiceMode.auto:
+      return 'auto';
+    case LLMToolChoiceMode.none:
+      return 'none';
+    case LLMToolChoiceMode.any:
+      return 'required';
+  }
+}
+
+/// OpenAI 互換のレスポンスボディを [LLMCompletionResponse] に変換する。
+LLMCompletionResponse parseOpenAiResponse(Map<String, dynamic> data) {
+  final choices = (data['choices'] as List?) ?? const [];
+  final choice =
+      choices.isNotEmpty
+          ? choices.first as Map<String, dynamic>
+          : const <String, dynamic>{};
+  final message =
+      (choice['message'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  final parts = <LLMContentPart>[];
+
+  final reasoning = message['reasoning_content'];
+  if (reasoning is String && reasoning.isNotEmpty) {
+    parts.add(LLMReasoningPart(reasoning));
+  }
+
+  final rawContent = message['content'];
+  if (rawContent is String && rawContent.isNotEmpty) {
+    parts.add(LLMTextPart(rawContent));
+  } else if (rawContent is List) {
+    _appendOpenAiContentParts(rawContent, parts);
+  }
+
+  final toolCalls = message['tool_calls'];
+  if (toolCalls is List) {
+    for (final tc in toolCalls) {
+      if (tc is Map<String, dynamic>) {
+        final fn = tc['function'];
+        final fnMap =
+            fn is Map<String, dynamic> ? fn : const <String, dynamic>{};
+        parts.add(
+          LLMToolCallPart(
+            id: (tc['id'] ?? '').toString(),
+            name: (fnMap['name'] ?? '').toString(),
+            arguments: _decodeArgs(fnMap['arguments']),
+          ),
+        );
+      }
+    }
+  }
+
+  final audio = message['audio'];
+  if (audio is Map<String, dynamic>) {
+    final adata = audio['data'];
+    if (adata is String && adata.isNotEmpty) {
+      parts.add(
+        LLMAudioPart.base64(adata, transcript: audio['transcript'] as String?),
+      );
+    }
+  }
+
+  final usage =
+      (data['usage'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  return LLMCompletionResponse(
+    content: LLMContent(role: LLMRole.model, parts: parts),
+    usage: _parseOpenAiUsage(usage),
+    finishReason: LLMFinishReason.parse(choice['finish_reason'] as String?),
+    model: data['model'] as String?,
+    id: data['id'] as String?,
+  );
+}
+
+void _appendOpenAiContentParts(List<dynamic> items, List<LLMContentPart> out) {
+  for (final item in items) {
+    if (item is! Map<String, dynamic>) continue;
+    final type = item['type'];
+    if (type == 'text' && item['text'] is String) {
+      out.add(LLMTextPart(item['text'] as String));
+    } else if (type == 'image_url') {
+      final url = (item['image_url'] as Map<String, dynamic>?)?['url'];
+      if (url is String) out.add(LLMImagePart.dataUri(url));
+    }
+  }
+}
+
+Map<String, dynamic> _decodeArgs(Object? argsRaw) {
+  if (argsRaw is Map<String, dynamic>) return argsRaw;
+  if (argsRaw is String && argsRaw.isNotEmpty) {
+    try {
+      final decoded = jsonDecode(argsRaw);
+      if (decoded is Map<String, dynamic>) return decoded;
+    } on FormatException {
+      return <String, dynamic>{};
+    }
+  }
+  return <String, dynamic>{};
+}
+
+LLMUsage _parseOpenAiUsage(Map<String, dynamic> usage) {
+  final promptDetails = usage['prompt_tokens_details'] as Map<String, dynamic>?;
+  final completionDetails =
+      usage['completion_tokens_details'] as Map<String, dynamic>?;
+  return LLMUsage(
+    inputTokens: (usage['prompt_tokens'] as num?)?.toInt() ?? 0,
+    outputTokens: (usage['completion_tokens'] as num?)?.toInt() ?? 0,
+    cachedInputTokens: (promptDetails?['cached_tokens'] as num?)?.toInt(),
+    reasoningTokens: (completionDetails?['reasoning_tokens'] as num?)?.toInt(),
+  );
+}
+
+/// OpenAI 互換 API に POST し、JSON ボディを返す。失敗時は [LLMException]。
+Future<Map<String, dynamic>> postOpenAiJson({
+  required String url,
+  required String apiKey,
+  required String provider,
+  required Map<String, dynamic> body,
+}) async {
+  try {
+    final response = await Api.post(
+      requestAcc: PostRequestAcc(
+        url: url,
+        headers: RestHeaders({
+          'Authorization': 'Bearer $apiKey',
+          'Content-Type': 'application/json',
+        }),
+        body: JsonRequestBody(body),
+      ),
+    );
+    final statusCode = int.tryParse(response.statusCode) ?? 0;
+    final respBody = response.body;
+    Map<String, dynamic>? mapData;
+    if (respBody is MapJsonResponseBody) {
+      mapData = respBody.data;
+    }
+    if (statusCode < 200 || statusCode >= 300) {
+      throw LLMException.fromHttp(
+        statusCode,
+        provider: provider,
+        body: mapData ?? respBody,
+      );
+    }
+    if (mapData != null) return mapData;
+    throw LLMUnknownException(
+      'Unexpected response body from $provider',
+      provider: provider,
+      raw: respBody,
+    );
+  } on LLMException {
+    rethrow;
+  } catch (e) {
+    throw LLMNetworkException(
+      'Network request failed',
+      provider: provider,
+      raw: e,
+    );
+  }
+}

--- a/pkgs/claude_box/lib/src/claude.dart
+++ b/pkgs/claude_box/lib/src/claude.dart
@@ -1,4 +1,5 @@
 import 'package:ai_box/ai_box.dart';
+import 'package:api_http/api_http.dart';
 import 'package:claude_box/src/claude_core.dart';
 import 'package:claude_box/src/freezed/message/request/message_request/message_request.dart';
 import 'package:claude_box/src/freezed/message/response/message_response.dart';
@@ -12,82 +13,53 @@ class Claude extends LLMAIBase {
   /// Claude API は max_tokens が必須のため、未指定時に使うデフォルト値。
   static const int defaultMaxTokens = 8000;
 
+  static const String _version = '2023-06-01';
+
   RequestHeader get requestHeader =>
-      RequestHeader(apiKey: apiKey, anthropicVersion: '2023-06-01');
+      RequestHeader(apiKey: apiKey, anthropicVersion: _version);
 
   @override
   Future<LLMCompletionResponse> completions(
     LLMCompletionRequest request,
   ) async {
-    // Claude では system ロールのメッセージを system フィールドに分離する
-    final systemMessages = request.messages
+    // Claude では system ロールのメッセージを system フィールドに分離する。
+    final system = request.messages
         .where((e) => e.role == LLMRole.system)
-        .map((e) => e.content)
+        .map((e) => e.text)
+        .where((t) => t.isNotEmpty)
         .join('\n');
-    final userMessages = request.messages
-        .where((e) => e.role != LLMRole.system)
-        .toList();
+    final convo =
+        request.messages.where((e) => e.role != LLMRole.system).toList();
 
-    final messageResponse = await createMessage(
-      messageRequest: MessageRequest(
-        model: request.model,
-        messages: userMessages
-            .map(
-              (e) => MessageContent(
-                role: e.role == LLMRole.model ? 'assistant' : 'user',
-                content: e.content,
-              ),
-            )
-            .toList(),
-        maxTokens: request.maxTokens ?? defaultMaxTokens,
-        system: systemMessages.isNotEmpty ? systemMessages : null,
-        temperature: request.temperature,
-        topP: request.topP,
-        stopSequences: request.stop,
-      ),
-    );
-    return LLMCompletionResponse(
-      content: _parseContent(messageResponse.content),
-      inputTokens: messageResponse.usage.inputTokens,
-      outputTokens: messageResponse.usage.outputTokens,
-      finishReason: messageResponse.stopReason,
-    );
-  }
-
-  LLMContent _parseContent(List<MessageResponseContent> blocks) {
-    final parts = <LLMContentPart>[];
-    final textBuffer = StringBuffer();
-
-    for (final block in blocks) {
-      switch (block.type) {
-        case 'text':
-          final text = block.text ?? '';
-          textBuffer.write(text);
-          parts.add(LLMTextPart(text));
-        case 'tool_use':
-          parts.add(
-            LLMToolCallPart(
-              id: block.id ?? '',
-              name: block.name ?? '',
-              arguments: block.input ?? {},
-            ),
-          );
-        case 'thinking':
-          // Thinking トークンはテキストとして扱う
-          final text = block.thinking ?? '';
-          textBuffer.write(text);
-          parts.add(LLMTextPart(text));
-      }
+    final body = <String, dynamic>{
+      'model': request.model,
+      'messages': _toClaudeMessages(convo),
+      'max_tokens': request.maxTokens ?? defaultMaxTokens,
+      if (system.isNotEmpty) 'system': system,
+      if (request.temperature != null) 'temperature': request.temperature,
+      if (request.topP != null) 'top_p': request.topP,
+      if (request.stop != null) 'stop_sequences': request.stop,
+    };
+    final tools = request.tools;
+    if (tools != null && tools.isNotEmpty) {
+      body['tools'] = [
+        for (final t in tools)
+          {
+            'name': t.name,
+            'description': t.description,
+            'input_schema': t.parameters,
+          },
+      ];
+      final tc = _toClaudeToolChoice(request.toolChoice);
+      if (tc != null) body['tool_choice'] = tc;
     }
 
-    if (parts.every((p) => p is LLMTextPart)) {
-      return LLMContent(role: LLMRole.model, content: textBuffer.toString());
-    }
-    return LLMContent(
-      role: LLMRole.model,
-      content: textBuffer.toString(),
-      parts: parts,
+    final data = await _postClaude(
+      apiKey: apiKey,
+      version: _version,
+      body: body,
     );
+    return _parseClaudeResponse(data);
   }
 
   Future<MessageResponse> createMessage({
@@ -101,18 +73,15 @@ class Claude extends LLMAIBase {
 
   Future<String?> easyTalk({required String message, int? maxTokens}) async {
     try {
-      final messageResponse = await createMessage(
-        messageRequest: MessageRequest(
+      final res = await completions(
+        LLMCompletionRequest(
           model: 'claude-sonnet-4-20250514',
-          messages: [MessageContent(role: 'user', content: message)],
+          messages: [LLMContent.user(message)],
           maxTokens: maxTokens ?? defaultMaxTokens,
         ),
       );
-      return messageResponse.content
-          .where((b) => b.type == 'text')
-          .map((b) => b.text ?? '')
-          .join();
-    } on Exception catch (_) {
+      return res.content.text;
+    } on LLMException catch (_) {
       return null;
     }
   }
@@ -142,5 +111,176 @@ class Claude extends LLMAIBase {
   @override
   Future<bool> validateKey() {
     return listModels().then((value) => value.data.isNotEmpty);
+  }
+}
+
+List<Map<String, dynamic>> _toClaudeMessages(List<LLMContent> messages) {
+  final out = <Map<String, dynamic>>[];
+  for (final m in messages) {
+    final role = m.role == LLMRole.model ? 'assistant' : 'user';
+    final blocks = <Map<String, dynamic>>[];
+    for (final p in m.parts) {
+      if (p is LLMTextPart) {
+        if (p.text.isNotEmpty) blocks.add({'type': 'text', 'text': p.text});
+      } else if (p is LLMImagePart) {
+        blocks.add(_claudeImageBlock(p));
+      } else if (p is LLMFilePart) {
+        blocks.add(_claudeDocumentBlock(p));
+      } else if (p is LLMToolResultPart) {
+        blocks.add({
+          'type': 'tool_result',
+          'tool_use_id': p.toolCallId,
+          'content': p.content,
+          if (p.isError) 'is_error': true,
+        });
+      } else if (p is LLMToolCallPart) {
+        blocks.add({
+          'type': 'tool_use',
+          'id': p.id,
+          'name': p.name,
+          'input': p.arguments,
+        });
+      }
+      // 音声・推論・コード実行パーツは Claude 入力では無視する。
+    }
+    if (blocks.isEmpty) continue;
+    out.add({'role': role, 'content': blocks});
+  }
+  return out;
+}
+
+Map<String, dynamic> _claudeImageBlock(LLMImagePart img) {
+  if (img.isUrl) {
+    return {
+      'type': 'image',
+      'source': {'type': 'url', 'url': img.url},
+    };
+  }
+  return {
+    'type': 'image',
+    'source': {
+      'type': 'base64',
+      'media_type': img.mimeType ?? 'image/png',
+      'data': img.base64Data,
+    },
+  };
+}
+
+Map<String, dynamic> _claudeDocumentBlock(LLMFilePart f) {
+  if (f.hasBytes) {
+    return {
+      'type': 'document',
+      'source': {
+        'type': 'base64',
+        'media_type': f.mimeType ?? 'application/pdf',
+        'data': f.base64Data,
+      },
+    };
+  }
+  return {
+    'type': 'document',
+    'source': {'type': 'url', 'url': f.url},
+  };
+}
+
+dynamic _toClaudeToolChoice(LLMToolChoice? tc) {
+  if (tc == null) return null;
+  final toolName = tc.toolName;
+  if (toolName != null) return {'type': 'tool', 'name': toolName};
+  switch (tc.mode) {
+    case LLMToolChoiceMode.auto:
+      return {'type': 'auto'};
+    case LLMToolChoiceMode.none:
+      return null;
+    case LLMToolChoiceMode.any:
+      return {'type': 'any'};
+  }
+}
+
+LLMCompletionResponse _parseClaudeResponse(Map<String, dynamic> data) {
+  final blocks = (data['content'] as List?) ?? const [];
+  final parts = <LLMContentPart>[];
+  for (final b in blocks) {
+    if (b is! Map<String, dynamic>) continue;
+    switch (b['type']) {
+      case 'text':
+        parts.add(LLMTextPart((b['text'] ?? '').toString()));
+      case 'thinking':
+        parts.add(
+          LLMReasoningPart(
+            (b['thinking'] ?? '').toString(),
+            signature: b['signature'] as String?,
+          ),
+        );
+      case 'tool_use':
+        parts.add(
+          LLMToolCallPart(
+            id: (b['id'] ?? '').toString(),
+            name: (b['name'] ?? '').toString(),
+            arguments:
+                (b['input'] as Map<String, dynamic>?) ?? <String, dynamic>{},
+          ),
+        );
+    }
+  }
+  final usage =
+      (data['usage'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  return LLMCompletionResponse(
+    content: LLMContent(role: LLMRole.model, parts: parts),
+    usage: LLMUsage(
+      inputTokens: (usage['input_tokens'] as num?)?.toInt() ?? 0,
+      outputTokens: (usage['output_tokens'] as num?)?.toInt() ?? 0,
+      cachedInputTokens: (usage['cache_read_input_tokens'] as num?)?.toInt(),
+    ),
+    finishReason: LLMFinishReason.parse(data['stop_reason'] as String?),
+    model: data['model'] as String?,
+    id: data['id'] as String?,
+  );
+}
+
+Future<Map<String, dynamic>> _postClaude({
+  required String apiKey,
+  required String version,
+  required Map<String, dynamic> body,
+}) async {
+  try {
+    final response = await Api.post(
+      requestAcc: PostRequestAcc(
+        url: 'https://api.anthropic.com/v1/messages',
+        headers: RestHeaders({
+          'x-api-key': apiKey,
+          'anthropic-version': version,
+          'content-type': 'application/json',
+        }),
+        body: JsonRequestBody(body),
+      ),
+    );
+    final statusCode = int.tryParse(response.statusCode) ?? 0;
+    final respBody = response.body;
+    Map<String, dynamic>? mapData;
+    if (respBody is MapJsonResponseBody) {
+      mapData = respBody.data;
+    }
+    if (statusCode < 200 || statusCode >= 300) {
+      throw LLMException.fromHttp(
+        statusCode,
+        provider: 'claude',
+        body: mapData ?? respBody,
+      );
+    }
+    if (mapData != null) return mapData;
+    throw LLMUnknownException(
+      'Unexpected response body from claude',
+      provider: 'claude',
+      raw: respBody,
+    );
+  } on LLMException {
+    rethrow;
+  } catch (e) {
+    throw LLMNetworkException(
+      'Network request failed',
+      provider: 'claude',
+      raw: e,
+    );
   }
 }

--- a/pkgs/deepseek_box/lib/src/deepseek.dart
+++ b/pkgs/deepseek_box/lib/src/deepseek.dart
@@ -1,100 +1,31 @@
-import 'dart:convert';
-
 import 'package:ai_box/ai_box.dart';
 import 'package:deepseek_box/deepseek_box.dart';
+import 'package:deepseek_box/src/openai_compat.dart';
 
 class DeepSeek extends LLMAIBase {
   DeepSeek({required super.apiKey});
+
+  static const _url = 'https://api.deepseek.com/chat/completions';
+  static const _provider = 'deepseek';
 
   @override
   Future<LLMCompletionResponse> completions(
     LLMCompletionRequest request,
   ) async {
-    final chatCompletion = await DeepSeekCore.chatCompletion(
+    final body = buildOpenAiBody(request, maxTokensKey: 'max_tokens');
+    final data = await postOpenAiJson(
+      url: _url,
       apiKey: apiKey,
-      request: ChatCompletionRequest(
-        model: request.model,
-        messages: request.messages
-            .map(
-              (e) => ChatCompletionMessage(
-                role: e.role == LLMRole.model
-                    ? ChatCompletionRole.assistant
-                    : e.role == LLMRole.system
-                        ? ChatCompletionRole.system
-                        : ChatCompletionRole.user,
-                content: e.content,
-              ),
-            )
-            .toList(),
-        maxTokens: request.maxTokens,
-        temperature: request.temperature,
-        topP: request.topP,
-        stop: request.stop,
-        seed: request.seed,
-        frequencyPenalty: request.frequencyPenalty,
-        presencePenalty: request.presencePenalty,
-        responseFormat: request.responseFormat != null
-            ? {'type': request.responseFormat!.type.toApiString()}
-            : null,
-      ),
+      provider: _provider,
+      body: body,
     );
-    final choice = chatCompletion.choices.first;
-    return LLMCompletionResponse(
-      content: _parseMessage(
-        content: choice.message.content,
-        toolCalls: choice.message.toolCalls,
-      ),
-      inputTokens: chatCompletion.usage?.promptTokens ?? 0,
-      outputTokens: chatCompletion.usage?.completionTokens ?? 0,
-      finishReason: choice.finishReason,
-    );
-  }
-
-  LLMContent _parseMessage({
-    required String? content,
-    required List<Map<String, dynamic>>? toolCalls,
-  }) {
-    final parts = <LLMContentPart>[];
-    final text = content ?? '';
-    if (text.isNotEmpty) parts.add(LLMTextPart(text));
-
-    if (toolCalls != null) {
-      for (final tc in toolCalls) {
-        final fn = tc['function'] as Map<String, dynamic>;
-        final argsRaw = fn['arguments'] as String;
-        final args =
-            argsRaw.isEmpty
-            ? <String, dynamic>{}
-            : jsonDecode(argsRaw) as Map<String, dynamic>;
-        parts.add(
-          LLMToolCallPart(
-            id: tc['id'] as String,
-            name: fn['name'] as String,
-            arguments: args,
-          ),
-        );
-      }
-    }
-
-    if (parts.isEmpty) {
-      return const LLMContent(role: LLMRole.model, content: '');
-    }
-    if (parts.every((p) => p is LLMTextPart)) {
-      return LLMContent(role: LLMRole.model, content: text);
-    }
-    return LLMContent(role: LLMRole.model, content: text, parts: parts);
+    return parseOpenAiResponse(data);
   }
 
   @override
   Future<List<AIModel>> getModels() async {
     final modelList = await DeepSeekCore.listModels(apiKey: apiKey);
-    return modelList.data
-        .map(
-          (e) => AIModel(
-            id: e.id,
-          ),
-        )
-        .toList();
+    return modelList.data.map((e) => AIModel(id: e.id)).toList();
   }
 
   @override

--- a/pkgs/deepseek_box/lib/src/openai_compat.dart
+++ b/pkgs/deepseek_box/lib/src/openai_compat.dart
@@ -1,0 +1,338 @@
+// OpenAI 互換 Chat Completions API のリクエスト構築・レスポンス解析ヘルパー。
+//
+// 画像・音声・ファイル・ツール呼び出し・構造化出力を raw JSON として
+// 組み立てる（freezed のコード生成に依存しない）。
+//
+// このファイルは src/ 配下のパッケージ内部実装であり、公開 API には含めない。
+import 'dart:convert';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:api_http/api_http.dart';
+
+/// [LLMCompletionRequest] を OpenAI 互換のリクエストボディに変換する。
+Map<String, dynamic> buildOpenAiBody(
+  LLMCompletionRequest request, {
+  required String maxTokensKey,
+}) {
+  final body = <String, dynamic>{
+    'model': request.model,
+    'messages': _toOpenAiMessages(request.messages),
+  };
+  if (request.maxTokens != null) body[maxTokensKey] = request.maxTokens;
+  if (request.temperature != null) body['temperature'] = request.temperature;
+  if (request.topP != null) body['top_p'] = request.topP;
+  if (request.stop != null) body['stop'] = request.stop;
+  if (request.seed != null) body['seed'] = request.seed;
+  if (request.frequencyPenalty != null) {
+    body['frequency_penalty'] = request.frequencyPenalty;
+  }
+  if (request.presencePenalty != null) {
+    body['presence_penalty'] = request.presencePenalty;
+  }
+  final rf = _toOpenAiResponseFormat(request.responseFormat);
+  if (rf != null) body['response_format'] = rf;
+  final tools = request.tools;
+  if (tools != null && tools.isNotEmpty) {
+    body['tools'] = [
+      for (final t in tools)
+        {
+          'type': 'function',
+          'function': {
+            'name': t.name,
+            'description': t.description,
+            'parameters': t.parameters,
+          },
+        },
+    ];
+    final tc = _toOpenAiToolChoice(request.toolChoice);
+    if (tc != null) body['tool_choice'] = tc;
+  }
+  return body;
+}
+
+List<Map<String, dynamic>> _toOpenAiMessages(List<LLMContent> messages) {
+  final out = <Map<String, dynamic>>[];
+  for (final m in messages) {
+    final role = switch (m.role) {
+      LLMRole.model => 'assistant',
+      LLMRole.system => 'system',
+      LLMRole.user => 'user',
+    };
+
+    // ツール実行結果は role: 'tool' の独立メッセージとして送る。
+    final toolResults = m.parts.whereType<LLMToolResultPart>().toList();
+    if (toolResults.isNotEmpty) {
+      for (final tr in toolResults) {
+        out.add({
+          'role': 'tool',
+          'tool_call_id': tr.toolCallId,
+          'content': tr.content,
+        });
+      }
+      continue;
+    }
+
+    // assistant のツール呼び出しエコー。
+    final toolCalls = m.parts.whereType<LLMToolCallPart>().toList();
+    if (toolCalls.isNotEmpty) {
+      out.add({
+        'role': 'assistant',
+        if (m.text.isNotEmpty) 'content': m.text,
+        'tool_calls': [
+          for (final tc in toolCalls)
+            {
+              'id': tc.id,
+              'type': 'function',
+              'function': {
+                'name': tc.name,
+                'arguments': jsonEncode(tc.arguments),
+              },
+            },
+        ],
+      });
+      continue;
+    }
+
+    final hasMedia = m.parts.any(
+      (p) => p is LLMImagePart || p is LLMAudioPart || p is LLMFilePart,
+    );
+    if (!hasMedia) {
+      out.add({'role': role, 'content': m.text});
+      continue;
+    }
+
+    out.add({'role': role, 'content': _toOpenAiContentArray(m.parts)});
+  }
+  return out;
+}
+
+List<Map<String, dynamic>> _toOpenAiContentArray(List<LLMContentPart> parts) {
+  final arr = <Map<String, dynamic>>[];
+  for (final p in parts) {
+    if (p is LLMTextPart) {
+      arr.add({'type': 'text', 'text': p.text});
+    } else if (p is LLMImagePart) {
+      arr.add({
+        'type': 'image_url',
+        'image_url': {'url': p.asUrlOrDataUri},
+      });
+    } else if (p is LLMAudioPart) {
+      arr.add({
+        'type': 'input_audio',
+        'input_audio': {
+          'data': p.base64Data ?? '',
+          'format': _audioFormat(p.mimeType),
+        },
+      });
+    } else if (p is LLMFilePart) {
+      arr.add({
+        'type': 'file',
+        'file': {
+          if (p.filename != null) 'filename': p.filename,
+          'file_data': _fileDataField(p),
+        },
+      });
+    }
+  }
+  return arr;
+}
+
+String _fileDataField(LLMFilePart f) {
+  if (f.hasBytes) {
+    final mime = f.mimeType ?? 'application/octet-stream';
+    return 'data:$mime;base64,${f.base64Data}';
+  }
+  return f.url ?? '';
+}
+
+String _audioFormat(String? mimeType) {
+  if (mimeType == null) return 'wav';
+  if (mimeType.contains('mp3') || mimeType.contains('mpeg')) return 'mp3';
+  if (mimeType.contains('wav')) return 'wav';
+  return mimeType.split('/').last;
+}
+
+Map<String, dynamic>? _toOpenAiResponseFormat(LLMResponseFormat? f) {
+  if (f == null) return null;
+  switch (f.type) {
+    case LLMResponseFormatType.text:
+      return {'type': 'text'};
+    case LLMResponseFormatType.jsonObject:
+      return {'type': 'json_object'};
+    case LLMResponseFormatType.jsonSchema:
+      return {
+        'type': 'json_schema',
+        'json_schema': {
+          'name': f.schemaName,
+          'schema': f.schema,
+          'strict': f.strict,
+        },
+      };
+  }
+}
+
+dynamic _toOpenAiToolChoice(LLMToolChoice? tc) {
+  if (tc == null) return null;
+  final toolName = tc.toolName;
+  if (toolName != null) {
+    return {
+      'type': 'function',
+      'function': {'name': toolName},
+    };
+  }
+  switch (tc.mode) {
+    case LLMToolChoiceMode.auto:
+      return 'auto';
+    case LLMToolChoiceMode.none:
+      return 'none';
+    case LLMToolChoiceMode.any:
+      return 'required';
+  }
+}
+
+/// OpenAI 互換のレスポンスボディを [LLMCompletionResponse] に変換する。
+LLMCompletionResponse parseOpenAiResponse(Map<String, dynamic> data) {
+  final choices = (data['choices'] as List?) ?? const [];
+  final choice = choices.isNotEmpty
+      ? choices.first as Map<String, dynamic>
+      : const <String, dynamic>{};
+  final message =
+      (choice['message'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  final parts = <LLMContentPart>[];
+
+  final reasoning = message['reasoning_content'];
+  if (reasoning is String && reasoning.isNotEmpty) {
+    parts.add(LLMReasoningPart(reasoning));
+  }
+
+  final rawContent = message['content'];
+  if (rawContent is String && rawContent.isNotEmpty) {
+    parts.add(LLMTextPart(rawContent));
+  } else if (rawContent is List) {
+    _appendOpenAiContentParts(rawContent, parts);
+  }
+
+  final toolCalls = message['tool_calls'];
+  if (toolCalls is List) {
+    for (final tc in toolCalls) {
+      if (tc is Map<String, dynamic>) {
+        final fn = tc['function'];
+        final fnMap =
+            fn is Map<String, dynamic> ? fn : const <String, dynamic>{};
+        parts.add(
+          LLMToolCallPart(
+            id: (tc['id'] ?? '').toString(),
+            name: (fnMap['name'] ?? '').toString(),
+            arguments: _decodeArgs(fnMap['arguments']),
+          ),
+        );
+      }
+    }
+  }
+
+  final audio = message['audio'];
+  if (audio is Map<String, dynamic>) {
+    final adata = audio['data'];
+    if (adata is String && adata.isNotEmpty) {
+      parts.add(
+        LLMAudioPart.base64(adata, transcript: audio['transcript'] as String?),
+      );
+    }
+  }
+
+  final usage =
+      (data['usage'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  return LLMCompletionResponse(
+    content: LLMContent(role: LLMRole.model, parts: parts),
+    usage: _parseOpenAiUsage(usage),
+    finishReason: LLMFinishReason.parse(choice['finish_reason'] as String?),
+    model: data['model'] as String?,
+    id: data['id'] as String?,
+  );
+}
+
+void _appendOpenAiContentParts(List<dynamic> items, List<LLMContentPart> out) {
+  for (final item in items) {
+    if (item is! Map<String, dynamic>) continue;
+    final type = item['type'];
+    if (type == 'text' && item['text'] is String) {
+      out.add(LLMTextPart(item['text'] as String));
+    } else if (type == 'image_url') {
+      final url = (item['image_url'] as Map<String, dynamic>?)?['url'];
+      if (url is String) out.add(LLMImagePart.dataUri(url));
+    }
+  }
+}
+
+Map<String, dynamic> _decodeArgs(Object? argsRaw) {
+  if (argsRaw is Map<String, dynamic>) return argsRaw;
+  if (argsRaw is String && argsRaw.isNotEmpty) {
+    try {
+      final decoded = jsonDecode(argsRaw);
+      if (decoded is Map<String, dynamic>) return decoded;
+    } on FormatException {
+      return <String, dynamic>{};
+    }
+  }
+  return <String, dynamic>{};
+}
+
+LLMUsage _parseOpenAiUsage(Map<String, dynamic> usage) {
+  final promptDetails = usage['prompt_tokens_details'] as Map<String, dynamic>?;
+  final completionDetails =
+      usage['completion_tokens_details'] as Map<String, dynamic>?;
+  return LLMUsage(
+    inputTokens: (usage['prompt_tokens'] as num?)?.toInt() ?? 0,
+    outputTokens: (usage['completion_tokens'] as num?)?.toInt() ?? 0,
+    cachedInputTokens: (promptDetails?['cached_tokens'] as num?)?.toInt(),
+    reasoningTokens: (completionDetails?['reasoning_tokens'] as num?)?.toInt(),
+  );
+}
+
+/// OpenAI 互換 API に POST し、JSON ボディを返す。失敗時は [LLMException]。
+Future<Map<String, dynamic>> postOpenAiJson({
+  required String url,
+  required String apiKey,
+  required String provider,
+  required Map<String, dynamic> body,
+}) async {
+  try {
+    final response = await Api.post(
+      requestAcc: PostRequestAcc(
+        url: url,
+        headers: RestHeaders({
+          'Authorization': 'Bearer $apiKey',
+          'Content-Type': 'application/json',
+        }),
+        body: JsonRequestBody(body),
+      ),
+    );
+    final statusCode = int.tryParse(response.statusCode) ?? 0;
+    final respBody = response.body;
+    Map<String, dynamic>? mapData;
+    if (respBody is MapJsonResponseBody) {
+      mapData = respBody.data;
+    }
+    if (statusCode < 200 || statusCode >= 300) {
+      throw LLMException.fromHttp(
+        statusCode,
+        provider: provider,
+        body: mapData ?? respBody,
+      );
+    }
+    if (mapData != null) return mapData;
+    throw LLMUnknownException(
+      'Unexpected response body from $provider',
+      provider: provider,
+      raw: respBody,
+    );
+  } on LLMException {
+    rethrow;
+  } catch (e) {
+    throw LLMNetworkException(
+      'Network request failed',
+      provider: provider,
+      raw: e,
+    );
+  }
+}

--- a/pkgs/gemini_box/lib/src/gemini_api/gemini.dart
+++ b/pkgs/gemini_box/lib/src/gemini_api/gemini.dart
@@ -1,6 +1,8 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:ai_box/ai_box.dart';
+import 'package:api_http/api_http.dart' as ac;
 import 'package:gemini_box/gemini_box.dart';
 
 class Gemini extends LLMAIBase {
@@ -12,120 +14,16 @@ class Gemini extends LLMAIBase {
   Future<LLMCompletionResponse> completions(
     LLMCompletionRequest request,
   ) async {
-    // Gemini では system ロールのメッセージを systemInstruction に分離する
-    final systemMessages = request.messages
-        .where((e) => e.role == LLMRole.system)
-        .map((e) => e.content)
-        .join('\n');
-    final userMessages = request.messages
-        .where((e) => e.role != LLMRole.system)
-        .toList();
-
-    String? responseMimeType;
-    if (request.responseFormat?.type == LLMResponseFormatType.jsonObject) {
-      responseMimeType = 'application/json';
-    }
-
-    final response = await GeminiCore.generateContent(
+    final body = _buildGeminiBody(request);
+    final data = await _postGemini(
       apiKey: apiKey,
       model: request.model,
-      requestBody: RequestBody(
-        contents: userMessages
-            .map(
-              (e) => Content(
-                role: e.role == LLMRole.model ? 'model' : 'user',
-                parts: [Part(text: e.content)],
-              ),
-            )
-            .toList(),
-        systemInstruction: systemMessages.isNotEmpty
-            ? Content(parts: [Part(text: systemMessages)])
-            : null,
-        generationConfig: GenerationConfig(
-          maxOutputTokens: request.maxTokens,
-          temperature: request.temperature,
-          topP: request.topP,
-          stopSequences: request.stop,
-          seed: request.seed,
-          frequencyPenalty: request.frequencyPenalty,
-          presencePenalty: request.presencePenalty,
-          responseMimeType: responseMimeType,
-        ),
-      ),
+      body: body,
     );
-
-    final candidate = response.candidates?.first;
-    return LLMCompletionResponse(
-      content: _parseParts(candidate?.content?.parts ?? []),
-      inputTokens: response.usageMetadata?.promptTokenCount ?? 0,
-      outputTokens: response.usageMetadata?.candidatesTokenCount ?? 0,
-      finishReason: candidate?.finishReason?.name,
-    );
+    return _parseGeminiResponse(data);
   }
 
-  LLMContent _parseParts(List<Part> parts) {
-    // thought=true のパーツ（Thinking トークン）は除外する
-    final contentParts = parts.where((p) => p.thought != true).toList();
-
-    if (contentParts.isEmpty) {
-      return const LLMContent(role: LLMRole.model, content: '');
-    }
-
-    // テキストのみかどうかを確認
-    final hasImages = contentParts.any(
-      (p) => p.inlineData != null || p.fileData != null,
-    );
-    if (!hasImages) {
-      final text = contentParts.map((p) => p.text ?? '').join();
-      return LLMContent(role: LLMRole.model, content: text);
-    }
-
-    // マルチモーダル: テキスト・画像・tool_calls・コード実行などが混在
-    final llmParts = <LLMContentPart>[];
-    final textBuffer = StringBuffer();
-    for (final part in contentParts) {
-      if (part.text case final text?) {
-        textBuffer.write(text);
-        llmParts.add(LLMTextPart(text));
-      } else if (part.inlineData case final blob?) {
-        if (blob.mimeType.startsWith('audio/')) {
-          llmParts.add(LLMAudioPart(data: blob.data, mimeType: blob.mimeType));
-        } else {
-          // 画像（image/png など）は data URI に変換
-          final dataUri = 'data:${blob.mimeType};base64,${blob.data}';
-          llmParts.add(LLMImagePart(dataUri));
-        }
-      } else if (part.fileData case final file?) {
-        llmParts.add(LLMImagePart(file.fileUri));
-      } else if (part.functionCall case final fc?) {
-        llmParts.add(
-          LLMToolCallPart(
-            id: fc.id ?? fc.name,
-            name: fc.name,
-            arguments: fc.args ?? {},
-          ),
-        );
-      } else if (part.executableCode case final ec?) {
-        llmParts.add(
-          LLMCodeExecutionPart(code: ec.code, language: ec.language.name),
-        );
-      } else if (part.codeExecutionResult case final cer?) {
-        llmParts.add(
-          LLMCodeExecutionResultPart(
-            outcome: cer.outcome.name,
-            output: cer.output,
-          ),
-        );
-      }
-    }
-    return LLMContent(
-      role: LLMRole.model,
-      content: textBuffer.toString(),
-      parts: llmParts,
-    );
-  }
-
-  /// Generate content
+  /// Generate content (低レベル・型付き API)
   ///
   /// Ref: https://ai.google.dev/api/generate-content#method:-models.generatecontent
   Future<GenerateContentResponse> generateContent({
@@ -157,6 +55,270 @@ class Gemini extends LLMAIBase {
   Future<bool> validateKey() {
     return GeminiCore.getModels(apiKey: apiKey)
         .then((value) => value.isNotEmpty);
+  }
+}
+
+Map<String, dynamic> _buildGeminiBody(LLMCompletionRequest request) {
+  final system = request.messages
+      .where((e) => e.role == LLMRole.system)
+      .map((e) => e.text)
+      .where((t) => t.isNotEmpty)
+      .join('\n');
+  final convo =
+      request.messages.where((e) => e.role != LLMRole.system).toList();
+
+  final body = <String, dynamic>{
+    'contents': [for (final m in convo) _toGeminiContent(m)],
+  };
+  if (system.isNotEmpty) {
+    body['systemInstruction'] = {
+      'parts': [
+        {'text': system},
+      ],
+    };
+  }
+
+  final genConfig = <String, dynamic>{};
+  if (request.maxTokens != null) {
+    genConfig['maxOutputTokens'] = request.maxTokens;
+  }
+  if (request.temperature != null) {
+    genConfig['temperature'] = request.temperature;
+  }
+  if (request.topP != null) genConfig['topP'] = request.topP;
+  if (request.stop != null) genConfig['stopSequences'] = request.stop;
+  if (request.seed != null) genConfig['seed'] = request.seed;
+  if (request.frequencyPenalty != null) {
+    genConfig['frequencyPenalty'] = request.frequencyPenalty;
+  }
+  if (request.presencePenalty != null) {
+    genConfig['presencePenalty'] = request.presencePenalty;
+  }
+  final rf = request.responseFormat;
+  if (rf != null) {
+    if (rf.type == LLMResponseFormatType.jsonObject) {
+      genConfig['responseMimeType'] = 'application/json';
+    } else if (rf.type == LLMResponseFormatType.jsonSchema) {
+      genConfig['responseMimeType'] = 'application/json';
+      genConfig['responseSchema'] = rf.schema;
+    }
+  }
+  if (genConfig.isNotEmpty) body['generationConfig'] = genConfig;
+
+  final tools = request.tools;
+  if (tools != null && tools.isNotEmpty) {
+    body['tools'] = [
+      {
+        'functionDeclarations': [
+          for (final t in tools)
+            {
+              'name': t.name,
+              'description': t.description,
+              'parameters': t.parameters,
+            },
+        ],
+      },
+    ];
+    final tc = _toGeminiToolConfig(request.toolChoice);
+    if (tc != null) body['toolConfig'] = tc;
+  }
+  return body;
+}
+
+Map<String, dynamic> _toGeminiContent(LLMContent m) {
+  final role = m.role == LLMRole.model ? 'model' : 'user';
+  final parts = <Map<String, dynamic>>[];
+  for (final p in m.parts) {
+    if (p is LLMTextPart) {
+      if (p.text.isNotEmpty) parts.add({'text': p.text});
+    } else if (p is LLMImagePart) {
+      parts.add(_geminiMediaPart(p.url, p.base64Data, p.mimeType, 'image/png'));
+    } else if (p is LLMAudioPart) {
+      parts.add(
+        _geminiMediaPart(p.url, p.base64Data, p.mimeType, 'audio/mpeg'),
+      );
+    } else if (p is LLMFilePart) {
+      parts.add(
+        _geminiMediaPart(
+          p.url,
+          p.base64Data,
+          p.mimeType,
+          'application/octet-stream',
+        ),
+      );
+    } else if (p is LLMToolCallPart) {
+      parts.add({
+        'functionCall': {'name': p.name, 'args': p.arguments},
+      });
+    } else if (p is LLMToolResultPart) {
+      parts.add({
+        'functionResponse': {
+          'name': p.toolName ?? p.toolCallId,
+          'response': {'content': p.content},
+        },
+      });
+    }
+  }
+  return {'role': role, 'parts': parts};
+}
+
+Map<String, dynamic> _geminiMediaPart(
+  String? url,
+  String? base64Data,
+  String? mimeType,
+  String fallbackMime,
+) {
+  if (base64Data != null) {
+    return {
+      'inlineData': {
+        'mimeType': mimeType ?? fallbackMime,
+        'data': base64Data,
+      },
+    };
+  }
+  return {
+    'fileData': {
+      'fileUri': url ?? '',
+      'mimeType': mimeType ?? fallbackMime,
+    },
+  };
+}
+
+Map<String, dynamic>? _toGeminiToolConfig(LLMToolChoice? tc) {
+  if (tc == null) return null;
+  final mode = switch (tc.mode) {
+    LLMToolChoiceMode.auto => 'AUTO',
+    LLMToolChoiceMode.none => 'NONE',
+    LLMToolChoiceMode.any => 'ANY',
+  };
+  final cfg = <String, dynamic>{'mode': mode};
+  final toolName = tc.toolName;
+  if (toolName != null) cfg['allowedFunctionNames'] = [toolName];
+  return {'functionCallingConfig': cfg};
+}
+
+Map<String, dynamic> _asMap(Object? v) =>
+    v is Map<String, dynamic> ? v : const <String, dynamic>{};
+
+LLMCompletionResponse _parseGeminiResponse(Map<String, dynamic> data) {
+  final candidates = (data['candidates'] as List?) ?? const [];
+  final candidate = candidates.isNotEmpty
+      ? _asMap(candidates.first)
+      : const <String, dynamic>{};
+  final content = _asMap(candidate['content']);
+  final rawParts = (content['parts'] as List?) ?? const [];
+
+  final parts = <LLMContentPart>[];
+  for (final p in rawParts) {
+    if (p is! Map<String, dynamic>) continue;
+    if (p['thought'] == true) {
+      final t = p['text'];
+      if (t is String) parts.add(LLMReasoningPart(t));
+      continue;
+    }
+    if (p['text'] is String) {
+      parts.add(LLMTextPart(p['text'] as String));
+    } else if (p['inlineData'] is Map<String, dynamic>) {
+      parts.add(_geminiInlineToPart(p['inlineData'] as Map<String, dynamic>));
+    } else if (p['fileData'] is Map<String, dynamic>) {
+      final fd = p['fileData'] as Map<String, dynamic>;
+      parts.add(LLMImagePart.url((fd['fileUri'] ?? '').toString()));
+    } else if (p['functionCall'] is Map<String, dynamic>) {
+      final fc = p['functionCall'] as Map<String, dynamic>;
+      parts.add(
+        LLMToolCallPart(
+          id: (fc['id'] ?? fc['name'] ?? '').toString(),
+          name: (fc['name'] ?? '').toString(),
+          arguments:
+              (fc['args'] as Map<String, dynamic>?) ?? <String, dynamic>{},
+        ),
+      );
+    } else if (p['executableCode'] is Map<String, dynamic>) {
+      final ec = p['executableCode'] as Map<String, dynamic>;
+      parts.add(
+        LLMCodeExecutionPart(
+          code: (ec['code'] ?? '').toString(),
+          language: (ec['language'] ?? '').toString(),
+        ),
+      );
+    } else if (p['codeExecutionResult'] is Map<String, dynamic>) {
+      final cer = p['codeExecutionResult'] as Map<String, dynamic>;
+      parts.add(
+        LLMCodeExecutionResultPart(
+          outcome: (cer['outcome'] ?? '').toString(),
+          output: cer['output'] as String?,
+        ),
+      );
+    }
+  }
+
+  final usage = _asMap(data['usageMetadata']);
+  return LLMCompletionResponse(
+    content: LLMContent(role: LLMRole.model, parts: parts),
+    usage: LLMUsage(
+      inputTokens: (usage['promptTokenCount'] as num?)?.toInt() ?? 0,
+      outputTokens: (usage['candidatesTokenCount'] as num?)?.toInt() ?? 0,
+      cachedInputTokens: (usage['cachedContentTokenCount'] as num?)?.toInt(),
+      reasoningTokens: (usage['thoughtsTokenCount'] as num?)?.toInt(),
+    ),
+    finishReason: LLMFinishReason.parse(candidate['finishReason'] as String?),
+    model: data['modelVersion'] as String?,
+  );
+}
+
+LLMContentPart _geminiInlineToPart(Map<String, dynamic> blob) {
+  final mime = (blob['mimeType'] ?? '').toString();
+  final b64 = (blob['data'] ?? '').toString();
+  if (mime.startsWith('audio/')) {
+    return LLMAudioPart.base64(b64, mimeType: mime);
+  }
+  if (mime.startsWith('image/')) {
+    return LLMImagePart.bytes(base64Decode(b64), mimeType: mime);
+  }
+  return LLMFilePart.bytes(base64Decode(b64), mimeType: mime);
+}
+
+Future<Map<String, dynamic>> _postGemini({
+  required String apiKey,
+  required String model,
+  required Map<String, dynamic> body,
+}) async {
+  const baseUrl = 'https://generativelanguage.googleapis.com/v1beta';
+  try {
+    final response = await ac.Api.post(
+      requestAcc: ac.PostRequestAcc(
+        url: '$baseUrl/models/$model:generateContent',
+        queryParameters: {'key': apiKey},
+        body: ac.JsonRequestBody(body),
+      ),
+    );
+    final statusCode = int.tryParse(response.statusCode) ?? 0;
+    final respBody = response.body;
+    Map<String, dynamic>? mapData;
+    if (respBody is ac.MapJsonResponseBody) {
+      mapData = respBody.data;
+    }
+    if (statusCode < 200 || statusCode >= 300) {
+      throw LLMException.fromHttp(
+        statusCode,
+        provider: 'gemini',
+        body: mapData ?? respBody,
+      );
+    }
+    if (mapData != null) return mapData;
+    throw LLMUnknownException(
+      'Unexpected response body from gemini',
+      provider: 'gemini',
+      raw: respBody,
+    );
+  } on LLMException {
+    rethrow;
+  } catch (e) {
+    throw LLMNetworkException(
+      'Network request failed',
+      provider: 'gemini',
+      raw: e,
+    );
   }
 }
 

--- a/pkgs/grok_box/lib/src/grok.dart
+++ b/pkgs/grok_box/lib/src/grok.dart
@@ -1,88 +1,25 @@
-import 'dart:convert';
-
 import 'package:ai_box/ai_box.dart';
 import 'package:grok_box/grok_box.dart';
+import 'package:grok_box/src/openai_compat.dart';
 
 class Grok extends LLMAIBase {
   Grok({required super.apiKey});
+
+  static const _url = 'https://api.x.ai/v1/chat/completions';
+  static const _provider = 'grok';
 
   @override
   Future<LLMCompletionResponse> completions(
     LLMCompletionRequest request,
   ) async {
-    final chatCompletion = await GrokCore.chatCompletion(
+    final body = buildOpenAiBody(request, maxTokensKey: 'max_tokens');
+    final data = await postOpenAiJson(
+      url: _url,
       apiKey: apiKey,
-      request: ChatCompletionRequest(
-        model: request.model,
-        messages: request.messages
-            .map(
-              (e) => ChatCompletionMessage(
-                role: e.role == LLMRole.model
-                    ? ChatCompletionRole.assistant
-                    : e.role == LLMRole.system
-                        ? ChatCompletionRole.system
-                        : ChatCompletionRole.user,
-                content: e.content,
-              ),
-            )
-            .toList(),
-        maxTokens: request.maxTokens,
-        temperature: request.temperature,
-        topP: request.topP,
-        stop: request.stop,
-        seed: request.seed,
-        frequencyPenalty: request.frequencyPenalty,
-        presencePenalty: request.presencePenalty,
-        responseFormat: request.responseFormat != null
-            ? {'type': request.responseFormat!.type.toApiString()}
-            : null,
-      ),
+      provider: _provider,
+      body: body,
     );
-    final choice = chatCompletion.choices.first;
-    return LLMCompletionResponse(
-      content: _parseMessage(
-        content: choice.message.content,
-        toolCalls: choice.message.toolCalls,
-      ),
-      inputTokens: chatCompletion.usage?.promptTokens ?? 0,
-      outputTokens: chatCompletion.usage?.completionTokens ?? 0,
-      finishReason: choice.finishReason,
-    );
-  }
-
-  LLMContent _parseMessage({
-    required String? content,
-    required List<Map<String, dynamic>>? toolCalls,
-  }) {
-    final parts = <LLMContentPart>[];
-    final text = content ?? '';
-    if (text.isNotEmpty) parts.add(LLMTextPart(text));
-
-    if (toolCalls != null) {
-      for (final tc in toolCalls) {
-        final fn = tc['function'] as Map<String, dynamic>;
-        final argsRaw = fn['arguments'] as String;
-        final args =
-            argsRaw.isEmpty
-                ? <String, dynamic>{}
-                : jsonDecode(argsRaw) as Map<String, dynamic>;
-        parts.add(
-          LLMToolCallPart(
-            id: tc['id'] as String,
-            name: fn['name'] as String,
-            arguments: args,
-          ),
-        );
-      }
-    }
-
-    if (parts.isEmpty) {
-      return const LLMContent(role: LLMRole.model, content: '');
-    }
-    if (parts.every((p) => p is LLMTextPart)) {
-      return LLMContent(role: LLMRole.model, content: text);
-    }
-    return LLMContent(role: LLMRole.model, content: text, parts: parts);
+    return parseOpenAiResponse(data);
   }
 
   @override

--- a/pkgs/grok_box/lib/src/openai_compat.dart
+++ b/pkgs/grok_box/lib/src/openai_compat.dart
@@ -1,0 +1,338 @@
+// OpenAI 互換 Chat Completions API のリクエスト構築・レスポンス解析ヘルパー。
+//
+// 画像・音声・ファイル・ツール呼び出し・構造化出力を raw JSON として
+// 組み立てる（freezed のコード生成に依存しない）。
+//
+// このファイルは src/ 配下のパッケージ内部実装であり、公開 API には含めない。
+import 'dart:convert';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:api_http/api_http.dart';
+
+/// [LLMCompletionRequest] を OpenAI 互換のリクエストボディに変換する。
+Map<String, dynamic> buildOpenAiBody(
+  LLMCompletionRequest request, {
+  required String maxTokensKey,
+}) {
+  final body = <String, dynamic>{
+    'model': request.model,
+    'messages': _toOpenAiMessages(request.messages),
+  };
+  if (request.maxTokens != null) body[maxTokensKey] = request.maxTokens;
+  if (request.temperature != null) body['temperature'] = request.temperature;
+  if (request.topP != null) body['top_p'] = request.topP;
+  if (request.stop != null) body['stop'] = request.stop;
+  if (request.seed != null) body['seed'] = request.seed;
+  if (request.frequencyPenalty != null) {
+    body['frequency_penalty'] = request.frequencyPenalty;
+  }
+  if (request.presencePenalty != null) {
+    body['presence_penalty'] = request.presencePenalty;
+  }
+  final rf = _toOpenAiResponseFormat(request.responseFormat);
+  if (rf != null) body['response_format'] = rf;
+  final tools = request.tools;
+  if (tools != null && tools.isNotEmpty) {
+    body['tools'] = [
+      for (final t in tools)
+        {
+          'type': 'function',
+          'function': {
+            'name': t.name,
+            'description': t.description,
+            'parameters': t.parameters,
+          },
+        },
+    ];
+    final tc = _toOpenAiToolChoice(request.toolChoice);
+    if (tc != null) body['tool_choice'] = tc;
+  }
+  return body;
+}
+
+List<Map<String, dynamic>> _toOpenAiMessages(List<LLMContent> messages) {
+  final out = <Map<String, dynamic>>[];
+  for (final m in messages) {
+    final role = switch (m.role) {
+      LLMRole.model => 'assistant',
+      LLMRole.system => 'system',
+      LLMRole.user => 'user',
+    };
+
+    // ツール実行結果は role: 'tool' の独立メッセージとして送る。
+    final toolResults = m.parts.whereType<LLMToolResultPart>().toList();
+    if (toolResults.isNotEmpty) {
+      for (final tr in toolResults) {
+        out.add({
+          'role': 'tool',
+          'tool_call_id': tr.toolCallId,
+          'content': tr.content,
+        });
+      }
+      continue;
+    }
+
+    // assistant のツール呼び出しエコー。
+    final toolCalls = m.parts.whereType<LLMToolCallPart>().toList();
+    if (toolCalls.isNotEmpty) {
+      out.add({
+        'role': 'assistant',
+        if (m.text.isNotEmpty) 'content': m.text,
+        'tool_calls': [
+          for (final tc in toolCalls)
+            {
+              'id': tc.id,
+              'type': 'function',
+              'function': {
+                'name': tc.name,
+                'arguments': jsonEncode(tc.arguments),
+              },
+            },
+        ],
+      });
+      continue;
+    }
+
+    final hasMedia = m.parts.any(
+      (p) => p is LLMImagePart || p is LLMAudioPart || p is LLMFilePart,
+    );
+    if (!hasMedia) {
+      out.add({'role': role, 'content': m.text});
+      continue;
+    }
+
+    out.add({'role': role, 'content': _toOpenAiContentArray(m.parts)});
+  }
+  return out;
+}
+
+List<Map<String, dynamic>> _toOpenAiContentArray(List<LLMContentPart> parts) {
+  final arr = <Map<String, dynamic>>[];
+  for (final p in parts) {
+    if (p is LLMTextPart) {
+      arr.add({'type': 'text', 'text': p.text});
+    } else if (p is LLMImagePart) {
+      arr.add({
+        'type': 'image_url',
+        'image_url': {'url': p.asUrlOrDataUri},
+      });
+    } else if (p is LLMAudioPart) {
+      arr.add({
+        'type': 'input_audio',
+        'input_audio': {
+          'data': p.base64Data ?? '',
+          'format': _audioFormat(p.mimeType),
+        },
+      });
+    } else if (p is LLMFilePart) {
+      arr.add({
+        'type': 'file',
+        'file': {
+          if (p.filename != null) 'filename': p.filename,
+          'file_data': _fileDataField(p),
+        },
+      });
+    }
+  }
+  return arr;
+}
+
+String _fileDataField(LLMFilePart f) {
+  if (f.hasBytes) {
+    final mime = f.mimeType ?? 'application/octet-stream';
+    return 'data:$mime;base64,${f.base64Data}';
+  }
+  return f.url ?? '';
+}
+
+String _audioFormat(String? mimeType) {
+  if (mimeType == null) return 'wav';
+  if (mimeType.contains('mp3') || mimeType.contains('mpeg')) return 'mp3';
+  if (mimeType.contains('wav')) return 'wav';
+  return mimeType.split('/').last;
+}
+
+Map<String, dynamic>? _toOpenAiResponseFormat(LLMResponseFormat? f) {
+  if (f == null) return null;
+  switch (f.type) {
+    case LLMResponseFormatType.text:
+      return {'type': 'text'};
+    case LLMResponseFormatType.jsonObject:
+      return {'type': 'json_object'};
+    case LLMResponseFormatType.jsonSchema:
+      return {
+        'type': 'json_schema',
+        'json_schema': {
+          'name': f.schemaName,
+          'schema': f.schema,
+          'strict': f.strict,
+        },
+      };
+  }
+}
+
+dynamic _toOpenAiToolChoice(LLMToolChoice? tc) {
+  if (tc == null) return null;
+  final toolName = tc.toolName;
+  if (toolName != null) {
+    return {
+      'type': 'function',
+      'function': {'name': toolName},
+    };
+  }
+  switch (tc.mode) {
+    case LLMToolChoiceMode.auto:
+      return 'auto';
+    case LLMToolChoiceMode.none:
+      return 'none';
+    case LLMToolChoiceMode.any:
+      return 'required';
+  }
+}
+
+/// OpenAI 互換のレスポンスボディを [LLMCompletionResponse] に変換する。
+LLMCompletionResponse parseOpenAiResponse(Map<String, dynamic> data) {
+  final choices = (data['choices'] as List?) ?? const [];
+  final choice = choices.isNotEmpty
+      ? choices.first as Map<String, dynamic>
+      : const <String, dynamic>{};
+  final message =
+      (choice['message'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  final parts = <LLMContentPart>[];
+
+  final reasoning = message['reasoning_content'];
+  if (reasoning is String && reasoning.isNotEmpty) {
+    parts.add(LLMReasoningPart(reasoning));
+  }
+
+  final rawContent = message['content'];
+  if (rawContent is String && rawContent.isNotEmpty) {
+    parts.add(LLMTextPart(rawContent));
+  } else if (rawContent is List) {
+    _appendOpenAiContentParts(rawContent, parts);
+  }
+
+  final toolCalls = message['tool_calls'];
+  if (toolCalls is List) {
+    for (final tc in toolCalls) {
+      if (tc is Map<String, dynamic>) {
+        final fn = tc['function'];
+        final fnMap =
+            fn is Map<String, dynamic> ? fn : const <String, dynamic>{};
+        parts.add(
+          LLMToolCallPart(
+            id: (tc['id'] ?? '').toString(),
+            name: (fnMap['name'] ?? '').toString(),
+            arguments: _decodeArgs(fnMap['arguments']),
+          ),
+        );
+      }
+    }
+  }
+
+  final audio = message['audio'];
+  if (audio is Map<String, dynamic>) {
+    final adata = audio['data'];
+    if (adata is String && adata.isNotEmpty) {
+      parts.add(
+        LLMAudioPart.base64(adata, transcript: audio['transcript'] as String?),
+      );
+    }
+  }
+
+  final usage =
+      (data['usage'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  return LLMCompletionResponse(
+    content: LLMContent(role: LLMRole.model, parts: parts),
+    usage: _parseOpenAiUsage(usage),
+    finishReason: LLMFinishReason.parse(choice['finish_reason'] as String?),
+    model: data['model'] as String?,
+    id: data['id'] as String?,
+  );
+}
+
+void _appendOpenAiContentParts(List<dynamic> items, List<LLMContentPart> out) {
+  for (final item in items) {
+    if (item is! Map<String, dynamic>) continue;
+    final type = item['type'];
+    if (type == 'text' && item['text'] is String) {
+      out.add(LLMTextPart(item['text'] as String));
+    } else if (type == 'image_url') {
+      final url = (item['image_url'] as Map<String, dynamic>?)?['url'];
+      if (url is String) out.add(LLMImagePart.dataUri(url));
+    }
+  }
+}
+
+Map<String, dynamic> _decodeArgs(Object? argsRaw) {
+  if (argsRaw is Map<String, dynamic>) return argsRaw;
+  if (argsRaw is String && argsRaw.isNotEmpty) {
+    try {
+      final decoded = jsonDecode(argsRaw);
+      if (decoded is Map<String, dynamic>) return decoded;
+    } on FormatException {
+      return <String, dynamic>{};
+    }
+  }
+  return <String, dynamic>{};
+}
+
+LLMUsage _parseOpenAiUsage(Map<String, dynamic> usage) {
+  final promptDetails = usage['prompt_tokens_details'] as Map<String, dynamic>?;
+  final completionDetails =
+      usage['completion_tokens_details'] as Map<String, dynamic>?;
+  return LLMUsage(
+    inputTokens: (usage['prompt_tokens'] as num?)?.toInt() ?? 0,
+    outputTokens: (usage['completion_tokens'] as num?)?.toInt() ?? 0,
+    cachedInputTokens: (promptDetails?['cached_tokens'] as num?)?.toInt(),
+    reasoningTokens: (completionDetails?['reasoning_tokens'] as num?)?.toInt(),
+  );
+}
+
+/// OpenAI 互換 API に POST し、JSON ボディを返す。失敗時は [LLMException]。
+Future<Map<String, dynamic>> postOpenAiJson({
+  required String url,
+  required String apiKey,
+  required String provider,
+  required Map<String, dynamic> body,
+}) async {
+  try {
+    final response = await Api.post(
+      requestAcc: PostRequestAcc(
+        url: url,
+        headers: RestHeaders({
+          'Authorization': 'Bearer $apiKey',
+          'Content-Type': 'application/json',
+        }),
+        body: JsonRequestBody(body),
+      ),
+    );
+    final statusCode = int.tryParse(response.statusCode) ?? 0;
+    final respBody = response.body;
+    Map<String, dynamic>? mapData;
+    if (respBody is MapJsonResponseBody) {
+      mapData = respBody.data;
+    }
+    if (statusCode < 200 || statusCode >= 300) {
+      throw LLMException.fromHttp(
+        statusCode,
+        provider: provider,
+        body: mapData ?? respBody,
+      );
+    }
+    if (mapData != null) return mapData;
+    throw LLMUnknownException(
+      'Unexpected response body from $provider',
+      provider: provider,
+      raw: respBody,
+    );
+  } on LLMException {
+    rethrow;
+  } catch (e) {
+    throw LLMNetworkException(
+      'Network request failed',
+      provider: provider,
+      raw: e,
+    );
+  }
+}

--- a/pkgs/minimax_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.dart
+++ b/pkgs/minimax_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.dart
@@ -19,6 +19,7 @@ abstract class ChatCompletionRequest with _$ChatCompletionRequest {
     @JsonKey(name: 'response_format') Map<String, dynamic>? responseFormat,
     List<Map<String, dynamic>>? tools,
     @JsonKey(name: 'tool_choice') dynamic toolChoice,
+
     /// DeepSeek-R1系と同様にThinkingプロセスを分離して取得する
     @JsonKey(name: 'reasoning_split') bool? reasoningSplit,
   }) = _ChatCompletionRequest;

--- a/pkgs/minimax_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.dart
+++ b/pkgs/minimax_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.dart
@@ -15,8 +15,10 @@ abstract class ChatCompletionResponse with _$ChatCompletionResponse {
     required String model,
     required String object,
     ChatCompletionResponseUsage? usage,
+
     /// コンテンツポリシー違反フラグ（入力側）
     @JsonKey(name: 'input_sensitive') bool? inputSensitive,
+
     /// コンテンツポリシー違反フラグ（出力側）
     @JsonKey(name: 'output_sensitive') bool? outputSensitive,
   }) = _ChatCompletionResponse;

--- a/pkgs/minimax_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart
+++ b/pkgs/minimax_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart
@@ -9,6 +9,7 @@ abstract class ChatCompletionResponseMessage
   factory ChatCompletionResponseMessage({
     required String role,
     String? content,
+
     /// reasoning_split=true のとき Thinking プロセスが入る
     @JsonKey(name: 'reasoning_content') String? reasoningContent,
     @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls,

--- a/pkgs/minimax_box/lib/src/minimax.dart
+++ b/pkgs/minimax_box/lib/src/minimax.dart
@@ -1,98 +1,31 @@
-import 'dart:convert';
-
 import 'package:ai_box/ai_box.dart';
 import 'package:minimax_box/minimax_box.dart';
+import 'package:minimax_box/src/openai_compat.dart';
 
 class MiniMax extends LLMAIBase {
   MiniMax({required super.apiKey});
+
+  static const _url = 'https://api.minimax.io/v1/chat/completions';
+  static const _provider = 'minimax';
 
   @override
   Future<LLMCompletionResponse> completions(
     LLMCompletionRequest request,
   ) async {
-    final chatCompletion = await MiniMaxCore.chatCompletion(
+    final body = buildOpenAiBody(request, maxTokensKey: 'max_tokens');
+    final data = await postOpenAiJson(
+      url: _url,
       apiKey: apiKey,
-      request: ChatCompletionRequest(
-        model: request.model,
-        messages: request.messages
-            .map(
-              (e) => ChatCompletionMessage(
-                role: e.role == LLMRole.model
-                    ? ChatCompletionRole.assistant
-                    : e.role == LLMRole.system
-                        ? ChatCompletionRole.system
-                        : ChatCompletionRole.user,
-                content: e.content,
-              ),
-            )
-            .toList(),
-        maxTokens: request.maxTokens,
-        temperature: request.temperature,
-        topP: request.topP,
-        stop: request.stop,
-        seed: request.seed,
-        responseFormat: request.responseFormat != null
-            ? {'type': request.responseFormat!.type.toApiString()}
-            : null,
-      ),
+      provider: _provider,
+      body: body,
     );
-    final choice = chatCompletion.choices.first;
-    return LLMCompletionResponse(
-      content: _parseMessage(
-        content: choice.message.content,
-        toolCalls: choice.message.toolCalls,
-      ),
-      inputTokens: chatCompletion.usage?.promptTokens ?? 0,
-      outputTokens: chatCompletion.usage?.completionTokens ?? 0,
-      finishReason: choice.finishReason,
-    );
-  }
-
-  LLMContent _parseMessage({
-    required String? content,
-    required List<Map<String, dynamic>>? toolCalls,
-  }) {
-    final parts = <LLMContentPart>[];
-    final text = content ?? '';
-    if (text.isNotEmpty) parts.add(LLMTextPart(text));
-
-    if (toolCalls != null) {
-      for (final tc in toolCalls) {
-        final fn = tc['function'] as Map<String, dynamic>;
-        final argsRaw = fn['arguments'] as String;
-        final args =
-            argsRaw.isEmpty
-            ? <String, dynamic>{}
-            : jsonDecode(argsRaw) as Map<String, dynamic>;
-        parts.add(
-          LLMToolCallPart(
-            id: tc['id'] as String,
-            name: fn['name'] as String,
-            arguments: args,
-          ),
-        );
-      }
-    }
-
-    if (parts.isEmpty) {
-      return const LLMContent(role: LLMRole.model, content: '');
-    }
-    if (parts.every((p) => p is LLMTextPart)) {
-      return LLMContent(role: LLMRole.model, content: text);
-    }
-    return LLMContent(role: LLMRole.model, content: text, parts: parts);
+    return parseOpenAiResponse(data);
   }
 
   @override
   Future<List<AIModel>> getModels() async {
     final modelList = await MiniMaxCore.listModels(apiKey: apiKey);
-    return modelList.data
-        .map(
-          (e) => AIModel(
-            id: e.id,
-          ),
-        )
-        .toList();
+    return modelList.data.map((e) => AIModel(id: e.id)).toList();
   }
 
   @override

--- a/pkgs/minimax_box/lib/src/openai_compat.dart
+++ b/pkgs/minimax_box/lib/src/openai_compat.dart
@@ -1,0 +1,338 @@
+// OpenAI 互換 Chat Completions API のリクエスト構築・レスポンス解析ヘルパー。
+//
+// 画像・音声・ファイル・ツール呼び出し・構造化出力を raw JSON として
+// 組み立てる（freezed のコード生成に依存しない）。
+//
+// このファイルは src/ 配下のパッケージ内部実装であり、公開 API には含めない。
+import 'dart:convert';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:api_http/api_http.dart';
+
+/// [LLMCompletionRequest] を OpenAI 互換のリクエストボディに変換する。
+Map<String, dynamic> buildOpenAiBody(
+  LLMCompletionRequest request, {
+  required String maxTokensKey,
+}) {
+  final body = <String, dynamic>{
+    'model': request.model,
+    'messages': _toOpenAiMessages(request.messages),
+  };
+  if (request.maxTokens != null) body[maxTokensKey] = request.maxTokens;
+  if (request.temperature != null) body['temperature'] = request.temperature;
+  if (request.topP != null) body['top_p'] = request.topP;
+  if (request.stop != null) body['stop'] = request.stop;
+  if (request.seed != null) body['seed'] = request.seed;
+  if (request.frequencyPenalty != null) {
+    body['frequency_penalty'] = request.frequencyPenalty;
+  }
+  if (request.presencePenalty != null) {
+    body['presence_penalty'] = request.presencePenalty;
+  }
+  final rf = _toOpenAiResponseFormat(request.responseFormat);
+  if (rf != null) body['response_format'] = rf;
+  final tools = request.tools;
+  if (tools != null && tools.isNotEmpty) {
+    body['tools'] = [
+      for (final t in tools)
+        {
+          'type': 'function',
+          'function': {
+            'name': t.name,
+            'description': t.description,
+            'parameters': t.parameters,
+          },
+        },
+    ];
+    final tc = _toOpenAiToolChoice(request.toolChoice);
+    if (tc != null) body['tool_choice'] = tc;
+  }
+  return body;
+}
+
+List<Map<String, dynamic>> _toOpenAiMessages(List<LLMContent> messages) {
+  final out = <Map<String, dynamic>>[];
+  for (final m in messages) {
+    final role = switch (m.role) {
+      LLMRole.model => 'assistant',
+      LLMRole.system => 'system',
+      LLMRole.user => 'user',
+    };
+
+    // ツール実行結果は role: 'tool' の独立メッセージとして送る。
+    final toolResults = m.parts.whereType<LLMToolResultPart>().toList();
+    if (toolResults.isNotEmpty) {
+      for (final tr in toolResults) {
+        out.add({
+          'role': 'tool',
+          'tool_call_id': tr.toolCallId,
+          'content': tr.content,
+        });
+      }
+      continue;
+    }
+
+    // assistant のツール呼び出しエコー。
+    final toolCalls = m.parts.whereType<LLMToolCallPart>().toList();
+    if (toolCalls.isNotEmpty) {
+      out.add({
+        'role': 'assistant',
+        if (m.text.isNotEmpty) 'content': m.text,
+        'tool_calls': [
+          for (final tc in toolCalls)
+            {
+              'id': tc.id,
+              'type': 'function',
+              'function': {
+                'name': tc.name,
+                'arguments': jsonEncode(tc.arguments),
+              },
+            },
+        ],
+      });
+      continue;
+    }
+
+    final hasMedia = m.parts.any(
+      (p) => p is LLMImagePart || p is LLMAudioPart || p is LLMFilePart,
+    );
+    if (!hasMedia) {
+      out.add({'role': role, 'content': m.text});
+      continue;
+    }
+
+    out.add({'role': role, 'content': _toOpenAiContentArray(m.parts)});
+  }
+  return out;
+}
+
+List<Map<String, dynamic>> _toOpenAiContentArray(List<LLMContentPart> parts) {
+  final arr = <Map<String, dynamic>>[];
+  for (final p in parts) {
+    if (p is LLMTextPart) {
+      arr.add({'type': 'text', 'text': p.text});
+    } else if (p is LLMImagePart) {
+      arr.add({
+        'type': 'image_url',
+        'image_url': {'url': p.asUrlOrDataUri},
+      });
+    } else if (p is LLMAudioPart) {
+      arr.add({
+        'type': 'input_audio',
+        'input_audio': {
+          'data': p.base64Data ?? '',
+          'format': _audioFormat(p.mimeType),
+        },
+      });
+    } else if (p is LLMFilePart) {
+      arr.add({
+        'type': 'file',
+        'file': {
+          if (p.filename != null) 'filename': p.filename,
+          'file_data': _fileDataField(p),
+        },
+      });
+    }
+  }
+  return arr;
+}
+
+String _fileDataField(LLMFilePart f) {
+  if (f.hasBytes) {
+    final mime = f.mimeType ?? 'application/octet-stream';
+    return 'data:$mime;base64,${f.base64Data}';
+  }
+  return f.url ?? '';
+}
+
+String _audioFormat(String? mimeType) {
+  if (mimeType == null) return 'wav';
+  if (mimeType.contains('mp3') || mimeType.contains('mpeg')) return 'mp3';
+  if (mimeType.contains('wav')) return 'wav';
+  return mimeType.split('/').last;
+}
+
+Map<String, dynamic>? _toOpenAiResponseFormat(LLMResponseFormat? f) {
+  if (f == null) return null;
+  switch (f.type) {
+    case LLMResponseFormatType.text:
+      return {'type': 'text'};
+    case LLMResponseFormatType.jsonObject:
+      return {'type': 'json_object'};
+    case LLMResponseFormatType.jsonSchema:
+      return {
+        'type': 'json_schema',
+        'json_schema': {
+          'name': f.schemaName,
+          'schema': f.schema,
+          'strict': f.strict,
+        },
+      };
+  }
+}
+
+dynamic _toOpenAiToolChoice(LLMToolChoice? tc) {
+  if (tc == null) return null;
+  final toolName = tc.toolName;
+  if (toolName != null) {
+    return {
+      'type': 'function',
+      'function': {'name': toolName},
+    };
+  }
+  switch (tc.mode) {
+    case LLMToolChoiceMode.auto:
+      return 'auto';
+    case LLMToolChoiceMode.none:
+      return 'none';
+    case LLMToolChoiceMode.any:
+      return 'required';
+  }
+}
+
+/// OpenAI 互換のレスポンスボディを [LLMCompletionResponse] に変換する。
+LLMCompletionResponse parseOpenAiResponse(Map<String, dynamic> data) {
+  final choices = (data['choices'] as List?) ?? const [];
+  final choice = choices.isNotEmpty
+      ? choices.first as Map<String, dynamic>
+      : const <String, dynamic>{};
+  final message =
+      (choice['message'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  final parts = <LLMContentPart>[];
+
+  final reasoning = message['reasoning_content'];
+  if (reasoning is String && reasoning.isNotEmpty) {
+    parts.add(LLMReasoningPart(reasoning));
+  }
+
+  final rawContent = message['content'];
+  if (rawContent is String && rawContent.isNotEmpty) {
+    parts.add(LLMTextPart(rawContent));
+  } else if (rawContent is List) {
+    _appendOpenAiContentParts(rawContent, parts);
+  }
+
+  final toolCalls = message['tool_calls'];
+  if (toolCalls is List) {
+    for (final tc in toolCalls) {
+      if (tc is Map<String, dynamic>) {
+        final fn = tc['function'];
+        final fnMap =
+            fn is Map<String, dynamic> ? fn : const <String, dynamic>{};
+        parts.add(
+          LLMToolCallPart(
+            id: (tc['id'] ?? '').toString(),
+            name: (fnMap['name'] ?? '').toString(),
+            arguments: _decodeArgs(fnMap['arguments']),
+          ),
+        );
+      }
+    }
+  }
+
+  final audio = message['audio'];
+  if (audio is Map<String, dynamic>) {
+    final adata = audio['data'];
+    if (adata is String && adata.isNotEmpty) {
+      parts.add(
+        LLMAudioPart.base64(adata, transcript: audio['transcript'] as String?),
+      );
+    }
+  }
+
+  final usage =
+      (data['usage'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  return LLMCompletionResponse(
+    content: LLMContent(role: LLMRole.model, parts: parts),
+    usage: _parseOpenAiUsage(usage),
+    finishReason: LLMFinishReason.parse(choice['finish_reason'] as String?),
+    model: data['model'] as String?,
+    id: data['id'] as String?,
+  );
+}
+
+void _appendOpenAiContentParts(List<dynamic> items, List<LLMContentPart> out) {
+  for (final item in items) {
+    if (item is! Map<String, dynamic>) continue;
+    final type = item['type'];
+    if (type == 'text' && item['text'] is String) {
+      out.add(LLMTextPart(item['text'] as String));
+    } else if (type == 'image_url') {
+      final url = (item['image_url'] as Map<String, dynamic>?)?['url'];
+      if (url is String) out.add(LLMImagePart.dataUri(url));
+    }
+  }
+}
+
+Map<String, dynamic> _decodeArgs(Object? argsRaw) {
+  if (argsRaw is Map<String, dynamic>) return argsRaw;
+  if (argsRaw is String && argsRaw.isNotEmpty) {
+    try {
+      final decoded = jsonDecode(argsRaw);
+      if (decoded is Map<String, dynamic>) return decoded;
+    } on FormatException {
+      return <String, dynamic>{};
+    }
+  }
+  return <String, dynamic>{};
+}
+
+LLMUsage _parseOpenAiUsage(Map<String, dynamic> usage) {
+  final promptDetails = usage['prompt_tokens_details'] as Map<String, dynamic>?;
+  final completionDetails =
+      usage['completion_tokens_details'] as Map<String, dynamic>?;
+  return LLMUsage(
+    inputTokens: (usage['prompt_tokens'] as num?)?.toInt() ?? 0,
+    outputTokens: (usage['completion_tokens'] as num?)?.toInt() ?? 0,
+    cachedInputTokens: (promptDetails?['cached_tokens'] as num?)?.toInt(),
+    reasoningTokens: (completionDetails?['reasoning_tokens'] as num?)?.toInt(),
+  );
+}
+
+/// OpenAI 互換 API に POST し、JSON ボディを返す。失敗時は [LLMException]。
+Future<Map<String, dynamic>> postOpenAiJson({
+  required String url,
+  required String apiKey,
+  required String provider,
+  required Map<String, dynamic> body,
+}) async {
+  try {
+    final response = await Api.post(
+      requestAcc: PostRequestAcc(
+        url: url,
+        headers: RestHeaders({
+          'Authorization': 'Bearer $apiKey',
+          'Content-Type': 'application/json',
+        }),
+        body: JsonRequestBody(body),
+      ),
+    );
+    final statusCode = int.tryParse(response.statusCode) ?? 0;
+    final respBody = response.body;
+    Map<String, dynamic>? mapData;
+    if (respBody is MapJsonResponseBody) {
+      mapData = respBody.data;
+    }
+    if (statusCode < 200 || statusCode >= 300) {
+      throw LLMException.fromHttp(
+        statusCode,
+        provider: provider,
+        body: mapData ?? respBody,
+      );
+    }
+    if (mapData != null) return mapData;
+    throw LLMUnknownException(
+      'Unexpected response body from $provider',
+      provider: provider,
+      raw: respBody,
+    );
+  } on LLMException {
+    rethrow;
+  } catch (e) {
+    throw LLMNetworkException(
+      'Network request failed',
+      provider: provider,
+      raw: e,
+    );
+  }
+}


### PR DESCRIPTION
## 概要

API設計レビューで判明した「できていない部分」を全面的に設計・実装しました。最大の問題は **入力側で `LLMContent.parts` が全プロバイダーで黙って捨てられていた**（＝画像・音声・ファイルを送れない）点で、ここを軸に再設計しています。

`ai_box` コアはプレーンDartで全面再設計し、各プロバイダーの `completions()` は **raw JSON 方式**に統一しました（freezedのコード生成に非依存で、マルチモーダル／ツール／スキーマをすべて表現可能）。

## 主な変更

### コア (`ai_box`)
- **マルチモーダル入力**: `LLMImagePart` / `LLMAudioPart` / `LLMFilePart`（bytes または url）。`LLMContent.user(text, attachments: [...])` で添付。
- **使いやすさ**: `package:ai_box/io.dart` の `File.toImagePart()/toFilePart()/toAudioPart()` で「Fileを入れるだけ」。コア本体は `dart:io` 非依存（Web互換維持）。
- **出力の網羅**: sealed `LLMContentPart`（text/image/audio/file/toolCall/toolResult/reasoning/code）、正規化 `LLMFinishReason` enum、拡張 `LLMUsage`（cached/reasoning トークン）。生成画像・音声は**バイト列**で返るので保存が容易。
- **sealedエラー**: `LLMException`（auth / rateLimit / invalidRequest / server / network / unknown）＋ `LLMException.fromHttp()` マッピング。
- **ツール（function calling）**: `LLMTool` / `LLMToolChoice` ＋ 結果返却用 `LLMToolResultPart`。
- **構造化出力**: `LLMResponseFormat.jsonSchema(...)`。
- **ストリーミング**: `completionsStream` / `generateTextStream`（既定は1チャンクのフォールバック。各プロバイダーで真のSSEに差し替え可能）。

### プロバイダー（ChatGPT / Grok / DeepSeek / MiniMax / Claude / Gemini）
- `completions()` を raw JSON 構築に変更し、画像/音声/ファイル/ツール/スキーマを**実際に送信**。
- エラーを `LLMException` に正規化、finish reason を正規化。
- OpenAI互換4社の変換ロジックは内部ファイル `openai_compat.dart` に集約。

## 検証（fvm + Flutter 3.41.3 / Dart 3.11.1）
- ✅ `dart analyze` … 全7パッケージ **エラー・警告ゼロ**
- ✅ `dart test pkgs/ai_box` … 追加した15テスト全パス（content/parts、finish-reason正規化、例外マッピング、responseFormat、toolChoice）
- ✅ `dart format` … 整形済み
- `api_http` のソースを確認し、非2xxでも例外を投げずレスポンスを返すこと・`statusCode` が `String` であることを確認した上でエラーハンドリングを実装。

## 互換性に関する注意（pre-1.0）
- `LLMContent` は `parts` ベースに変更（`content` は派生getterとして残置）。
- `LLMCompletionResponse` は `usage` を保持（`inputTokens`/`outputTokens` はgetterで後方互換）。
- `LLMResponseFormat` は `text`/`jsonObject` 定数を維持しつつ `jsonSchema` を追加。

## 既知の制限 / フォローアップ候補
- ストリーミングは現状フォールバック（真のSSEは各プロバイダーで実装余地あり）。
- 複数候補（n>1）は単一応答に簡略化したまま。
- OpenAI互換の `openai_compat.dart` はパッケージ自己完結のため4箇所に複製（公開依存を増やさない方針）。

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VscEdvZWN49XZESkSuarGG)_