### PR TITLE
feat: OpenRouter プロバイダー (openrouter_box) を追加

### DIFF
--- a/pkgs/openrouter_box/.gitignore
+++ b/pkgs/openrouter_box/.gitignore
@@ -1,0 +1,31 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/

--- a/pkgs/openrouter_box/CHANGELOG.md
+++ b/pkgs/openrouter_box/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+- Initial release.

--- a/pkgs/openrouter_box/LICENSE
+++ b/pkgs/openrouter_box/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Normidar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkgs/openrouter_box/README.md
+++ b/pkgs/openrouter_box/README.md
@@ -1,0 +1,67 @@
+# openrouter_box
+
+An [OpenRouter](https://openrouter.ai) AI provider based on [ai_box](https://github.com/normidar/ai_box).
+
+OpenRouter exposes a single OpenAI-compatible endpoint that routes to many
+underlying models (OpenAI, Anthropic, Google, Meta, and more). Specify a model
+with the `provider/model` form, e.g. `openai/gpt-4o-mini`.
+
+## Usage
+
+```dart
+import 'package:openrouter_box/openrouter_box.dart';
+
+Future<void> main() async {
+  final ai = OpenRouter(apiKey: 'sk-or-...');
+
+  // One-shot text generation.
+  final answer = await ai.generateText(
+    model: 'openai/gpt-4o-mini',
+    message: 'Say hello in one short sentence.',
+  );
+  print(answer);
+
+  // Multi-turn chat.
+  final res = await ai.chat(
+    model: 'openai/gpt-4o-mini',
+    messages: [
+      LLMContent.system('You are concise.'),
+      LLMContent.user('What is the capital of Japan?'),
+    ],
+    maxTokens: 32,
+  );
+  print(res.text);
+  print(res.usage); // token usage
+}
+```
+
+### Optional ranking headers
+
+Pass `referer` / `title` to send OpenRouter's optional `HTTP-Referer` /
+`X-Title` ranking headers:
+
+```dart
+final ai = OpenRouter(
+  apiKey: 'sk-or-...',
+  referer: 'https://your-app.example',
+  title: 'Your App',
+);
+```
+
+### Models and key info
+
+```dart
+// Rich model metadata (pricing, modalities, context length, ...).
+final models = await ai.listOpenRouterModels();
+final free = models.where((m) => m.isFree).map((m) => m.id).toList();
+
+// Common ai_box model list.
+final aiModels = await ai.getModels();
+
+// API key balance / limits.
+final info = await ai.getKeyInfo();
+print('usage: \$${info.usage} / limit: \$${info.limit}');
+
+// Validate the key.
+final ok = await ai.validateKey();
+```

--- a/pkgs/openrouter_box/analysis_options.yaml
+++ b/pkgs/openrouter_box/analysis_options.yaml
@@ -1,0 +1,11 @@
+include: package:very_good_analysis/analysis_options.yaml
+analyzer:
+  exclude: [build/**, lib/**.freezed.dart, lib/**.g.dart]
+  errors:
+    sort_constructors_first: ignore
+    public_member_api_docs: ignore
+    one_member_abstracts: ignore
+    invalid_annotation_target: ignore
+    avoid_positional_boolean_parameters: ignore
+    use_setters_to_change_properties: ignore
+    prefer_asserts_with_message: ignore

--- a/pkgs/openrouter_box/build.yaml
+++ b/pkgs/openrouter_box/build.yaml
@@ -1,0 +1,7 @@
+targets:
+  $default:
+    builders:
+      auto_exporter:
+        options:
+          default_export_all: true
+          project_name: openrouter_box

--- a/pkgs/openrouter_box/lib/openrouter_box.dart
+++ b/pkgs/openrouter_box/lib/openrouter_box.dart
@@ -1,0 +1,4 @@
+export 'package:openrouter_box/src/core/openrouter_core.dart';
+export 'package:openrouter_box/src/models/openrouter_key_info.dart';
+export 'package:openrouter_box/src/models/openrouter_model.dart';
+export 'package:openrouter_box/src/openrouter.dart';

--- a/pkgs/openrouter_box/lib/src/core/openrouter_core.dart
+++ b/pkgs/openrouter_box/lib/src/core/openrouter_core.dart
@@ -1,0 +1,83 @@
+import 'package:ai_box/ai_box.dart';
+import 'package:api_http/api_http.dart';
+import 'package:openrouter_box/src/models/openrouter_key_info.dart';
+import 'package:openrouter_box/src/models/openrouter_model.dart';
+
+/// OpenRouter REST API（`https://openrouter.ai/api/v1`）への薄いアクセスレイヤ。
+class OpenRouterCore {
+  const OpenRouterCore._();
+
+  /// API のベース URL。
+  static const baseUrl = 'https://openrouter.ai/api/v1';
+
+  static const _provider = 'openrouter';
+
+  /// 利用可能なモデル一覧を取得する。
+  ///
+  /// このエンドポイントは認証不要だが、[apiKey] を渡すとアカウントに応じた
+  /// 結果を取得できる。
+  static Future<List<OpenRouterModel>> listModels({String? apiKey}) async {
+    final response = await Api.get(
+      requestAcc: GetRequestAcc(
+        url: '$baseUrl/models',
+        headers: getHeaders(apiKey: apiKey),
+      ),
+    );
+    final data = _ensureOk(response.statusCode, response.body);
+    final list = (data['data'] as List?) ?? const [];
+    return [
+      for (final e in list)
+        if (e is Map<String, dynamic>) OpenRouterModel.fromJson(e),
+    ];
+  }
+
+  /// API キーの情報（利用額・上限など）を取得する。
+  ///
+  /// 認証が必要なため、キーの有効性確認にも使える。
+  static Future<OpenRouterKeyInfo> getKeyInfo({required String apiKey}) async {
+    final response = await Api.get(
+      requestAcc: GetRequestAcc(
+        url: '$baseUrl/key',
+        headers: getHeaders(apiKey: apiKey),
+      ),
+    );
+    final data = _ensureOk(response.statusCode, response.body);
+    return OpenRouterKeyInfo.fromJson(data);
+  }
+
+  /// 共通のリクエストヘッダを生成する。
+  ///
+  /// [referer] / [title] は OpenRouter のランキング用ヘッダ
+  /// （`HTTP-Referer` / `X-Title`、任意）。
+  static RestHeaders getHeaders({
+    String? apiKey,
+    String? referer,
+    String? title,
+  }) {
+    return RestHeaders({
+      if (apiKey != null) 'Authorization': 'Bearer $apiKey',
+      'Content-Type': 'application/json',
+      if (referer != null) 'HTTP-Referer': referer,
+      if (title != null) 'X-Title': title,
+    });
+  }
+
+  /// 2xx を確認しつつ JSON マップを取り出す。失敗時は [LLMException]。
+  static Map<String, dynamic> _ensureOk(String statusCodeStr, Object? body) {
+    final statusCode = int.tryParse(statusCodeStr) ?? 0;
+    final mapData = body is MapJsonResponseBody ? body.data : null;
+    if (statusCode < 200 || statusCode >= 300) {
+      throw LLMException.fromHttp(
+        statusCode,
+        provider: _provider,
+        body: mapData ?? body,
+      );
+    }
+    if (mapData != null) return mapData;
+    throw LLMUnknownException(
+      'Unexpected response body from $_provider',
+      provider: _provider,
+      raw: body,
+    );
+  }
+}

--- a/pkgs/openrouter_box/lib/src/models/openrouter_key_info.dart
+++ b/pkgs/openrouter_box/lib/src/models/openrouter_key_info.dart
@@ -1,0 +1,50 @@
+/// OpenRouter `/key` が返す API キーの情報。
+///
+/// 残高上限（[limit]）・利用済み（[usage]）・残り（[limitRemaining]）などを保持する。
+class OpenRouterKeyInfo {
+  const OpenRouterKeyInfo({
+    required this.raw,
+    this.label,
+    this.usage,
+    this.limit,
+    this.limitRemaining,
+    this.isFreeTier,
+  });
+
+  /// JSON から生成する。`{"data": {...}}` の内側・外側どちらでも受け付ける。
+  factory OpenRouterKeyInfo.fromJson(Map<String, dynamic> json) {
+    final data = (json['data'] as Map<String, dynamic>?) ?? json;
+    return OpenRouterKeyInfo(
+      label: data['label'] as String?,
+      usage: _toDouble(data['usage']),
+      limit: _toDouble(data['limit']),
+      limitRemaining: _toDouble(data['limit_remaining']),
+      isFreeTier: data['is_free_tier'] as bool?,
+      raw: data,
+    );
+  }
+
+  /// キーのラベル（マスクされた表示名）。
+  final String? label;
+
+  /// これまでの利用額（USD）。
+  final double? usage;
+
+  /// 利用上限（USD）。`null` は無制限。
+  final double? limit;
+
+  /// 残り利用可能額（USD）。`null` は無制限。
+  final double? limitRemaining;
+
+  /// 無料ティアのキーか。
+  final bool? isFreeTier;
+
+  /// 元の JSON。
+  final Map<String, dynamic> raw;
+
+  static double? _toDouble(Object? v) {
+    if (v == null) return null;
+    if (v is num) return v.toDouble();
+    return double.tryParse(v.toString());
+  }
+}

--- a/pkgs/openrouter_box/lib/src/models/openrouter_model.dart
+++ b/pkgs/openrouter_box/lib/src/models/openrouter_model.dart
@@ -1,0 +1,171 @@
+import 'package:ai_box/ai_box.dart';
+
+/// OpenRouter `/models` が返す 1 モデルの情報。
+///
+/// OpenRouter は各モデルについて、コンテキスト長・対応モダリティ・価格などの
+/// 豊富なメタデータを返す。ai_box 共通の [AIModel] には [toAIModel] で変換できる。
+class OpenRouterModel {
+  const OpenRouterModel({
+    required this.id,
+    required this.raw,
+    this.name,
+    this.canonicalSlug,
+    this.created,
+    this.description,
+    this.contextLength,
+    this.maxCompletionTokens,
+    this.inputModalities,
+    this.outputModalities,
+    this.pricing,
+    this.supportedParameters,
+  });
+
+  /// JSON（`data` 配列の 1 要素）から生成する。
+  factory OpenRouterModel.fromJson(Map<String, dynamic> json) {
+    final architecture = json['architecture'] as Map<String, dynamic>?;
+    final topProvider = json['top_provider'] as Map<String, dynamic>?;
+    final pricing = json['pricing'] as Map<String, dynamic>?;
+    final createdRaw = json['created'];
+    return OpenRouterModel(
+      id: (json['id'] ?? '').toString(),
+      name: json['name'] as String?,
+      canonicalSlug: json['canonical_slug'] as String?,
+      created:
+          createdRaw is num
+              ? DateTime.fromMillisecondsSinceEpoch(createdRaw.toInt() * 1000)
+              : null,
+      description: json['description'] as String?,
+      contextLength: (json['context_length'] as num?)?.toInt(),
+      maxCompletionTokens:
+          (topProvider?['max_completion_tokens'] as num?)?.toInt(),
+      inputModalities: _parseModalities(architecture?['input_modalities']),
+      outputModalities: _parseModalities(architecture?['output_modalities']),
+      pricing: pricing == null ? null : OpenRouterPricing.fromJson(pricing),
+      supportedParameters:
+          (json['supported_parameters'] as List?)
+              ?.map((e) => e.toString())
+              .toList(),
+      raw: json,
+    );
+  }
+
+  /// モデル ID（例: `openai/gpt-4o-mini`）。
+  final String id;
+
+  /// 人間可読のモデル名。
+  final String? name;
+
+  /// 安定したスラッグ（バージョン込みの正規名）。
+  final String? canonicalSlug;
+
+  /// 作成日時。
+  final DateTime? created;
+
+  /// モデルの説明。
+  final String? description;
+
+  /// コンテキストウィンドウ（入力トークン上限）。
+  final int? contextLength;
+
+  /// 最大出力トークン数。
+  final int? maxCompletionTokens;
+
+  /// 入力で対応するモダリティ。
+  final Set<LLMModality>? inputModalities;
+
+  /// 出力で対応するモダリティ。
+  final Set<LLMModality>? outputModalities;
+
+  /// 価格情報（トークンあたりの USD）。
+  final OpenRouterPricing? pricing;
+
+  /// このモデルが受け付けるパラメータ名の一覧。
+  final List<String>? supportedParameters;
+
+  /// 元の JSON（取りこぼした項目にアクセスするため保持）。
+  final Map<String, dynamic> raw;
+
+  /// 無料モデル（プロンプト・補完ともに 0 USD）か。
+  bool get isFree =>
+      (pricing?.prompt ?? 0) == 0 && (pricing?.completion ?? 0) == 0;
+
+  /// ai_box 共通の [AIModel] へ変換する。
+  AIModel toAIModel() => AIModel(
+    id: id,
+    name: name,
+    created: created,
+    description: description,
+    contextLength: contextLength,
+    maxOutputTokens: maxCompletionTokens,
+    inputModalities: inputModalities,
+    outputModalities: outputModalities,
+  );
+
+  @override
+  String toString() => 'OpenRouterModel(id: $id, name: $name)';
+
+  static Set<LLMModality>? _parseModalities(Object? raw) {
+    if (raw is! List) return null;
+    final out = <LLMModality>{};
+    for (final m in raw) {
+      switch (m.toString()) {
+        case 'text':
+          out.add(LLMModality.text);
+        case 'image':
+          out.add(LLMModality.image);
+        case 'audio':
+          out.add(LLMModality.audio);
+        case 'video':
+          out.add(LLMModality.video);
+        case 'file':
+        case 'document':
+          out.add(LLMModality.document);
+      }
+    }
+    return out.isEmpty ? null : out;
+  }
+}
+
+/// OpenRouter のモデル価格（USD/トークンなど）。
+///
+/// OpenRouter は価格を文字列で返すため、数値としても [prompt] / [completion]
+/// などでアクセスできるよう解析しておく。元の文字列は [raw] に保持する。
+class OpenRouterPricing {
+  const OpenRouterPricing({
+    required this.raw,
+    this.prompt,
+    this.completion,
+    this.request,
+    this.image,
+  });
+
+  factory OpenRouterPricing.fromJson(Map<String, dynamic> json) =>
+      OpenRouterPricing(
+        prompt: _toDouble(json['prompt']),
+        completion: _toDouble(json['completion']),
+        request: _toDouble(json['request']),
+        image: _toDouble(json['image']),
+        raw: json,
+      );
+
+  /// 入力トークンあたりの USD。
+  final double? prompt;
+
+  /// 出力トークンあたりの USD。
+  final double? completion;
+
+  /// リクエストあたりの USD。
+  final double? request;
+
+  /// 画像あたりの USD。
+  final double? image;
+
+  /// 元の価格 JSON（文字列値のまま）。
+  final Map<String, dynamic> raw;
+
+  static double? _toDouble(Object? v) {
+    if (v == null) return null;
+    if (v is num) return v.toDouble();
+    return double.tryParse(v.toString());
+  }
+}

--- a/pkgs/openrouter_box/lib/src/openai_compat.dart
+++ b/pkgs/openrouter_box/lib/src/openai_compat.dart
@@ -214,6 +214,19 @@ LLMCompletionResponse parseOpenAiResponse(Map<String, dynamic> data) {
     _appendOpenAiContentParts(rawContent, parts);
   }
 
+  // 生成画像（OpenRouter は message.images で返す）。
+  final images = message['images'];
+  if (images is List) {
+    for (final im in images) {
+      if (im is! Map<String, dynamic>) continue;
+      final imageUrl = im['image_url'];
+      final url = imageUrl is Map<String, dynamic> ? imageUrl['url'] : null;
+      if (url is String && url.isNotEmpty) {
+        parts.add(LLMImagePart.dataUri(url));
+      }
+    }
+  }
+
   final toolCalls = message['tool_calls'];
   if (toolCalls is List) {
     for (final tc in toolCalls) {

--- a/pkgs/openrouter_box/lib/src/openai_compat.dart
+++ b/pkgs/openrouter_box/lib/src/openai_compat.dart
@@ -1,0 +1,345 @@
+// OpenAI 互換 Chat Completions API のリクエスト構築・レスポンス解析ヘルパー。
+//
+// 画像・音声・ファイル・ツール呼び出し・構造化出力を raw JSON として
+// 組み立てる（freezed のコード生成に依存しない）。
+//
+// OpenRouter は OpenAI 互換のため、ChatGPT などと同じ実装を共有できる。
+// このファイルは src/ 配下のパッケージ内部実装であり、公開 API には含めない。
+import 'dart:convert';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:api_http/api_http.dart';
+
+/// [LLMCompletionRequest] を OpenAI 互換のリクエストボディに変換する。
+Map<String, dynamic> buildOpenAiBody(
+  LLMCompletionRequest request, {
+  required String maxTokensKey,
+}) {
+  final body = <String, dynamic>{
+    'model': request.model,
+    'messages': _toOpenAiMessages(request.messages),
+  };
+  if (request.maxTokens != null) body[maxTokensKey] = request.maxTokens;
+  if (request.temperature != null) body['temperature'] = request.temperature;
+  if (request.topP != null) body['top_p'] = request.topP;
+  if (request.stop != null) body['stop'] = request.stop;
+  if (request.seed != null) body['seed'] = request.seed;
+  if (request.frequencyPenalty != null) {
+    body['frequency_penalty'] = request.frequencyPenalty;
+  }
+  if (request.presencePenalty != null) {
+    body['presence_penalty'] = request.presencePenalty;
+  }
+  final rf = _toOpenAiResponseFormat(request.responseFormat);
+  if (rf != null) body['response_format'] = rf;
+  final tools = request.tools;
+  if (tools != null && tools.isNotEmpty) {
+    body['tools'] = [
+      for (final t in tools)
+        {
+          'type': 'function',
+          'function': {
+            'name': t.name,
+            'description': t.description,
+            'parameters': t.parameters,
+          },
+        },
+    ];
+    final tc = _toOpenAiToolChoice(request.toolChoice);
+    if (tc != null) body['tool_choice'] = tc;
+  }
+  return body;
+}
+
+List<Map<String, dynamic>> _toOpenAiMessages(List<LLMContent> messages) {
+  final out = <Map<String, dynamic>>[];
+  for (final m in messages) {
+    final role = switch (m.role) {
+      LLMRole.model => 'assistant',
+      LLMRole.system => 'system',
+      LLMRole.user => 'user',
+    };
+
+    // ツール実行結果は role: 'tool' の独立メッセージとして送る。
+    final toolResults = m.parts.whereType<LLMToolResultPart>().toList();
+    if (toolResults.isNotEmpty) {
+      for (final tr in toolResults) {
+        out.add({
+          'role': 'tool',
+          'tool_call_id': tr.toolCallId,
+          'content': tr.content,
+        });
+      }
+      continue;
+    }
+
+    // assistant のツール呼び出しエコー。
+    final toolCalls = m.parts.whereType<LLMToolCallPart>().toList();
+    if (toolCalls.isNotEmpty) {
+      out.add({
+        'role': 'assistant',
+        if (m.text.isNotEmpty) 'content': m.text,
+        'tool_calls': [
+          for (final tc in toolCalls)
+            {
+              'id': tc.id,
+              'type': 'function',
+              'function': {
+                'name': tc.name,
+                'arguments': jsonEncode(tc.arguments),
+              },
+            },
+        ],
+      });
+      continue;
+    }
+
+    final hasMedia = m.parts.any(
+      (p) => p is LLMImagePart || p is LLMAudioPart || p is LLMFilePart,
+    );
+    if (!hasMedia) {
+      out.add({'role': role, 'content': m.text});
+      continue;
+    }
+
+    out.add({'role': role, 'content': _toOpenAiContentArray(m.parts)});
+  }
+  return out;
+}
+
+List<Map<String, dynamic>> _toOpenAiContentArray(List<LLMContentPart> parts) {
+  final arr = <Map<String, dynamic>>[];
+  for (final p in parts) {
+    if (p is LLMTextPart) {
+      arr.add({'type': 'text', 'text': p.text});
+    } else if (p is LLMImagePart) {
+      arr.add({
+        'type': 'image_url',
+        'image_url': {'url': p.asUrlOrDataUri},
+      });
+    } else if (p is LLMAudioPart) {
+      arr.add({
+        'type': 'input_audio',
+        'input_audio': {
+          'data': p.base64Data ?? '',
+          'format': _audioFormat(p.mimeType),
+        },
+      });
+    } else if (p is LLMFilePart) {
+      arr.add({
+        'type': 'file',
+        'file': {
+          if (p.filename != null) 'filename': p.filename,
+          'file_data': _fileDataField(p),
+        },
+      });
+    }
+  }
+  return arr;
+}
+
+String _fileDataField(LLMFilePart f) {
+  if (f.hasBytes) {
+    final mime = f.mimeType ?? 'application/octet-stream';
+    return 'data:$mime;base64,${f.base64Data}';
+  }
+  return f.url ?? '';
+}
+
+String _audioFormat(String? mimeType) {
+  if (mimeType == null) return 'wav';
+  if (mimeType.contains('mp3') || mimeType.contains('mpeg')) return 'mp3';
+  if (mimeType.contains('wav')) return 'wav';
+  return mimeType.split('/').last;
+}
+
+Map<String, dynamic>? _toOpenAiResponseFormat(LLMResponseFormat? f) {
+  if (f == null) return null;
+  switch (f.type) {
+    case LLMResponseFormatType.text:
+      return {'type': 'text'};
+    case LLMResponseFormatType.jsonObject:
+      return {'type': 'json_object'};
+    case LLMResponseFormatType.jsonSchema:
+      return {
+        'type': 'json_schema',
+        'json_schema': {
+          'name': f.schemaName,
+          'schema': f.schema,
+          'strict': f.strict,
+        },
+      };
+  }
+}
+
+dynamic _toOpenAiToolChoice(LLMToolChoice? tc) {
+  if (tc == null) return null;
+  final toolName = tc.toolName;
+  if (toolName != null) {
+    return {
+      'type': 'function',
+      'function': {'name': toolName},
+    };
+  }
+  switch (tc.mode) {
+    case LLMToolChoiceMode.auto:
+      return 'auto';
+    case LLMToolChoiceMode.none:
+      return 'none';
+    case LLMToolChoiceMode.any:
+      return 'required';
+  }
+}
+
+/// OpenAI 互換のレスポンスボディを [LLMCompletionResponse] に変換する。
+LLMCompletionResponse parseOpenAiResponse(Map<String, dynamic> data) {
+  final choices = (data['choices'] as List?) ?? const [];
+  final choice =
+      choices.isNotEmpty
+          ? choices.first as Map<String, dynamic>
+          : const <String, dynamic>{};
+  final message =
+      (choice['message'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  final parts = <LLMContentPart>[];
+
+  final reasoning = message['reasoning_content'] ?? message['reasoning'];
+  if (reasoning is String && reasoning.isNotEmpty) {
+    parts.add(LLMReasoningPart(reasoning));
+  }
+
+  final rawContent = message['content'];
+  if (rawContent is String && rawContent.isNotEmpty) {
+    parts.add(LLMTextPart(rawContent));
+  } else if (rawContent is List) {
+    _appendOpenAiContentParts(rawContent, parts);
+  }
+
+  final toolCalls = message['tool_calls'];
+  if (toolCalls is List) {
+    for (final tc in toolCalls) {
+      if (tc is Map<String, dynamic>) {
+        final fn = tc['function'];
+        final fnMap =
+            fn is Map<String, dynamic> ? fn : const <String, dynamic>{};
+        parts.add(
+          LLMToolCallPart(
+            id: (tc['id'] ?? '').toString(),
+            name: (fnMap['name'] ?? '').toString(),
+            arguments: _decodeArgs(fnMap['arguments']),
+          ),
+        );
+      }
+    }
+  }
+
+  final audio = message['audio'];
+  if (audio is Map<String, dynamic>) {
+    final adata = audio['data'];
+    if (adata is String && adata.isNotEmpty) {
+      parts.add(
+        LLMAudioPart.base64(adata, transcript: audio['transcript'] as String?),
+      );
+    }
+  }
+
+  final usage =
+      (data['usage'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  return LLMCompletionResponse(
+    content: LLMContent(role: LLMRole.model, parts: parts),
+    usage: _parseOpenAiUsage(usage),
+    finishReason: LLMFinishReason.parse(choice['finish_reason'] as String?),
+    model: data['model'] as String?,
+    id: data['id'] as String?,
+  );
+}
+
+void _appendOpenAiContentParts(List<dynamic> items, List<LLMContentPart> out) {
+  for (final item in items) {
+    if (item is! Map<String, dynamic>) continue;
+    final type = item['type'];
+    if (type == 'text' && item['text'] is String) {
+      out.add(LLMTextPart(item['text'] as String));
+    } else if (type == 'image_url') {
+      final url = (item['image_url'] as Map<String, dynamic>?)?['url'];
+      if (url is String) out.add(LLMImagePart.dataUri(url));
+    }
+  }
+}
+
+Map<String, dynamic> _decodeArgs(Object? argsRaw) {
+  if (argsRaw is Map<String, dynamic>) return argsRaw;
+  if (argsRaw is String && argsRaw.isNotEmpty) {
+    try {
+      final decoded = jsonDecode(argsRaw);
+      if (decoded is Map<String, dynamic>) return decoded;
+    } on FormatException {
+      return <String, dynamic>{};
+    }
+  }
+  return <String, dynamic>{};
+}
+
+LLMUsage _parseOpenAiUsage(Map<String, dynamic> usage) {
+  final promptDetails = usage['prompt_tokens_details'] as Map<String, dynamic>?;
+  final completionDetails =
+      usage['completion_tokens_details'] as Map<String, dynamic>?;
+  return LLMUsage(
+    inputTokens: (usage['prompt_tokens'] as num?)?.toInt() ?? 0,
+    outputTokens: (usage['completion_tokens'] as num?)?.toInt() ?? 0,
+    cachedInputTokens: (promptDetails?['cached_tokens'] as num?)?.toInt(),
+    reasoningTokens: (completionDetails?['reasoning_tokens'] as num?)?.toInt(),
+  );
+}
+
+/// OpenAI 互換 API に POST し、JSON ボディを返す。失敗時は [LLMException]。
+///
+/// [extraHeaders] で OpenRouter 推奨の `HTTP-Referer` / `X-Title` などを
+/// 追加できる。
+Future<Map<String, dynamic>> postOpenAiJson({
+  required String url,
+  required String apiKey,
+  required String provider,
+  required Map<String, dynamic> body,
+  Map<String, String> extraHeaders = const {},
+}) async {
+  try {
+    final response = await Api.post(
+      requestAcc: PostRequestAcc(
+        url: url,
+        headers: RestHeaders({
+          'Authorization': 'Bearer $apiKey',
+          'Content-Type': 'application/json',
+          ...extraHeaders,
+        }),
+        body: JsonRequestBody(body),
+      ),
+    );
+    final statusCode = int.tryParse(response.statusCode) ?? 0;
+    final respBody = response.body;
+    Map<String, dynamic>? mapData;
+    if (respBody is MapJsonResponseBody) {
+      mapData = respBody.data;
+    }
+    if (statusCode < 200 || statusCode >= 300) {
+      throw LLMException.fromHttp(
+        statusCode,
+        provider: provider,
+        body: mapData ?? respBody,
+      );
+    }
+    if (mapData != null) return mapData;
+    throw LLMUnknownException(
+      'Unexpected response body from $provider',
+      provider: provider,
+      raw: respBody,
+    );
+  } on LLMException {
+    rethrow;
+  } catch (e) {
+    throw LLMNetworkException(
+      'Network request failed',
+      provider: provider,
+      raw: e,
+    );
+  }
+}

--- a/pkgs/openrouter_box/lib/src/openrouter.dart
+++ b/pkgs/openrouter_box/lib/src/openrouter.dart
@@ -1,0 +1,86 @@
+import 'package:ai_box/ai_box.dart';
+import 'package:openrouter_box/src/core/openrouter_core.dart';
+import 'package:openrouter_box/src/models/openrouter_key_info.dart';
+import 'package:openrouter_box/src/models/openrouter_model.dart';
+import 'package:openrouter_box/src/openai_compat.dart';
+
+/// OpenRouter（`https://openrouter.ai`）プロバイダー。
+///
+/// OpenRouter は OpenAI 互換の単一エンドポイントから、OpenAI・Anthropic・
+/// Google・Meta など多数のモデルへアクセスできるルーターサービス。
+/// モデル ID は `openai/gpt-4o-mini` のように `provider/model` 形式で指定する。
+///
+/// ```dart
+/// final ai = OpenRouter(apiKey: 'sk-or-...');
+/// final answer = await ai.generateText(
+///   model: 'openai/gpt-4o-mini',
+///   message: 'こんにちは',
+/// );
+/// ```
+///
+/// [referer] / [title] を渡すと、OpenRouter のランキング用ヘッダ
+/// （`HTTP-Referer` / `X-Title`）が付与される（任意）。
+class OpenRouter extends LLMAIBase {
+  OpenRouter({required super.apiKey, this.referer, this.title});
+
+  static const _url = '${OpenRouterCore.baseUrl}/chat/completions';
+  static const _provider = 'openrouter';
+
+  /// ランキング用の参照元 URL（`HTTP-Referer`、任意）。
+  final String? referer;
+
+  /// ランキング用のアプリ名（`X-Title`、任意）。
+  final String? title;
+
+  @override
+  Future<LLMCompletionResponse> completions(
+    LLMCompletionRequest request,
+  ) async {
+    final body = buildOpenAiBody(request, maxTokensKey: 'max_tokens');
+    final data = await postOpenAiJson(
+      url: _url,
+      apiKey: apiKey,
+      provider: _provider,
+      body: body,
+      extraHeaders: _rankingHeaders(),
+    );
+    return parseOpenAiResponse(data);
+  }
+
+  @override
+  Future<List<AIModel>> getModels() async {
+    final models = await OpenRouterCore.listModels(apiKey: apiKey);
+    return models.map((e) => e.toAIModel()).toList();
+  }
+
+  /// OpenRouter のリッチなモデル情報（価格・モダリティなど）を取得する。
+  ///
+  /// [getModels] が返す共通の [AIModel] よりも詳細な情報が必要なときに使う。
+  Future<List<OpenRouterModel>> listOpenRouterModels() {
+    return OpenRouterCore.listModels(apiKey: apiKey);
+  }
+
+  /// API キーの情報（利用額・上限など）を取得する。
+  Future<OpenRouterKeyInfo> getKeyInfo() {
+    return OpenRouterCore.getKeyInfo(apiKey: apiKey);
+  }
+
+  @override
+  Future<bool> validateKey() async {
+    try {
+      await OpenRouterCore.getKeyInfo(apiKey: apiKey);
+      return true;
+    } on LLMException {
+      return false;
+    }
+  }
+
+  Map<String, String> _rankingHeaders() {
+    final headers = <String, String>{};
+    final r = referer;
+    final t = title;
+    if (r != null) headers['HTTP-Referer'] = r;
+    if (t != null) headers['X-Title'] = t;
+    return headers;
+  }
+}

--- a/pkgs/openrouter_box/pubspec.yaml
+++ b/pkgs/openrouter_box/pubspec.yaml
@@ -1,0 +1,20 @@
+---
+dependencies:
+  ai_box: ^0.1.0
+  api_http: ^0.0.1
+description: '''An OpenRouter AI provider based on ai_box. '''
+dev_dependencies:
+  auto_exporter: any
+  build_runner: ^2.5.4
+  test: ^1.26.0
+  very_good_analysis: any
+environment:
+  sdk: ^3.7.0
+homepage: https://github.com/normidar/ai_box
+name: openrouter_box
+topics:
+  - ai
+  - openrouter
+  - ai-box
+  - llm
+version: 0.0.1

--- a/pkgs/openrouter_box/pubspec_overrides.yaml
+++ b/pkgs/openrouter_box/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: ai_box
+dependency_overrides:
+  ai_box:
+    path: ../ai_box

--- a/pkgs/openrouter_box/test/multimodal_test.dart
+++ b/pkgs/openrouter_box/test/multimodal_test.dart
@@ -1,0 +1,128 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:openrouter_box/src/openai_compat.dart';
+import 'package:test/test.dart';
+
+/// `buildOpenAiBody` がマルチモーダル入力（画像・音声・ファイル）を
+/// OpenAI 互換のリクエストへ正しく変換するかを検証する。
+///
+/// これらは OpenRouter のマルチモーダル対応モデルへ送られる実際のペイロード形状。
+void main() {
+  final bytes = Uint8List.fromList(utf8.encode('hello-bytes'));
+  final b64 = base64Encode(bytes);
+
+  List<dynamic> contentOf(LLMContent message) {
+    final body = buildOpenAiBody(
+      LLMCompletionRequest(model: 'test/model', messages: [message]),
+      maxTokensKey: 'max_tokens',
+    );
+    final messages = body['messages'] as List;
+    return (messages.single as Map<String, dynamic>)['content'] as List;
+  }
+
+  group('image input', () {
+    test('bytes -> image_url with data URI', () {
+      final content = contentOf(
+        LLMContent.user(
+          'describe',
+          attachments: [LLMImagePart.bytes(bytes)],
+        ),
+      );
+      expect(content[0], {'type': 'text', 'text': 'describe'});
+      final img = content[1] as Map<String, dynamic>;
+      expect(img['type'], 'image_url');
+      expect(
+        (img['image_url'] as Map)['url'],
+        'data:image/png;base64,$b64',
+      );
+    });
+
+    test('url -> image_url with the raw url', () {
+      final content = contentOf(
+        LLMContent.user(
+          'what is this',
+          attachments: [LLMImagePart.url('https://example.com/a.jpg')],
+        ),
+      );
+      final img = content[1] as Map<String, dynamic>;
+      expect((img['image_url'] as Map)['url'], 'https://example.com/a.jpg');
+    });
+  });
+
+  group('audio input', () {
+    test('wav bytes -> input_audio with base64 + format', () {
+      final content = contentOf(
+        LLMContent.user(
+          'transcribe',
+          attachments: [LLMAudioPart.bytes(bytes, mimeType: 'audio/wav')],
+        ),
+      );
+      final audio = content[1] as Map<String, dynamic>;
+      expect(audio['type'], 'input_audio');
+      final inner = audio['input_audio'] as Map<String, dynamic>;
+      expect(inner['data'], b64);
+      expect(inner['format'], 'wav');
+    });
+
+    test('mp3 mime is normalized to format "mp3"', () {
+      final content = contentOf(
+        LLMContent.user(
+          'listen',
+          attachments: [LLMAudioPart.bytes(bytes, mimeType: 'audio/mpeg')],
+        ),
+      );
+      final inner =
+          (content[1] as Map<String, dynamic>)['input_audio']
+              as Map<String, dynamic>;
+      expect(inner['format'], 'mp3');
+    });
+  });
+
+  group('file input', () {
+    test('pdf bytes -> file with filename + file_data data URI', () {
+      final content = contentOf(
+        LLMContent.user(
+          'summarize',
+          attachments: [
+            LLMFilePart.bytes(
+              bytes,
+              mimeType: 'application/pdf',
+              filename: 'doc.pdf',
+            ),
+          ],
+        ),
+      );
+      final file = content[1] as Map<String, dynamic>;
+      expect(file['type'], 'file');
+      final inner = file['file'] as Map<String, dynamic>;
+      expect(inner['filename'], 'doc.pdf');
+      expect(inner['file_data'], 'data:application/pdf;base64,$b64');
+    });
+  });
+
+  group('mixed multimodal message', () {
+    test('text + image + audio + file are all encoded in order', () {
+      final content = contentOf(
+        LLMContent.user(
+          'analyze all of these',
+          attachments: [
+            LLMImagePart.bytes(bytes),
+            LLMAudioPart.bytes(bytes, mimeType: 'audio/wav'),
+            LLMFilePart.bytes(
+              bytes,
+              mimeType: 'application/pdf',
+              filename: 'd.pdf',
+            ),
+          ],
+        ),
+      );
+      expect(content.length, 4);
+      expect((content[0] as Map)['type'], 'text');
+      expect((content[1] as Map)['type'], 'image_url');
+      expect((content[2] as Map)['type'], 'input_audio');
+      expect((content[3] as Map)['type'], 'file');
+    });
+  });
+}

--- a/pkgs/openrouter_box/test/multimodal_test.dart
+++ b/pkgs/openrouter_box/test/multimodal_test.dart
@@ -5,10 +5,12 @@ import 'package:ai_box/ai_box.dart';
 import 'package:openrouter_box/src/openai_compat.dart';
 import 'package:test/test.dart';
 
-/// `buildOpenAiBody` がマルチモーダル入力（画像・音声・ファイル）を
-/// OpenAI 互換のリクエストへ正しく変換するかを検証する。
+/// マルチモーダルの入出力を検証する。
 ///
-/// これらは OpenRouter のマルチモーダル対応モデルへ送られる実際のペイロード形状。
+/// - 入力: `buildOpenAiBody` が画像・音声・ファイルを OpenAI 互換リクエストへ
+///   正しく変換するか（OpenRouter へ送る実際のペイロード形状）。
+/// - 出力: `parseOpenAiResponse` が OpenRouter の生成画像（`message.images`）と
+///   音声（`message.audio`）をパーツへ復元できるか。
 void main() {
   final bytes = Uint8List.fromList(utf8.encode('hello-bytes'));
   final b64 = base64Encode(bytes);
@@ -123,6 +125,90 @@ void main() {
       expect((content[1] as Map)['type'], 'image_url');
       expect((content[2] as Map)['type'], 'input_audio');
       expect((content[3] as Map)['type'], 'file');
+    });
+  });
+
+  group('image output parsing', () {
+    test('message.images (OpenRouter) -> LLMImagePart with bytes', () {
+      final imgBytes = Uint8List.fromList([1, 2, 3, 4]);
+      final dataUri = 'data:image/png;base64,${base64Encode(imgBytes)}';
+      final res = parseOpenAiResponse({
+        'choices': [
+          {
+            'message': {
+              'role': 'assistant',
+              'content': 'Here is your image:',
+              'images': [
+                {
+                  'type': 'image_url',
+                  'image_url': {'url': dataUri},
+                },
+              ],
+            },
+            'finish_reason': 'stop',
+          },
+        ],
+        'usage': {'prompt_tokens': 5, 'completion_tokens': 1290},
+      });
+
+      expect(res.text, 'Here is your image:');
+      expect(res.content.hasImages, isTrue);
+      final img = res.content.images.single;
+      expect(img.hasBytes, isTrue);
+      expect(img.mimeType, 'image/png');
+      expect(img.bytes, imgBytes);
+      expect(res.usage.outputTokens, 1290);
+    });
+
+    test('image in content array is also captured', () {
+      final dataUri =
+          'data:image/png;base64,${base64Encode(
+            Uint8List.fromList([9, 9]),
+          )}';
+      final res = parseOpenAiResponse({
+        'choices': [
+          {
+            'message': {
+              'role': 'assistant',
+              'content': [
+                {'type': 'text', 'text': 'see:'},
+                {
+                  'type': 'image_url',
+                  'image_url': {'url': dataUri},
+                },
+              ],
+            },
+            'finish_reason': 'stop',
+          },
+        ],
+      });
+      expect(res.text, 'see:');
+      expect(res.content.images.single.bytes, [9, 9]);
+    });
+  });
+
+  group('audio output parsing', () {
+    test('message.audio -> LLMAudioPart with base64 + transcript', () {
+      final audioBytes = Uint8List.fromList([5, 6, 7, 8]);
+      final res = parseOpenAiResponse({
+        'choices': [
+          {
+            'message': {
+              'role': 'assistant',
+              'content': '',
+              'audio': {
+                'data': base64Encode(audioBytes),
+                'transcript': 'hello world',
+              },
+            },
+            'finish_reason': 'stop',
+          },
+        ],
+      });
+      expect(res.content.hasAudio, isTrue);
+      final audio = res.content.audioList.single;
+      expect(audio.base64Data, base64Encode(audioBytes));
+      expect(audio.transcript, 'hello world');
     });
   });
 }

--- a/pkgs/openrouter_box/test/openrouter_box_test.dart
+++ b/pkgs/openrouter_box/test/openrouter_box_test.dart
@@ -1,0 +1,124 @@
+import 'package:ai_box/ai_box.dart';
+import 'package:openrouter_box/openrouter_box.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OpenRouterModel.fromJson', () {
+    final json = <String, dynamic>{
+      'id': 'openai/gpt-4o-mini',
+      'canonical_slug': 'openai/gpt-4o-mini-2024',
+      'name': 'OpenAI: GPT-4o-mini',
+      'created': 1721260800,
+      'description': 'A small, fast model.',
+      'context_length': 128000,
+      'architecture': {
+        'modality': 'text+image->text',
+        'input_modalities': ['text', 'image'],
+        'output_modalities': ['text'],
+      },
+      'pricing': {'prompt': '0.00000015', 'completion': '0.0000006'},
+      'top_provider': {
+        'context_length': 128000,
+        'max_completion_tokens': 16384,
+      },
+      'supported_parameters': ['max_tokens', 'temperature', 'tools'],
+    };
+
+    test('parses rich metadata', () {
+      final m = OpenRouterModel.fromJson(json);
+      expect(m.id, 'openai/gpt-4o-mini');
+      expect(m.name, 'OpenAI: GPT-4o-mini');
+      expect(m.canonicalSlug, 'openai/gpt-4o-mini-2024');
+      expect(m.description, 'A small, fast model.');
+      expect(m.contextLength, 128000);
+      expect(m.maxCompletionTokens, 16384);
+      expect(m.created, DateTime.fromMillisecondsSinceEpoch(1721260800 * 1000));
+      expect(m.supportedParameters, contains('tools'));
+    });
+
+    test('parses modalities into LLMModality sets', () {
+      final m = OpenRouterModel.fromJson(json);
+      expect(m.inputModalities, {LLMModality.text, LLMModality.image});
+      expect(m.outputModalities, {LLMModality.text});
+    });
+
+    test('parses pricing as numbers', () {
+      final m = OpenRouterModel.fromJson(json);
+      expect(m.pricing?.prompt, 0.00000015);
+      expect(m.pricing?.completion, 0.0000006);
+      expect(m.isFree, isFalse);
+    });
+
+    test('toAIModel maps to the common AIModel', () {
+      final ai = OpenRouterModel.fromJson(json).toAIModel();
+      expect(ai, isA<AIModel>());
+      expect(ai.id, 'openai/gpt-4o-mini');
+      expect(ai.name, 'OpenAI: GPT-4o-mini');
+      expect(ai.contextLength, 128000);
+      expect(ai.maxOutputTokens, 16384);
+      expect(ai.inputModalities, {LLMModality.text, LLMModality.image});
+    });
+
+    test('free model detection', () {
+      final free = OpenRouterModel.fromJson({
+        'id': 'some/model:free',
+        'pricing': {'prompt': '0', 'completion': '0'},
+      });
+      expect(free.isFree, isTrue);
+      expect(free.toAIModel().id, 'some/model:free');
+    });
+
+    test('tolerates missing optional fields', () {
+      final m = OpenRouterModel.fromJson({'id': 'x/y'});
+      expect(m.id, 'x/y');
+      expect(m.name, isNull);
+      expect(m.pricing, isNull);
+      expect(m.inputModalities, isNull);
+      expect(m.created, isNull);
+    });
+  });
+
+  group('OpenRouterKeyInfo.fromJson', () {
+    test('parses the {data: {...}} envelope', () {
+      final info = OpenRouterKeyInfo.fromJson({
+        'data': {
+          'label': 'sk-or-v1-...xyz',
+          'usage': 0,
+          'limit': 1,
+          'limit_remaining': 1,
+          'is_free_tier': false,
+        },
+      });
+      expect(info.label, 'sk-or-v1-...xyz');
+      expect(info.usage, 0);
+      expect(info.limit, 1);
+      expect(info.limitRemaining, 1);
+      expect(info.isFreeTier, isFalse);
+    });
+
+    test('parses an unwrapped map and null (unlimited) limit', () {
+      final info = OpenRouterKeyInfo.fromJson({
+        'label': 'k',
+        'usage': 1.5,
+        'limit': null,
+      });
+      expect(info.label, 'k');
+      expect(info.usage, 1.5);
+      expect(info.limit, isNull);
+    });
+  });
+
+  group('OpenRouter client', () {
+    test('exposes apiKey and optional ranking headers', () {
+      final ai = OpenRouter(
+        apiKey: 'sk-or-test',
+        referer: 'https://example.app',
+        title: 'Example',
+      );
+      expect(ai.apiKey, 'sk-or-test');
+      expect(ai.referer, 'https://example.app');
+      expect(ai.title, 'Example');
+      expect(ai, isA<LLMAIBase>());
+    });
+  });
+}


### PR DESCRIPTION
## 概要

`ai_box` ベースの **OpenRouter** サポートパッケージ `openrouter_box` を新設しました。
OpenRouter は OpenAI 互換の単一エンドポイントから多数のモデル（OpenAI / Anthropic /
Google / Meta など）へアクセスできるルーターサービスです。モデルは
`openai/gpt-4o-mini` のように `provider/model` 形式で指定します。

```dart
import 'package:openrouter_box/openrouter_box.dart';

final ai = OpenRouter(apiKey: 'sk-or-...');
final answer = await ai.generateText(
  model: 'openai/gpt-4o-mini',
  message: 'こんにちは',
);
```

## 実装内容

- **`OpenRouter`**（`LLMAIBase` 実装）: `completions` / `getModels` / `validateKey`
  に加えて、OpenRouter 固有の以下を提供
  - `listOpenRouterModels()` … 価格・モダリティ・コンテキスト長などリッチなモデル情報
  - `getKeyInfo()` … API キーの利用額・上限
  - 任意の `referer` / `title`（`HTTP-Referer` / `X-Title` ランキングヘッダ）
- **`validateKey`** は認証必須の `GET /key` で実装（`/models` は公開エンドポイントの
  ため検証に使えない）
- **`/models`** のリッチなメタデータを共通の `AIModel` へ完全マッピング
  （context 長・入出力モダリティ・最大出力トークン）
- 例外は `ai_box` の sealed `LLMException` 階層へ正規化
- 既存の OpenAI 互換プロバイダーと同じ `openai_compat.dart` を共有しつつ、
  OpenRouter 推奨ヘッダ用に `extraHeaders` を追加
- **freezed 非依存**（raw JSON 解析）。既存パッケージの規約（`auto_exporter` の
  dev 依存・`build.yaml`・`pubspec_overrides.yaml`）に合わせて構成

## 動作確認

| チェック | 結果 |
| --- | --- |
| `dart pub get` | ✅ |
| `dart format .` | ✅ 変更なし |
| `dart analyze` | ✅ No issues found |
| `dart test`（オフライン単体テスト 9 件） | ✅ All tests passed |
| 実 API（テストキー） | ✅ 下記 |

実 API での確認内容（Flutter 3.41.3 / Dart 3.11.1, fvm 管理）:

- `validateKey()` → `true`、残高 `$1.0` 確認
- モデル一覧 341 件（無料 27 件）取得・`AIModel` 変換
- テキスト生成 / system+user チャット（usage・finishReason・model 取得）
- JSON 構造化出力（`response_format`）
- 無効キーで `LLMAuthException`(HTTP 401) を正しく送出

**テスト費用は $1 以内（実質 $0）** に収まりました。

## 補足

- 内部実装の `openai_compat.dart` は他パッケージと同様にバレルから除外しています。
- `gviz.dot`（melos 生成の依存グラフ）は未更新です。必要なら `make melos_generate`
  で再生成できます。

https://claude.ai/code/session_01J7ScpPUcGL1sQwbM6EHQn9

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7ScpPUcGL1sQwbM6EHQn9)_