### PR TITLE
Add Mistral, Qwen, WaveSpeedAI, and Perplexity AI providers

### DIFF
--- a/pkgs/mistral_box/.gitignore
+++ b/pkgs/mistral_box/.gitignore
@@ -1,0 +1,31 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/

--- a/pkgs/mistral_box/CHANGELOG.md
+++ b/pkgs/mistral_box/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+- Initial release.

--- a/pkgs/mistral_box/README.md
+++ b/pkgs/mistral_box/README.md
@@ -1,0 +1,3 @@
+# mistral_box
+
+A Mistral AI provider based on [ai_box](https://github.com/normidar/ai_box).

--- a/pkgs/mistral_box/analysis_options.yaml
+++ b/pkgs/mistral_box/analysis_options.yaml
@@ -1,0 +1,11 @@
+include: package:very_good_analysis/analysis_options.yaml
+analyzer:
+  exclude: [build/**, lib/**.freezed.dart, lib/**.g.dart]
+  errors:
+    sort_constructors_first: ignore
+    public_member_api_docs: ignore
+    one_member_abstracts: ignore
+    invalid_annotation_target: ignore
+    avoid_positional_boolean_parameters: ignore
+    use_setters_to_change_properties: ignore
+    prefer_asserts_with_message: ignore

--- a/pkgs/mistral_box/build.yaml
+++ b/pkgs/mistral_box/build.yaml
@@ -1,0 +1,7 @@
+targets:
+  $default:
+    builders:
+      auto_exporter:
+        options:
+          default_export_all: true
+          project_name: mistral_box

--- a/pkgs/mistral_box/lib/mistral_box.dart
+++ b/pkgs/mistral_box/lib/mistral_box.dart
@@ -1,0 +1,10 @@
+export 'package:mistral_box/src/core/mistral_core.dart';
+export 'package:mistral_box/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart';
+export 'package:mistral_box/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.dart';
+export 'package:mistral_box/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.dart';
+export 'package:mistral_box/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart';
+export 'package:mistral_box/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart';
+export 'package:mistral_box/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart';
+export 'package:mistral_box/src/freezed/model/model/model.dart';
+export 'package:mistral_box/src/freezed/model/model_list/model_list.dart';
+export 'package:mistral_box/src/mistral.dart';

--- a/pkgs/mistral_box/lib/src/core/mistral_core.dart
+++ b/pkgs/mistral_box/lib/src/core/mistral_core.dart
@@ -1,0 +1,47 @@
+import 'package:api_http/api_http.dart';
+import 'package:mistral_box/mistral_box.dart';
+
+class MistralCore {
+  static const _baseUrl = 'https://api.mistral.ai/v1';
+
+  static Future<ChatCompletionResponse> chatCompletion({
+    required String apiKey,
+    required ChatCompletionRequest request,
+  }) async {
+    final response = await Api.post(
+      requestAcc: PostRequestAcc(
+        url: '$_baseUrl/chat/completions',
+        headers: _getHeaders(apiKey: apiKey),
+        body: JsonRequestBody(request.toJson()),
+      ),
+    );
+    switch (response.body) {
+      case MapJsonResponseBody(:final data):
+        return ChatCompletionResponse.fromJson(data);
+      case _:
+        throw Exception('Failed to chat completion: ${response.body}');
+    }
+  }
+
+  static Future<ModelList> listModels({required String apiKey}) async {
+    final response = await Api.get(
+      requestAcc: GetRequestAcc(
+        url: '$_baseUrl/models',
+        headers: _getHeaders(apiKey: apiKey),
+      ),
+    );
+    switch (response.body) {
+      case MapJsonResponseBody(:final data):
+        return ModelList.fromJson(data);
+      case _:
+        throw Exception('Failed to list models: ${response.body}');
+    }
+  }
+
+  static RestHeaders _getHeaders({required String apiKey}) {
+    return RestHeaders({
+      'Authorization': 'Bearer $apiKey',
+      'Content-Type': 'application/json',
+    });
+  }
+}

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'chat_completion_message.freezed.dart';
+part 'chat_completion_message.g.dart';
+
+@freezed
+abstract class ChatCompletionMessage with _$ChatCompletionMessage {
+  factory ChatCompletionMessage({
+    required ChatCompletionRole role,
+    required String content,
+    String? name,
+    @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls,
+  }) = _ChatCompletionMessage;
+
+  factory ChatCompletionMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionMessageFromJson(json);
+  const ChatCompletionMessage._();
+}
+
+enum ChatCompletionRole { system, user, assistant, tool }

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.freezed.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.freezed.dart
@@ -1,0 +1,394 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_message.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionMessage {
+  ChatCompletionRole get role;
+  String get content;
+  String? get name;
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls;
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionMessageCopyWith<ChatCompletionMessage> get copyWith =>
+      _$ChatCompletionMessageCopyWithImpl<ChatCompletionMessage>(
+          this as ChatCompletionMessage, _$identity);
+
+  /// Serializes this ChatCompletionMessage to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.name, name) || other.name == name) &&
+            const DeepCollectionEquality().equals(other.toolCalls, toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, name,
+      const DeepCollectionEquality().hash(toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionMessage(role: $role, content: $content, name: $name, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionMessageCopyWith<$Res> {
+  factory $ChatCompletionMessageCopyWith(ChatCompletionMessage value,
+          $Res Function(ChatCompletionMessage) _then) =
+      _$ChatCompletionMessageCopyWithImpl;
+  @useResult
+  $Res call(
+      {ChatCompletionRole role,
+      String content,
+      String? name,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class _$ChatCompletionMessageCopyWithImpl<$Res>
+    implements $ChatCompletionMessageCopyWith<$Res> {
+  _$ChatCompletionMessageCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionMessage _self;
+  final $Res Function(ChatCompletionMessage) _then;
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? role = null,
+    Object? content = null,
+    Object? name = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_self.copyWith(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionRole,
+      content: null == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: freezed == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self.toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionMessage].
+extension ChatCompletionMessagePatterns on ChatCompletionMessage {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionMessage value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionMessage value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionMessage value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(ChatCompletionRole role, String content, String? name,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.name, _that.toolCalls);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(ChatCompletionRole role, String content, String? name,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage():
+        return $default(_that.role, _that.content, _that.name, _that.toolCalls);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(ChatCompletionRole role, String content, String? name,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.name, _that.toolCalls);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionMessage extends ChatCompletionMessage {
+  _ChatCompletionMessage(
+      {required this.role,
+      required this.content,
+      this.name,
+      @JsonKey(name: 'tool_calls') final List<Map<String, dynamic>>? toolCalls})
+      : _toolCalls = toolCalls,
+        super._();
+  factory _ChatCompletionMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionMessageFromJson(json);
+
+  @override
+  final ChatCompletionRole role;
+  @override
+  final String content;
+  @override
+  final String? name;
+  final List<Map<String, dynamic>>? _toolCalls;
+  @override
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls {
+    final value = _toolCalls;
+    if (value == null) return null;
+    if (_toolCalls is EqualUnmodifiableListView) return _toolCalls;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionMessageCopyWith<_ChatCompletionMessage> get copyWith =>
+      __$ChatCompletionMessageCopyWithImpl<_ChatCompletionMessage>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionMessageToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.name, name) || other.name == name) &&
+            const DeepCollectionEquality()
+                .equals(other._toolCalls, _toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, name,
+      const DeepCollectionEquality().hash(_toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionMessage(role: $role, content: $content, name: $name, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionMessageCopyWith<$Res>
+    implements $ChatCompletionMessageCopyWith<$Res> {
+  factory _$ChatCompletionMessageCopyWith(_ChatCompletionMessage value,
+          $Res Function(_ChatCompletionMessage) _then) =
+      __$ChatCompletionMessageCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {ChatCompletionRole role,
+      String content,
+      String? name,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class __$ChatCompletionMessageCopyWithImpl<$Res>
+    implements _$ChatCompletionMessageCopyWith<$Res> {
+  __$ChatCompletionMessageCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionMessage _self;
+  final $Res Function(_ChatCompletionMessage) _then;
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? role = null,
+    Object? content = null,
+    Object? name = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_ChatCompletionMessage(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionRole,
+      content: null == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: freezed == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self._toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.g.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.g.dart
@@ -1,0 +1,34 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_message.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionMessage _$ChatCompletionMessageFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionMessage(
+      role: $enumDecode(_$ChatCompletionRoleEnumMap, json['role']),
+      content: json['content'] as String,
+      name: json['name'] as String?,
+      toolCalls: (json['tool_calls'] as List<dynamic>?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+    );
+
+Map<String, dynamic> _$ChatCompletionMessageToJson(
+        _ChatCompletionMessage instance) =>
+    <String, dynamic>{
+      'role': _$ChatCompletionRoleEnumMap[instance.role]!,
+      'content': instance.content,
+      'name': instance.name,
+      'tool_calls': instance.toolCalls,
+    };
+
+const _$ChatCompletionRoleEnumMap = {
+  ChatCompletionRole.system: 'system',
+  ChatCompletionRole.user: 'user',
+  ChatCompletionRole.assistant: 'assistant',
+  ChatCompletionRole.tool: 'tool',
+};

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mistral_box/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart';
+
+part 'chat_completion_request.freezed.dart';
+part 'chat_completion_request.g.dart';
+
+/// https://docs.mistral.ai/api/
+@freezed
+abstract class ChatCompletionRequest with _$ChatCompletionRequest {
+  factory ChatCompletionRequest({
+    required List<ChatCompletionMessage> messages,
+    required String model,
+    @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+    @JsonKey(name: 'max_tokens') int? maxTokens,
+    @JsonKey(name: 'presence_penalty') double? presencePenalty,
+    @JsonKey(name: 'response_format') Map<String, dynamic>? responseFormat,
+    int? seed,
+    List<String>? stop,
+    bool? stream,
+    double? temperature,
+    @JsonKey(name: 'top_p') double? topP,
+    List<Map<String, dynamic>>? tools,
+    @JsonKey(name: 'tool_choice') dynamic toolChoice,
+    bool? logprobs,
+    @JsonKey(name: 'top_logprobs') int? topLogprobs,
+  }) = _ChatCompletionRequest;
+
+  factory ChatCompletionRequest.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionRequestFromJson(json);
+  const ChatCompletionRequest._();
+}

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.freezed.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.freezed.dart
@@ -1,0 +1,766 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_request.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionRequest {
+  List<ChatCompletionMessage> get messages;
+  String get model;
+  @JsonKey(name: 'frequency_penalty')
+  double? get frequencyPenalty;
+  @JsonKey(name: 'max_tokens')
+  int? get maxTokens;
+  @JsonKey(name: 'presence_penalty')
+  double? get presencePenalty;
+  @JsonKey(name: 'response_format')
+  Map<String, dynamic>? get responseFormat;
+  int? get seed;
+  List<String>? get stop;
+  bool? get stream;
+  double? get temperature;
+  @JsonKey(name: 'top_p')
+  double? get topP;
+  List<Map<String, dynamic>>? get tools;
+  @JsonKey(name: 'tool_choice')
+  dynamic get toolChoice;
+  bool? get logprobs;
+  @JsonKey(name: 'top_logprobs')
+  int? get topLogprobs;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionRequestCopyWith<ChatCompletionRequest> get copyWith =>
+      _$ChatCompletionRequestCopyWithImpl<ChatCompletionRequest>(
+          this as ChatCompletionRequest, _$identity);
+
+  /// Serializes this ChatCompletionRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionRequest &&
+            const DeepCollectionEquality().equals(other.messages, messages) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.frequencyPenalty, frequencyPenalty) ||
+                other.frequencyPenalty == frequencyPenalty) &&
+            (identical(other.maxTokens, maxTokens) ||
+                other.maxTokens == maxTokens) &&
+            (identical(other.presencePenalty, presencePenalty) ||
+                other.presencePenalty == presencePenalty) &&
+            const DeepCollectionEquality()
+                .equals(other.responseFormat, responseFormat) &&
+            (identical(other.seed, seed) || other.seed == seed) &&
+            const DeepCollectionEquality().equals(other.stop, stop) &&
+            (identical(other.stream, stream) || other.stream == stream) &&
+            (identical(other.temperature, temperature) ||
+                other.temperature == temperature) &&
+            (identical(other.topP, topP) || other.topP == topP) &&
+            const DeepCollectionEquality().equals(other.tools, tools) &&
+            const DeepCollectionEquality()
+                .equals(other.toolChoice, toolChoice) &&
+            (identical(other.logprobs, logprobs) ||
+                other.logprobs == logprobs) &&
+            (identical(other.topLogprobs, topLogprobs) ||
+                other.topLogprobs == topLogprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(messages),
+      model,
+      frequencyPenalty,
+      maxTokens,
+      presencePenalty,
+      const DeepCollectionEquality().hash(responseFormat),
+      seed,
+      const DeepCollectionEquality().hash(stop),
+      stream,
+      temperature,
+      topP,
+      const DeepCollectionEquality().hash(tools),
+      const DeepCollectionEquality().hash(toolChoice),
+      logprobs,
+      topLogprobs);
+
+  @override
+  String toString() {
+    return 'ChatCompletionRequest(messages: $messages, model: $model, frequencyPenalty: $frequencyPenalty, maxTokens: $maxTokens, presencePenalty: $presencePenalty, responseFormat: $responseFormat, seed: $seed, stop: $stop, stream: $stream, temperature: $temperature, topP: $topP, tools: $tools, toolChoice: $toolChoice, logprobs: $logprobs, topLogprobs: $topLogprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionRequestCopyWith<$Res> {
+  factory $ChatCompletionRequestCopyWith(ChatCompletionRequest value,
+          $Res Function(ChatCompletionRequest) _then) =
+      _$ChatCompletionRequestCopyWithImpl;
+  @useResult
+  $Res call(
+      {List<ChatCompletionMessage> messages,
+      String model,
+      @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+      @JsonKey(name: 'max_tokens') int? maxTokens,
+      @JsonKey(name: 'presence_penalty') double? presencePenalty,
+      @JsonKey(name: 'response_format') Map<String, dynamic>? responseFormat,
+      int? seed,
+      List<String>? stop,
+      bool? stream,
+      double? temperature,
+      @JsonKey(name: 'top_p') double? topP,
+      List<Map<String, dynamic>>? tools,
+      @JsonKey(name: 'tool_choice') dynamic toolChoice,
+      bool? logprobs,
+      @JsonKey(name: 'top_logprobs') int? topLogprobs});
+}
+
+/// @nodoc
+class _$ChatCompletionRequestCopyWithImpl<$Res>
+    implements $ChatCompletionRequestCopyWith<$Res> {
+  _$ChatCompletionRequestCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionRequest _self;
+  final $Res Function(ChatCompletionRequest) _then;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? messages = null,
+    Object? model = null,
+    Object? frequencyPenalty = freezed,
+    Object? maxTokens = freezed,
+    Object? presencePenalty = freezed,
+    Object? responseFormat = freezed,
+    Object? seed = freezed,
+    Object? stop = freezed,
+    Object? stream = freezed,
+    Object? temperature = freezed,
+    Object? topP = freezed,
+    Object? tools = freezed,
+    Object? toolChoice = freezed,
+    Object? logprobs = freezed,
+    Object? topLogprobs = freezed,
+  }) {
+    return _then(_self.copyWith(
+      messages: null == messages
+          ? _self.messages
+          : messages // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionMessage>,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      frequencyPenalty: freezed == frequencyPenalty
+          ? _self.frequencyPenalty
+          : frequencyPenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      maxTokens: freezed == maxTokens
+          ? _self.maxTokens
+          : maxTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      presencePenalty: freezed == presencePenalty
+          ? _self.presencePenalty
+          : presencePenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      responseFormat: freezed == responseFormat
+          ? _self.responseFormat
+          : responseFormat // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+      seed: freezed == seed
+          ? _self.seed
+          : seed // ignore: cast_nullable_to_non_nullable
+              as int?,
+      stop: freezed == stop
+          ? _self.stop
+          : stop // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      stream: freezed == stream
+          ? _self.stream
+          : stream // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      temperature: freezed == temperature
+          ? _self.temperature
+          : temperature // ignore: cast_nullable_to_non_nullable
+              as double?,
+      topP: freezed == topP
+          ? _self.topP
+          : topP // ignore: cast_nullable_to_non_nullable
+              as double?,
+      tools: freezed == tools
+          ? _self.tools
+          : tools // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+      toolChoice: freezed == toolChoice
+          ? _self.toolChoice
+          : toolChoice // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      logprobs: freezed == logprobs
+          ? _self.logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      topLogprobs: freezed == topLogprobs
+          ? _self.topLogprobs
+          : topLogprobs // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionRequest].
+extension ChatCompletionRequestPatterns on ChatCompletionRequest {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionRequest value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionRequest value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionRequest value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionMessage> messages,
+            String model,
+            @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+            @JsonKey(name: 'max_tokens') int? maxTokens,
+            @JsonKey(name: 'presence_penalty') double? presencePenalty,
+            @JsonKey(name: 'response_format')
+            Map<String, dynamic>? responseFormat,
+            int? seed,
+            List<String>? stop,
+            bool? stream,
+            double? temperature,
+            @JsonKey(name: 'top_p') double? topP,
+            List<Map<String, dynamic>>? tools,
+            @JsonKey(name: 'tool_choice') dynamic toolChoice,
+            bool? logprobs,
+            @JsonKey(name: 'top_logprobs') int? topLogprobs)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(
+            _that.messages,
+            _that.model,
+            _that.frequencyPenalty,
+            _that.maxTokens,
+            _that.presencePenalty,
+            _that.responseFormat,
+            _that.seed,
+            _that.stop,
+            _that.stream,
+            _that.temperature,
+            _that.topP,
+            _that.tools,
+            _that.toolChoice,
+            _that.logprobs,
+            _that.topLogprobs);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionMessage> messages,
+            String model,
+            @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+            @JsonKey(name: 'max_tokens') int? maxTokens,
+            @JsonKey(name: 'presence_penalty') double? presencePenalty,
+            @JsonKey(name: 'response_format')
+            Map<String, dynamic>? responseFormat,
+            int? seed,
+            List<String>? stop,
+            bool? stream,
+            double? temperature,
+            @JsonKey(name: 'top_p') double? topP,
+            List<Map<String, dynamic>>? tools,
+            @JsonKey(name: 'tool_choice') dynamic toolChoice,
+            bool? logprobs,
+            @JsonKey(name: 'top_logprobs') int? topLogprobs)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest():
+        return $default(
+            _that.messages,
+            _that.model,
+            _that.frequencyPenalty,
+            _that.maxTokens,
+            _that.presencePenalty,
+            _that.responseFormat,
+            _that.seed,
+            _that.stop,
+            _that.stream,
+            _that.temperature,
+            _that.topP,
+            _that.tools,
+            _that.toolChoice,
+            _that.logprobs,
+            _that.topLogprobs);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            List<ChatCompletionMessage> messages,
+            String model,
+            @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+            @JsonKey(name: 'max_tokens') int? maxTokens,
+            @JsonKey(name: 'presence_penalty') double? presencePenalty,
+            @JsonKey(name: 'response_format')
+            Map<String, dynamic>? responseFormat,
+            int? seed,
+            List<String>? stop,
+            bool? stream,
+            double? temperature,
+            @JsonKey(name: 'top_p') double? topP,
+            List<Map<String, dynamic>>? tools,
+            @JsonKey(name: 'tool_choice') dynamic toolChoice,
+            bool? logprobs,
+            @JsonKey(name: 'top_logprobs') int? topLogprobs)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(
+            _that.messages,
+            _that.model,
+            _that.frequencyPenalty,
+            _that.maxTokens,
+            _that.presencePenalty,
+            _that.responseFormat,
+            _that.seed,
+            _that.stop,
+            _that.stream,
+            _that.temperature,
+            _that.topP,
+            _that.tools,
+            _that.toolChoice,
+            _that.logprobs,
+            _that.topLogprobs);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionRequest extends ChatCompletionRequest {
+  _ChatCompletionRequest(
+      {required final List<ChatCompletionMessage> messages,
+      required this.model,
+      @JsonKey(name: 'frequency_penalty') this.frequencyPenalty,
+      @JsonKey(name: 'max_tokens') this.maxTokens,
+      @JsonKey(name: 'presence_penalty') this.presencePenalty,
+      @JsonKey(name: 'response_format')
+      final Map<String, dynamic>? responseFormat,
+      this.seed,
+      final List<String>? stop,
+      this.stream,
+      this.temperature,
+      @JsonKey(name: 'top_p') this.topP,
+      final List<Map<String, dynamic>>? tools,
+      @JsonKey(name: 'tool_choice') this.toolChoice,
+      this.logprobs,
+      @JsonKey(name: 'top_logprobs') this.topLogprobs})
+      : _messages = messages,
+        _responseFormat = responseFormat,
+        _stop = stop,
+        _tools = tools,
+        super._();
+  factory _ChatCompletionRequest.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionRequestFromJson(json);
+
+  final List<ChatCompletionMessage> _messages;
+  @override
+  List<ChatCompletionMessage> get messages {
+    if (_messages is EqualUnmodifiableListView) return _messages;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_messages);
+  }
+
+  @override
+  final String model;
+  @override
+  @JsonKey(name: 'frequency_penalty')
+  final double? frequencyPenalty;
+  @override
+  @JsonKey(name: 'max_tokens')
+  final int? maxTokens;
+  @override
+  @JsonKey(name: 'presence_penalty')
+  final double? presencePenalty;
+  final Map<String, dynamic>? _responseFormat;
+  @override
+  @JsonKey(name: 'response_format')
+  Map<String, dynamic>? get responseFormat {
+    final value = _responseFormat;
+    if (value == null) return null;
+    if (_responseFormat is EqualUnmodifiableMapView) return _responseFormat;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(value);
+  }
+
+  @override
+  final int? seed;
+  final List<String>? _stop;
+  @override
+  List<String>? get stop {
+    final value = _stop;
+    if (value == null) return null;
+    if (_stop is EqualUnmodifiableListView) return _stop;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  final bool? stream;
+  @override
+  final double? temperature;
+  @override
+  @JsonKey(name: 'top_p')
+  final double? topP;
+  final List<Map<String, dynamic>>? _tools;
+  @override
+  List<Map<String, dynamic>>? get tools {
+    final value = _tools;
+    if (value == null) return null;
+    if (_tools is EqualUnmodifiableListView) return _tools;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  @JsonKey(name: 'tool_choice')
+  final dynamic toolChoice;
+  @override
+  final bool? logprobs;
+  @override
+  @JsonKey(name: 'top_logprobs')
+  final int? topLogprobs;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionRequestCopyWith<_ChatCompletionRequest> get copyWith =>
+      __$ChatCompletionRequestCopyWithImpl<_ChatCompletionRequest>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionRequestToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionRequest &&
+            const DeepCollectionEquality().equals(other._messages, _messages) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.frequencyPenalty, frequencyPenalty) ||
+                other.frequencyPenalty == frequencyPenalty) &&
+            (identical(other.maxTokens, maxTokens) ||
+                other.maxTokens == maxTokens) &&
+            (identical(other.presencePenalty, presencePenalty) ||
+                other.presencePenalty == presencePenalty) &&
+            const DeepCollectionEquality()
+                .equals(other._responseFormat, _responseFormat) &&
+            (identical(other.seed, seed) || other.seed == seed) &&
+            const DeepCollectionEquality().equals(other._stop, _stop) &&
+            (identical(other.stream, stream) || other.stream == stream) &&
+            (identical(other.temperature, temperature) ||
+                other.temperature == temperature) &&
+            (identical(other.topP, topP) || other.topP == topP) &&
+            const DeepCollectionEquality().equals(other._tools, _tools) &&
+            const DeepCollectionEquality()
+                .equals(other.toolChoice, toolChoice) &&
+            (identical(other.logprobs, logprobs) ||
+                other.logprobs == logprobs) &&
+            (identical(other.topLogprobs, topLogprobs) ||
+                other.topLogprobs == topLogprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_messages),
+      model,
+      frequencyPenalty,
+      maxTokens,
+      presencePenalty,
+      const DeepCollectionEquality().hash(_responseFormat),
+      seed,
+      const DeepCollectionEquality().hash(_stop),
+      stream,
+      temperature,
+      topP,
+      const DeepCollectionEquality().hash(_tools),
+      const DeepCollectionEquality().hash(toolChoice),
+      logprobs,
+      topLogprobs);
+
+  @override
+  String toString() {
+    return 'ChatCompletionRequest(messages: $messages, model: $model, frequencyPenalty: $frequencyPenalty, maxTokens: $maxTokens, presencePenalty: $presencePenalty, responseFormat: $responseFormat, seed: $seed, stop: $stop, stream: $stream, temperature: $temperature, topP: $topP, tools: $tools, toolChoice: $toolChoice, logprobs: $logprobs, topLogprobs: $topLogprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionRequestCopyWith<$Res>
+    implements $ChatCompletionRequestCopyWith<$Res> {
+  factory _$ChatCompletionRequestCopyWith(_ChatCompletionRequest value,
+          $Res Function(_ChatCompletionRequest) _then) =
+      __$ChatCompletionRequestCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {List<ChatCompletionMessage> messages,
+      String model,
+      @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+      @JsonKey(name: 'max_tokens') int? maxTokens,
+      @JsonKey(name: 'presence_penalty') double? presencePenalty,
+      @JsonKey(name: 'response_format') Map<String, dynamic>? responseFormat,
+      int? seed,
+      List<String>? stop,
+      bool? stream,
+      double? temperature,
+      @JsonKey(name: 'top_p') double? topP,
+      List<Map<String, dynamic>>? tools,
+      @JsonKey(name: 'tool_choice') dynamic toolChoice,
+      bool? logprobs,
+      @JsonKey(name: 'top_logprobs') int? topLogprobs});
+}
+
+/// @nodoc
+class __$ChatCompletionRequestCopyWithImpl<$Res>
+    implements _$ChatCompletionRequestCopyWith<$Res> {
+  __$ChatCompletionRequestCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionRequest _self;
+  final $Res Function(_ChatCompletionRequest) _then;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? messages = null,
+    Object? model = null,
+    Object? frequencyPenalty = freezed,
+    Object? maxTokens = freezed,
+    Object? presencePenalty = freezed,
+    Object? responseFormat = freezed,
+    Object? seed = freezed,
+    Object? stop = freezed,
+    Object? stream = freezed,
+    Object? temperature = freezed,
+    Object? topP = freezed,
+    Object? tools = freezed,
+    Object? toolChoice = freezed,
+    Object? logprobs = freezed,
+    Object? topLogprobs = freezed,
+  }) {
+    return _then(_ChatCompletionRequest(
+      messages: null == messages
+          ? _self._messages
+          : messages // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionMessage>,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      frequencyPenalty: freezed == frequencyPenalty
+          ? _self.frequencyPenalty
+          : frequencyPenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      maxTokens: freezed == maxTokens
+          ? _self.maxTokens
+          : maxTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      presencePenalty: freezed == presencePenalty
+          ? _self.presencePenalty
+          : presencePenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      responseFormat: freezed == responseFormat
+          ? _self._responseFormat
+          : responseFormat // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+      seed: freezed == seed
+          ? _self.seed
+          : seed // ignore: cast_nullable_to_non_nullable
+              as int?,
+      stop: freezed == stop
+          ? _self._stop
+          : stop // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      stream: freezed == stream
+          ? _self.stream
+          : stream // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      temperature: freezed == temperature
+          ? _self.temperature
+          : temperature // ignore: cast_nullable_to_non_nullable
+              as double?,
+      topP: freezed == topP
+          ? _self.topP
+          : topP // ignore: cast_nullable_to_non_nullable
+              as double?,
+      tools: freezed == tools
+          ? _self._tools
+          : tools // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+      toolChoice: freezed == toolChoice
+          ? _self.toolChoice
+          : toolChoice // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      logprobs: freezed == logprobs
+          ? _self.logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      topLogprobs: freezed == topLogprobs
+          ? _self.topLogprobs
+          : topLogprobs // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.g.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.g.dart
@@ -1,0 +1,51 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionRequest _$ChatCompletionRequestFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionRequest(
+      messages: (json['messages'] as List<dynamic>)
+          .map((e) => ChatCompletionMessage.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      model: json['model'] as String,
+      frequencyPenalty: (json['frequency_penalty'] as num?)?.toDouble(),
+      maxTokens: (json['max_tokens'] as num?)?.toInt(),
+      presencePenalty: (json['presence_penalty'] as num?)?.toDouble(),
+      responseFormat: json['response_format'] as Map<String, dynamic>?,
+      seed: (json['seed'] as num?)?.toInt(),
+      stop: (json['stop'] as List<dynamic>?)?.map((e) => e as String).toList(),
+      stream: json['stream'] as bool?,
+      temperature: (json['temperature'] as num?)?.toDouble(),
+      topP: (json['top_p'] as num?)?.toDouble(),
+      tools: (json['tools'] as List<dynamic>?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+      toolChoice: json['tool_choice'],
+      logprobs: json['logprobs'] as bool?,
+      topLogprobs: (json['top_logprobs'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$ChatCompletionRequestToJson(
+        _ChatCompletionRequest instance) =>
+    <String, dynamic>{
+      'messages': instance.messages,
+      'model': instance.model,
+      'frequency_penalty': instance.frequencyPenalty,
+      'max_tokens': instance.maxTokens,
+      'presence_penalty': instance.presencePenalty,
+      'response_format': instance.responseFormat,
+      'seed': instance.seed,
+      'stop': instance.stop,
+      'stream': instance.stream,
+      'temperature': instance.temperature,
+      'top_p': instance.topP,
+      'tools': instance.tools,
+      'tool_choice': instance.toolChoice,
+      'logprobs': instance.logprobs,
+      'top_logprobs': instance.topLogprobs,
+    };

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mistral_box/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart';
+import 'package:mistral_box/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart';
+
+part 'chat_completion_response.freezed.dart';
+part 'chat_completion_response.g.dart';
+
+/// https://docs.mistral.ai/api/
+@freezed
+abstract class ChatCompletionResponse with _$ChatCompletionResponse {
+  factory ChatCompletionResponse({
+    required List<ChatCompletionResponseChoice> choices,
+    required int created,
+    required String id,
+    required String model,
+    required String object,
+    @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+    ChatCompletionResponseUsage? usage,
+  }) = _ChatCompletionResponse;
+
+  factory ChatCompletionResponse.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseFromJson(json);
+  const ChatCompletionResponse._();
+}

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.freezed.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.freezed.dart
@@ -1,0 +1,516 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponse {
+  List<ChatCompletionResponseChoice> get choices;
+  int get created;
+  String get id;
+  String get model;
+  String get object;
+  @JsonKey(name: 'system_fingerprint')
+  String? get systemFingerprint;
+  ChatCompletionResponseUsage? get usage;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseCopyWith<ChatCompletionResponse> get copyWith =>
+      _$ChatCompletionResponseCopyWithImpl<ChatCompletionResponse>(
+          this as ChatCompletionResponse, _$identity);
+
+  /// Serializes this ChatCompletionResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponse &&
+            const DeepCollectionEquality().equals(other.choices, choices) &&
+            (identical(other.created, created) || other.created == created) &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.systemFingerprint, systemFingerprint) ||
+                other.systemFingerprint == systemFingerprint) &&
+            (identical(other.usage, usage) || other.usage == usage));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(choices),
+      created,
+      id,
+      model,
+      object,
+      systemFingerprint,
+      usage);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponse(choices: $choices, created: $created, id: $id, model: $model, object: $object, systemFingerprint: $systemFingerprint, usage: $usage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseCopyWith<$Res> {
+  factory $ChatCompletionResponseCopyWith(ChatCompletionResponse value,
+          $Res Function(ChatCompletionResponse) _then) =
+      _$ChatCompletionResponseCopyWithImpl;
+  @useResult
+  $Res call(
+      {List<ChatCompletionResponseChoice> choices,
+      int created,
+      String id,
+      String model,
+      String object,
+      @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+      ChatCompletionResponseUsage? usage});
+
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage;
+}
+
+/// @nodoc
+class _$ChatCompletionResponseCopyWithImpl<$Res>
+    implements $ChatCompletionResponseCopyWith<$Res> {
+  _$ChatCompletionResponseCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponse _self;
+  final $Res Function(ChatCompletionResponse) _then;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? choices = null,
+    Object? created = null,
+    Object? id = null,
+    Object? model = null,
+    Object? object = null,
+    Object? systemFingerprint = freezed,
+    Object? usage = freezed,
+  }) {
+    return _then(_self.copyWith(
+      choices: null == choices
+          ? _self.choices
+          : choices // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionResponseChoice>,
+      created: null == created
+          ? _self.created
+          : created // ignore: cast_nullable_to_non_nullable
+              as int,
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      systemFingerprint: freezed == systemFingerprint
+          ? _self.systemFingerprint
+          : systemFingerprint // ignore: cast_nullable_to_non_nullable
+              as String?,
+      usage: freezed == usage
+          ? _self.usage
+          : usage // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsage?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage {
+    if (_self.usage == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCopyWith<$Res>(_self.usage!, (value) {
+      return _then(_self.copyWith(usage: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponse].
+extension ChatCompletionResponsePatterns on ChatCompletionResponse {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponse value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponse value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponse value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionResponseChoice> choices,
+            int created,
+            String id,
+            String model,
+            String object,
+            @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+            ChatCompletionResponseUsage? usage)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that.choices, _that.created, _that.id, _that.model,
+            _that.object, _that.systemFingerprint, _that.usage);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionResponseChoice> choices,
+            int created,
+            String id,
+            String model,
+            String object,
+            @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+            ChatCompletionResponseUsage? usage)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse():
+        return $default(_that.choices, _that.created, _that.id, _that.model,
+            _that.object, _that.systemFingerprint, _that.usage);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            List<ChatCompletionResponseChoice> choices,
+            int created,
+            String id,
+            String model,
+            String object,
+            @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+            ChatCompletionResponseUsage? usage)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that.choices, _that.created, _that.id, _that.model,
+            _that.object, _that.systemFingerprint, _that.usage);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponse extends ChatCompletionResponse {
+  _ChatCompletionResponse(
+      {required final List<ChatCompletionResponseChoice> choices,
+      required this.created,
+      required this.id,
+      required this.model,
+      required this.object,
+      @JsonKey(name: 'system_fingerprint') this.systemFingerprint,
+      this.usage})
+      : _choices = choices,
+        super._();
+  factory _ChatCompletionResponse.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseFromJson(json);
+
+  final List<ChatCompletionResponseChoice> _choices;
+  @override
+  List<ChatCompletionResponseChoice> get choices {
+    if (_choices is EqualUnmodifiableListView) return _choices;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_choices);
+  }
+
+  @override
+  final int created;
+  @override
+  final String id;
+  @override
+  final String model;
+  @override
+  final String object;
+  @override
+  @JsonKey(name: 'system_fingerprint')
+  final String? systemFingerprint;
+  @override
+  final ChatCompletionResponseUsage? usage;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseCopyWith<_ChatCompletionResponse> get copyWith =>
+      __$ChatCompletionResponseCopyWithImpl<_ChatCompletionResponse>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponse &&
+            const DeepCollectionEquality().equals(other._choices, _choices) &&
+            (identical(other.created, created) || other.created == created) &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.systemFingerprint, systemFingerprint) ||
+                other.systemFingerprint == systemFingerprint) &&
+            (identical(other.usage, usage) || other.usage == usage));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_choices),
+      created,
+      id,
+      model,
+      object,
+      systemFingerprint,
+      usage);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponse(choices: $choices, created: $created, id: $id, model: $model, object: $object, systemFingerprint: $systemFingerprint, usage: $usage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseCopyWith<$Res>
+    implements $ChatCompletionResponseCopyWith<$Res> {
+  factory _$ChatCompletionResponseCopyWith(_ChatCompletionResponse value,
+          $Res Function(_ChatCompletionResponse) _then) =
+      __$ChatCompletionResponseCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {List<ChatCompletionResponseChoice> choices,
+      int created,
+      String id,
+      String model,
+      String object,
+      @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+      ChatCompletionResponseUsage? usage});
+
+  @override
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage;
+}
+
+/// @nodoc
+class __$ChatCompletionResponseCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseCopyWith<$Res> {
+  __$ChatCompletionResponseCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponse _self;
+  final $Res Function(_ChatCompletionResponse) _then;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? choices = null,
+    Object? created = null,
+    Object? id = null,
+    Object? model = null,
+    Object? object = null,
+    Object? systemFingerprint = freezed,
+    Object? usage = freezed,
+  }) {
+    return _then(_ChatCompletionResponse(
+      choices: null == choices
+          ? _self._choices
+          : choices // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionResponseChoice>,
+      created: null == created
+          ? _self.created
+          : created // ignore: cast_nullable_to_non_nullable
+              as int,
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      systemFingerprint: freezed == systemFingerprint
+          ? _self.systemFingerprint
+          : systemFingerprint // ignore: cast_nullable_to_non_nullable
+              as String?,
+      usage: freezed == usage
+          ? _self.usage
+          : usage // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsage?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage {
+    if (_self.usage == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCopyWith<$Res>(_self.usage!, (value) {
+      return _then(_self.copyWith(usage: value));
+    });
+  }
+}
+
+// dart format on

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.g.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponse _$ChatCompletionResponseFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponse(
+      choices: (json['choices'] as List<dynamic>)
+          .map((e) =>
+              ChatCompletionResponseChoice.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      created: (json['created'] as num).toInt(),
+      id: json['id'] as String,
+      model: json['model'] as String,
+      object: json['object'] as String,
+      systemFingerprint: json['system_fingerprint'] as String?,
+      usage: json['usage'] == null
+          ? null
+          : ChatCompletionResponseUsage.fromJson(
+              json['usage'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseToJson(
+        _ChatCompletionResponse instance) =>
+    <String, dynamic>{
+      'choices': instance.choices,
+      'created': instance.created,
+      'id': instance.id,
+      'model': instance.model,
+      'object': instance.object,
+      'system_fingerprint': instance.systemFingerprint,
+      'usage': instance.usage,
+    };

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mistral_box/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart';
+
+part 'chat_completion_response_choice.freezed.dart';
+part 'chat_completion_response_choice.g.dart';
+
+@freezed
+abstract class ChatCompletionResponseChoice
+    with _$ChatCompletionResponseChoice {
+  factory ChatCompletionResponseChoice({
+    required int index,
+    required ChatCompletionResponseMessage message,
+    @JsonKey(name: 'finish_reason') String? finishReason,
+    Map<String, dynamic>? logprobs,
+  }) = _ChatCompletionResponseChoice;
+
+  factory ChatCompletionResponseChoice.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseChoiceFromJson(json);
+  const ChatCompletionResponseChoice._();
+}

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.freezed.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.freezed.dart
@@ -1,0 +1,435 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response_choice.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponseChoice {
+  int get index;
+  ChatCompletionResponseMessage get message;
+  @JsonKey(name: 'finish_reason')
+  String? get finishReason;
+  Map<String, dynamic>? get logprobs;
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseChoiceCopyWith<ChatCompletionResponseChoice>
+      get copyWith => _$ChatCompletionResponseChoiceCopyWithImpl<
+              ChatCompletionResponseChoice>(
+          this as ChatCompletionResponseChoice, _$identity);
+
+  /// Serializes this ChatCompletionResponseChoice to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseChoice &&
+            (identical(other.index, index) || other.index == index) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.finishReason, finishReason) ||
+                other.finishReason == finishReason) &&
+            const DeepCollectionEquality().equals(other.logprobs, logprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, index, message, finishReason,
+      const DeepCollectionEquality().hash(logprobs));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseChoice(index: $index, message: $message, finishReason: $finishReason, logprobs: $logprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseChoiceCopyWith<$Res> {
+  factory $ChatCompletionResponseChoiceCopyWith(
+          ChatCompletionResponseChoice value,
+          $Res Function(ChatCompletionResponseChoice) _then) =
+      _$ChatCompletionResponseChoiceCopyWithImpl;
+  @useResult
+  $Res call(
+      {int index,
+      ChatCompletionResponseMessage message,
+      @JsonKey(name: 'finish_reason') String? finishReason,
+      Map<String, dynamic>? logprobs});
+
+  $ChatCompletionResponseMessageCopyWith<$Res> get message;
+}
+
+/// @nodoc
+class _$ChatCompletionResponseChoiceCopyWithImpl<$Res>
+    implements $ChatCompletionResponseChoiceCopyWith<$Res> {
+  _$ChatCompletionResponseChoiceCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponseChoice _self;
+  final $Res Function(ChatCompletionResponseChoice) _then;
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? index = null,
+    Object? message = null,
+    Object? finishReason = freezed,
+    Object? logprobs = freezed,
+  }) {
+    return _then(_self.copyWith(
+      index: null == index
+          ? _self.index
+          : index // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseMessage,
+      finishReason: freezed == finishReason
+          ? _self.finishReason
+          : finishReason // ignore: cast_nullable_to_non_nullable
+              as String?,
+      logprobs: freezed == logprobs
+          ? _self.logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseMessageCopyWith<$Res> get message {
+    return $ChatCompletionResponseMessageCopyWith<$Res>(_self.message, (value) {
+      return _then(_self.copyWith(message: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseChoice].
+extension ChatCompletionResponseChoicePatterns on ChatCompletionResponseChoice {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseChoice value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseChoice value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponseChoice value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            int index,
+            ChatCompletionResponseMessage message,
+            @JsonKey(name: 'finish_reason') String? finishReason,
+            Map<String, dynamic>? logprobs)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(
+            _that.index, _that.message, _that.finishReason, _that.logprobs);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            int index,
+            ChatCompletionResponseMessage message,
+            @JsonKey(name: 'finish_reason') String? finishReason,
+            Map<String, dynamic>? logprobs)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice():
+        return $default(
+            _that.index, _that.message, _that.finishReason, _that.logprobs);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            int index,
+            ChatCompletionResponseMessage message,
+            @JsonKey(name: 'finish_reason') String? finishReason,
+            Map<String, dynamic>? logprobs)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(
+            _that.index, _that.message, _that.finishReason, _that.logprobs);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseChoice extends ChatCompletionResponseChoice {
+  _ChatCompletionResponseChoice(
+      {required this.index,
+      required this.message,
+      @JsonKey(name: 'finish_reason') this.finishReason,
+      final Map<String, dynamic>? logprobs})
+      : _logprobs = logprobs,
+        super._();
+  factory _ChatCompletionResponseChoice.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseChoiceFromJson(json);
+
+  @override
+  final int index;
+  @override
+  final ChatCompletionResponseMessage message;
+  @override
+  @JsonKey(name: 'finish_reason')
+  final String? finishReason;
+  final Map<String, dynamic>? _logprobs;
+  @override
+  Map<String, dynamic>? get logprobs {
+    final value = _logprobs;
+    if (value == null) return null;
+    if (_logprobs is EqualUnmodifiableMapView) return _logprobs;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(value);
+  }
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseChoiceCopyWith<_ChatCompletionResponseChoice>
+      get copyWith => __$ChatCompletionResponseChoiceCopyWithImpl<
+          _ChatCompletionResponseChoice>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseChoiceToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseChoice &&
+            (identical(other.index, index) || other.index == index) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.finishReason, finishReason) ||
+                other.finishReason == finishReason) &&
+            const DeepCollectionEquality().equals(other._logprobs, _logprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, index, message, finishReason,
+      const DeepCollectionEquality().hash(_logprobs));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseChoice(index: $index, message: $message, finishReason: $finishReason, logprobs: $logprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseChoiceCopyWith<$Res>
+    implements $ChatCompletionResponseChoiceCopyWith<$Res> {
+  factory _$ChatCompletionResponseChoiceCopyWith(
+          _ChatCompletionResponseChoice value,
+          $Res Function(_ChatCompletionResponseChoice) _then) =
+      __$ChatCompletionResponseChoiceCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {int index,
+      ChatCompletionResponseMessage message,
+      @JsonKey(name: 'finish_reason') String? finishReason,
+      Map<String, dynamic>? logprobs});
+
+  @override
+  $ChatCompletionResponseMessageCopyWith<$Res> get message;
+}
+
+/// @nodoc
+class __$ChatCompletionResponseChoiceCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseChoiceCopyWith<$Res> {
+  __$ChatCompletionResponseChoiceCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponseChoice _self;
+  final $Res Function(_ChatCompletionResponseChoice) _then;
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? index = null,
+    Object? message = null,
+    Object? finishReason = freezed,
+    Object? logprobs = freezed,
+  }) {
+    return _then(_ChatCompletionResponseChoice(
+      index: null == index
+          ? _self.index
+          : index // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseMessage,
+      finishReason: freezed == finishReason
+          ? _self.finishReason
+          : finishReason // ignore: cast_nullable_to_non_nullable
+              as String?,
+      logprobs: freezed == logprobs
+          ? _self._logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseMessageCopyWith<$Res> get message {
+    return $ChatCompletionResponseMessageCopyWith<$Res>(_self.message, (value) {
+      return _then(_self.copyWith(message: value));
+    });
+  }
+}
+
+// dart format on

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.g.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response_choice.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponseChoice _$ChatCompletionResponseChoiceFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponseChoice(
+      index: (json['index'] as num).toInt(),
+      message: ChatCompletionResponseMessage.fromJson(
+          json['message'] as Map<String, dynamic>),
+      finishReason: json['finish_reason'] as String?,
+      logprobs: json['logprobs'] as Map<String, dynamic>?,
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseChoiceToJson(
+        _ChatCompletionResponseChoice instance) =>
+    <String, dynamic>{
+      'index': instance.index,
+      'message': instance.message,
+      'finish_reason': instance.finishReason,
+      'logprobs': instance.logprobs,
+    };

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'chat_completion_response_message.freezed.dart';
+part 'chat_completion_response_message.g.dart';
+
+@freezed
+abstract class ChatCompletionResponseMessage
+    with _$ChatCompletionResponseMessage {
+  factory ChatCompletionResponseMessage({
+    required String role,
+    String? content,
+    @JsonKey(name: 'reasoning_content') String? reasoningContent,
+    String? refusal,
+    @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls,
+  }) = _ChatCompletionResponseMessage;
+
+  factory ChatCompletionResponseMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseMessageFromJson(json);
+  const ChatCompletionResponseMessage._();
+}

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.freezed.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.freezed.dart
@@ -1,0 +1,435 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response_message.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponseMessage {
+  String get role;
+  String? get content;
+  @JsonKey(name: 'reasoning_content')
+  String? get reasoningContent;
+  String? get refusal;
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls;
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseMessageCopyWith<ChatCompletionResponseMessage>
+      get copyWith => _$ChatCompletionResponseMessageCopyWithImpl<
+              ChatCompletionResponseMessage>(
+          this as ChatCompletionResponseMessage, _$identity);
+
+  /// Serializes this ChatCompletionResponseMessage to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.reasoningContent, reasoningContent) ||
+                other.reasoningContent == reasoningContent) &&
+            (identical(other.refusal, refusal) || other.refusal == refusal) &&
+            const DeepCollectionEquality().equals(other.toolCalls, toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, reasoningContent,
+      refusal, const DeepCollectionEquality().hash(toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseMessage(role: $role, content: $content, reasoningContent: $reasoningContent, refusal: $refusal, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseMessageCopyWith<$Res> {
+  factory $ChatCompletionResponseMessageCopyWith(
+          ChatCompletionResponseMessage value,
+          $Res Function(ChatCompletionResponseMessage) _then) =
+      _$ChatCompletionResponseMessageCopyWithImpl;
+  @useResult
+  $Res call(
+      {String role,
+      String? content,
+      @JsonKey(name: 'reasoning_content') String? reasoningContent,
+      String? refusal,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class _$ChatCompletionResponseMessageCopyWithImpl<$Res>
+    implements $ChatCompletionResponseMessageCopyWith<$Res> {
+  _$ChatCompletionResponseMessageCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponseMessage _self;
+  final $Res Function(ChatCompletionResponseMessage) _then;
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? role = null,
+    Object? content = freezed,
+    Object? reasoningContent = freezed,
+    Object? refusal = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_self.copyWith(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: freezed == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String?,
+      reasoningContent: freezed == reasoningContent
+          ? _self.reasoningContent
+          : reasoningContent // ignore: cast_nullable_to_non_nullable
+              as String?,
+      refusal: freezed == refusal
+          ? _self.refusal
+          : refusal // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self.toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseMessage].
+extension ChatCompletionResponseMessagePatterns
+    on ChatCompletionResponseMessage {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseMessage value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseMessage value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponseMessage value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String role,
+            String? content,
+            @JsonKey(name: 'reasoning_content') String? reasoningContent,
+            String? refusal,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.reasoningContent,
+            _that.refusal, _that.toolCalls);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String role,
+            String? content,
+            @JsonKey(name: 'reasoning_content') String? reasoningContent,
+            String? refusal,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage():
+        return $default(_that.role, _that.content, _that.reasoningContent,
+            _that.refusal, _that.toolCalls);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String role,
+            String? content,
+            @JsonKey(name: 'reasoning_content') String? reasoningContent,
+            String? refusal,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.reasoningContent,
+            _that.refusal, _that.toolCalls);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseMessage extends ChatCompletionResponseMessage {
+  _ChatCompletionResponseMessage(
+      {required this.role,
+      this.content,
+      @JsonKey(name: 'reasoning_content') this.reasoningContent,
+      this.refusal,
+      @JsonKey(name: 'tool_calls') final List<Map<String, dynamic>>? toolCalls})
+      : _toolCalls = toolCalls,
+        super._();
+  factory _ChatCompletionResponseMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseMessageFromJson(json);
+
+  @override
+  final String role;
+  @override
+  final String? content;
+  @override
+  @JsonKey(name: 'reasoning_content')
+  final String? reasoningContent;
+  @override
+  final String? refusal;
+  final List<Map<String, dynamic>>? _toolCalls;
+  @override
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls {
+    final value = _toolCalls;
+    if (value == null) return null;
+    if (_toolCalls is EqualUnmodifiableListView) return _toolCalls;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseMessageCopyWith<_ChatCompletionResponseMessage>
+      get copyWith => __$ChatCompletionResponseMessageCopyWithImpl<
+          _ChatCompletionResponseMessage>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseMessageToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.reasoningContent, reasoningContent) ||
+                other.reasoningContent == reasoningContent) &&
+            (identical(other.refusal, refusal) || other.refusal == refusal) &&
+            const DeepCollectionEquality()
+                .equals(other._toolCalls, _toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, reasoningContent,
+      refusal, const DeepCollectionEquality().hash(_toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseMessage(role: $role, content: $content, reasoningContent: $reasoningContent, refusal: $refusal, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseMessageCopyWith<$Res>
+    implements $ChatCompletionResponseMessageCopyWith<$Res> {
+  factory _$ChatCompletionResponseMessageCopyWith(
+          _ChatCompletionResponseMessage value,
+          $Res Function(_ChatCompletionResponseMessage) _then) =
+      __$ChatCompletionResponseMessageCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String role,
+      String? content,
+      @JsonKey(name: 'reasoning_content') String? reasoningContent,
+      String? refusal,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class __$ChatCompletionResponseMessageCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseMessageCopyWith<$Res> {
+  __$ChatCompletionResponseMessageCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponseMessage _self;
+  final $Res Function(_ChatCompletionResponseMessage) _then;
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? role = null,
+    Object? content = freezed,
+    Object? reasoningContent = freezed,
+    Object? refusal = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_ChatCompletionResponseMessage(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: freezed == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String?,
+      reasoningContent: freezed == reasoningContent
+          ? _self.reasoningContent
+          : reasoningContent // ignore: cast_nullable_to_non_nullable
+              as String?,
+      refusal: freezed == refusal
+          ? _self.refusal
+          : refusal // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self._toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.g.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response_message.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponseMessage _$ChatCompletionResponseMessageFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponseMessage(
+      role: json['role'] as String,
+      content: json['content'] as String?,
+      reasoningContent: json['reasoning_content'] as String?,
+      refusal: json['refusal'] as String?,
+      toolCalls: (json['tool_calls'] as List<dynamic>?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseMessageToJson(
+        _ChatCompletionResponseMessage instance) =>
+    <String, dynamic>{
+      'role': instance.role,
+      'content': instance.content,
+      'reasoning_content': instance.reasoningContent,
+      'refusal': instance.refusal,
+      'tool_calls': instance.toolCalls,
+    };

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart
@@ -1,0 +1,35 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'chat_completion_response_usage.freezed.dart';
+part 'chat_completion_response_usage.g.dart';
+
+@freezed
+abstract class ChatCompletionResponseUsage with _$ChatCompletionResponseUsage {
+  factory ChatCompletionResponseUsage({
+    @JsonKey(name: 'completion_tokens') required int completionTokens,
+    @JsonKey(name: 'prompt_tokens') required int promptTokens,
+    @JsonKey(name: 'total_tokens') required int totalTokens,
+    @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+    @JsonKey(name: 'prompt_cache_miss_tokens') int? promptCacheMissTokens,
+    @JsonKey(name: 'completion_tokens_details')
+    ChatCompletionResponseUsageCompletionTokensDetails? completionTokensDetails,
+  }) = _ChatCompletionResponseUsage;
+
+  factory ChatCompletionResponseUsage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseUsageFromJson(json);
+  const ChatCompletionResponseUsage._();
+}
+
+@freezed
+abstract class ChatCompletionResponseUsageCompletionTokensDetails
+    with _$ChatCompletionResponseUsageCompletionTokensDetails {
+  factory ChatCompletionResponseUsageCompletionTokensDetails({
+    @JsonKey(name: 'reasoning_tokens') required int reasoningTokens,
+  }) = _ChatCompletionResponseUsageCompletionTokensDetails;
+
+  factory ChatCompletionResponseUsageCompletionTokensDetails.fromJson(
+    Map<String, dynamic> json,
+  ) =>
+      _$ChatCompletionResponseUsageCompletionTokensDetailsFromJson(json);
+  const ChatCompletionResponseUsageCompletionTokensDetails._();
+}

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.freezed.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.freezed.dart
@@ -1,0 +1,888 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response_usage.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponseUsage {
+  @JsonKey(name: 'completion_tokens')
+  int get completionTokens;
+  @JsonKey(name: 'prompt_tokens')
+  int get promptTokens;
+  @JsonKey(name: 'total_tokens')
+  int get totalTokens;
+  @JsonKey(name: 'prompt_cache_hit_tokens')
+  int? get promptCacheHitTokens;
+  @JsonKey(name: 'prompt_cache_miss_tokens')
+  int? get promptCacheMissTokens;
+  @JsonKey(name: 'completion_tokens_details')
+  ChatCompletionResponseUsageCompletionTokensDetails?
+      get completionTokensDetails;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCopyWith<ChatCompletionResponseUsage>
+      get copyWith => _$ChatCompletionResponseUsageCopyWithImpl<
+              ChatCompletionResponseUsage>(
+          this as ChatCompletionResponseUsage, _$identity);
+
+  /// Serializes this ChatCompletionResponseUsage to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseUsage &&
+            (identical(other.completionTokens, completionTokens) ||
+                other.completionTokens == completionTokens) &&
+            (identical(other.promptTokens, promptTokens) ||
+                other.promptTokens == promptTokens) &&
+            (identical(other.totalTokens, totalTokens) ||
+                other.totalTokens == totalTokens) &&
+            (identical(other.promptCacheHitTokens, promptCacheHitTokens) ||
+                other.promptCacheHitTokens == promptCacheHitTokens) &&
+            (identical(other.promptCacheMissTokens, promptCacheMissTokens) ||
+                other.promptCacheMissTokens == promptCacheMissTokens) &&
+            (identical(
+                    other.completionTokensDetails, completionTokensDetails) ||
+                other.completionTokensDetails == completionTokensDetails));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      completionTokens,
+      promptTokens,
+      totalTokens,
+      promptCacheHitTokens,
+      promptCacheMissTokens,
+      completionTokensDetails);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsage(completionTokens: $completionTokens, promptTokens: $promptTokens, totalTokens: $totalTokens, promptCacheHitTokens: $promptCacheHitTokens, promptCacheMissTokens: $promptCacheMissTokens, completionTokensDetails: $completionTokensDetails)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseUsageCopyWith<$Res> {
+  factory $ChatCompletionResponseUsageCopyWith(
+          ChatCompletionResponseUsage value,
+          $Res Function(ChatCompletionResponseUsage) _then) =
+      _$ChatCompletionResponseUsageCopyWithImpl;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'completion_tokens') int completionTokens,
+      @JsonKey(name: 'prompt_tokens') int promptTokens,
+      @JsonKey(name: 'total_tokens') int totalTokens,
+      @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+      @JsonKey(name: 'prompt_cache_miss_tokens') int? promptCacheMissTokens,
+      @JsonKey(name: 'completion_tokens_details')
+      ChatCompletionResponseUsageCompletionTokensDetails?
+          completionTokensDetails});
+
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails;
+}
+
+/// @nodoc
+class _$ChatCompletionResponseUsageCopyWithImpl<$Res>
+    implements $ChatCompletionResponseUsageCopyWith<$Res> {
+  _$ChatCompletionResponseUsageCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponseUsage _self;
+  final $Res Function(ChatCompletionResponseUsage) _then;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? completionTokens = null,
+    Object? promptTokens = null,
+    Object? totalTokens = null,
+    Object? promptCacheHitTokens = freezed,
+    Object? promptCacheMissTokens = freezed,
+    Object? completionTokensDetails = freezed,
+  }) {
+    return _then(_self.copyWith(
+      completionTokens: null == completionTokens
+          ? _self.completionTokens
+          : completionTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptTokens: null == promptTokens
+          ? _self.promptTokens
+          : promptTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalTokens: null == totalTokens
+          ? _self.totalTokens
+          : totalTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptCacheHitTokens: freezed == promptCacheHitTokens
+          ? _self.promptCacheHitTokens
+          : promptCacheHitTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      promptCacheMissTokens: freezed == promptCacheMissTokens
+          ? _self.promptCacheMissTokens
+          : promptCacheMissTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      completionTokensDetails: freezed == completionTokensDetails
+          ? _self.completionTokensDetails
+          : completionTokensDetails // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsageCompletionTokensDetails?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails {
+    if (_self.completionTokensDetails == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>(
+        _self.completionTokensDetails!, (value) {
+      return _then(_self.copyWith(completionTokensDetails: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseUsage].
+extension ChatCompletionResponseUsagePatterns on ChatCompletionResponseUsage {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsage value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsage value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponseUsage value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: 'completion_tokens') int completionTokens,
+            @JsonKey(name: 'prompt_tokens') int promptTokens,
+            @JsonKey(name: 'total_tokens') int totalTokens,
+            @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+            @JsonKey(name: 'prompt_cache_miss_tokens')
+            int? promptCacheMissTokens,
+            @JsonKey(name: 'completion_tokens_details')
+            ChatCompletionResponseUsageCompletionTokensDetails?
+                completionTokensDetails)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(
+            _that.completionTokens,
+            _that.promptTokens,
+            _that.totalTokens,
+            _that.promptCacheHitTokens,
+            _that.promptCacheMissTokens,
+            _that.completionTokensDetails);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: 'completion_tokens') int completionTokens,
+            @JsonKey(name: 'prompt_tokens') int promptTokens,
+            @JsonKey(name: 'total_tokens') int totalTokens,
+            @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+            @JsonKey(name: 'prompt_cache_miss_tokens')
+            int? promptCacheMissTokens,
+            @JsonKey(name: 'completion_tokens_details')
+            ChatCompletionResponseUsageCompletionTokensDetails?
+                completionTokensDetails)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage():
+        return $default(
+            _that.completionTokens,
+            _that.promptTokens,
+            _that.totalTokens,
+            _that.promptCacheHitTokens,
+            _that.promptCacheMissTokens,
+            _that.completionTokensDetails);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @JsonKey(name: 'completion_tokens') int completionTokens,
+            @JsonKey(name: 'prompt_tokens') int promptTokens,
+            @JsonKey(name: 'total_tokens') int totalTokens,
+            @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+            @JsonKey(name: 'prompt_cache_miss_tokens')
+            int? promptCacheMissTokens,
+            @JsonKey(name: 'completion_tokens_details')
+            ChatCompletionResponseUsageCompletionTokensDetails?
+                completionTokensDetails)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(
+            _that.completionTokens,
+            _that.promptTokens,
+            _that.totalTokens,
+            _that.promptCacheHitTokens,
+            _that.promptCacheMissTokens,
+            _that.completionTokensDetails);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseUsage extends ChatCompletionResponseUsage {
+  _ChatCompletionResponseUsage(
+      {@JsonKey(name: 'completion_tokens') required this.completionTokens,
+      @JsonKey(name: 'prompt_tokens') required this.promptTokens,
+      @JsonKey(name: 'total_tokens') required this.totalTokens,
+      @JsonKey(name: 'prompt_cache_hit_tokens') this.promptCacheHitTokens,
+      @JsonKey(name: 'prompt_cache_miss_tokens') this.promptCacheMissTokens,
+      @JsonKey(name: 'completion_tokens_details') this.completionTokensDetails})
+      : super._();
+  factory _ChatCompletionResponseUsage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseUsageFromJson(json);
+
+  @override
+  @JsonKey(name: 'completion_tokens')
+  final int completionTokens;
+  @override
+  @JsonKey(name: 'prompt_tokens')
+  final int promptTokens;
+  @override
+  @JsonKey(name: 'total_tokens')
+  final int totalTokens;
+  @override
+  @JsonKey(name: 'prompt_cache_hit_tokens')
+  final int? promptCacheHitTokens;
+  @override
+  @JsonKey(name: 'prompt_cache_miss_tokens')
+  final int? promptCacheMissTokens;
+  @override
+  @JsonKey(name: 'completion_tokens_details')
+  final ChatCompletionResponseUsageCompletionTokensDetails?
+      completionTokensDetails;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseUsageCopyWith<_ChatCompletionResponseUsage>
+      get copyWith => __$ChatCompletionResponseUsageCopyWithImpl<
+          _ChatCompletionResponseUsage>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseUsageToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseUsage &&
+            (identical(other.completionTokens, completionTokens) ||
+                other.completionTokens == completionTokens) &&
+            (identical(other.promptTokens, promptTokens) ||
+                other.promptTokens == promptTokens) &&
+            (identical(other.totalTokens, totalTokens) ||
+                other.totalTokens == totalTokens) &&
+            (identical(other.promptCacheHitTokens, promptCacheHitTokens) ||
+                other.promptCacheHitTokens == promptCacheHitTokens) &&
+            (identical(other.promptCacheMissTokens, promptCacheMissTokens) ||
+                other.promptCacheMissTokens == promptCacheMissTokens) &&
+            (identical(
+                    other.completionTokensDetails, completionTokensDetails) ||
+                other.completionTokensDetails == completionTokensDetails));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      completionTokens,
+      promptTokens,
+      totalTokens,
+      promptCacheHitTokens,
+      promptCacheMissTokens,
+      completionTokensDetails);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsage(completionTokens: $completionTokens, promptTokens: $promptTokens, totalTokens: $totalTokens, promptCacheHitTokens: $promptCacheHitTokens, promptCacheMissTokens: $promptCacheMissTokens, completionTokensDetails: $completionTokensDetails)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseUsageCopyWith<$Res>
+    implements $ChatCompletionResponseUsageCopyWith<$Res> {
+  factory _$ChatCompletionResponseUsageCopyWith(
+          _ChatCompletionResponseUsage value,
+          $Res Function(_ChatCompletionResponseUsage) _then) =
+      __$ChatCompletionResponseUsageCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'completion_tokens') int completionTokens,
+      @JsonKey(name: 'prompt_tokens') int promptTokens,
+      @JsonKey(name: 'total_tokens') int totalTokens,
+      @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+      @JsonKey(name: 'prompt_cache_miss_tokens') int? promptCacheMissTokens,
+      @JsonKey(name: 'completion_tokens_details')
+      ChatCompletionResponseUsageCompletionTokensDetails?
+          completionTokensDetails});
+
+  @override
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails;
+}
+
+/// @nodoc
+class __$ChatCompletionResponseUsageCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseUsageCopyWith<$Res> {
+  __$ChatCompletionResponseUsageCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponseUsage _self;
+  final $Res Function(_ChatCompletionResponseUsage) _then;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? completionTokens = null,
+    Object? promptTokens = null,
+    Object? totalTokens = null,
+    Object? promptCacheHitTokens = freezed,
+    Object? promptCacheMissTokens = freezed,
+    Object? completionTokensDetails = freezed,
+  }) {
+    return _then(_ChatCompletionResponseUsage(
+      completionTokens: null == completionTokens
+          ? _self.completionTokens
+          : completionTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptTokens: null == promptTokens
+          ? _self.promptTokens
+          : promptTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalTokens: null == totalTokens
+          ? _self.totalTokens
+          : totalTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptCacheHitTokens: freezed == promptCacheHitTokens
+          ? _self.promptCacheHitTokens
+          : promptCacheHitTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      promptCacheMissTokens: freezed == promptCacheMissTokens
+          ? _self.promptCacheMissTokens
+          : promptCacheMissTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      completionTokensDetails: freezed == completionTokensDetails
+          ? _self.completionTokensDetails
+          : completionTokensDetails // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsageCompletionTokensDetails?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails {
+    if (_self.completionTokensDetails == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>(
+        _self.completionTokensDetails!, (value) {
+      return _then(_self.copyWith(completionTokensDetails: value));
+    });
+  }
+}
+
+/// @nodoc
+mixin _$ChatCompletionResponseUsageCompletionTokensDetails {
+  @JsonKey(name: 'reasoning_tokens')
+  int get reasoningTokens;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+          ChatCompletionResponseUsageCompletionTokensDetails>
+      get copyWith =>
+          _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<
+                  ChatCompletionResponseUsageCompletionTokensDetails>(
+              this as ChatCompletionResponseUsageCompletionTokensDetails,
+              _$identity);
+
+  /// Serializes this ChatCompletionResponseUsageCompletionTokensDetails to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseUsageCompletionTokensDetails &&
+            (identical(other.reasoningTokens, reasoningTokens) ||
+                other.reasoningTokens == reasoningTokens));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, reasoningTokens);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsageCompletionTokensDetails(reasoningTokens: $reasoningTokens)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+    $Res> {
+  factory $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith(
+          ChatCompletionResponseUsageCompletionTokensDetails value,
+          $Res Function(ChatCompletionResponseUsageCompletionTokensDetails)
+              _then) =
+      _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl;
+  @useResult
+  $Res call({@JsonKey(name: 'reasoning_tokens') int reasoningTokens});
+}
+
+/// @nodoc
+class _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<$Res>
+    implements
+        $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res> {
+  _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl(
+      this._self, this._then);
+
+  final ChatCompletionResponseUsageCompletionTokensDetails _self;
+  final $Res Function(ChatCompletionResponseUsageCompletionTokensDetails) _then;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? reasoningTokens = null,
+  }) {
+    return _then(_self.copyWith(
+      reasoningTokens: null == reasoningTokens
+          ? _self.reasoningTokens
+          : reasoningTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseUsageCompletionTokensDetails].
+extension ChatCompletionResponseUsageCompletionTokensDetailsPatterns
+    on ChatCompletionResponseUsageCompletionTokensDetails {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsageCompletionTokensDetails value)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsageCompletionTokensDetails value)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(
+            _ChatCompletionResponseUsageCompletionTokensDetails value)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@JsonKey(name: 'reasoning_tokens') int reasoningTokens)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that.reasoningTokens);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@JsonKey(name: 'reasoning_tokens') int reasoningTokens)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails():
+        return $default(_that.reasoningTokens);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@JsonKey(name: 'reasoning_tokens') int reasoningTokens)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that.reasoningTokens);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseUsageCompletionTokensDetails
+    extends ChatCompletionResponseUsageCompletionTokensDetails {
+  _ChatCompletionResponseUsageCompletionTokensDetails(
+      {@JsonKey(name: 'reasoning_tokens') required this.reasoningTokens})
+      : super._();
+  factory _ChatCompletionResponseUsageCompletionTokensDetails.fromJson(
+          Map<String, dynamic> json) =>
+      _$ChatCompletionResponseUsageCompletionTokensDetailsFromJson(json);
+
+  @override
+  @JsonKey(name: 'reasoning_tokens')
+  final int reasoningTokens;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+          _ChatCompletionResponseUsageCompletionTokensDetails>
+      get copyWith =>
+          __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<
+                  _ChatCompletionResponseUsageCompletionTokensDetails>(
+              this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseUsageCompletionTokensDetailsToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseUsageCompletionTokensDetails &&
+            (identical(other.reasoningTokens, reasoningTokens) ||
+                other.reasoningTokens == reasoningTokens));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, reasoningTokens);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsageCompletionTokensDetails(reasoningTokens: $reasoningTokens)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+        $Res>
+    implements
+        $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res> {
+  factory _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith(
+          _ChatCompletionResponseUsageCompletionTokensDetails value,
+          $Res Function(_ChatCompletionResponseUsageCompletionTokensDetails)
+              _then) =
+      __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl;
+  @override
+  @useResult
+  $Res call({@JsonKey(name: 'reasoning_tokens') int reasoningTokens});
+}
+
+/// @nodoc
+class __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<$Res>
+    implements
+        _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res> {
+  __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl(
+      this._self, this._then);
+
+  final _ChatCompletionResponseUsageCompletionTokensDetails _self;
+  final $Res Function(_ChatCompletionResponseUsageCompletionTokensDetails)
+      _then;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? reasoningTokens = null,
+  }) {
+    return _then(_ChatCompletionResponseUsageCompletionTokensDetails(
+      reasoningTokens: null == reasoningTokens
+          ? _self.reasoningTokens
+          : reasoningTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.g.dart
+++ b/pkgs/mistral_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response_usage.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponseUsage _$ChatCompletionResponseUsageFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponseUsage(
+      completionTokens: (json['completion_tokens'] as num).toInt(),
+      promptTokens: (json['prompt_tokens'] as num).toInt(),
+      totalTokens: (json['total_tokens'] as num).toInt(),
+      promptCacheHitTokens: (json['prompt_cache_hit_tokens'] as num?)?.toInt(),
+      promptCacheMissTokens:
+          (json['prompt_cache_miss_tokens'] as num?)?.toInt(),
+      completionTokensDetails: json['completion_tokens_details'] == null
+          ? null
+          : ChatCompletionResponseUsageCompletionTokensDetails.fromJson(
+              json['completion_tokens_details'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseUsageToJson(
+        _ChatCompletionResponseUsage instance) =>
+    <String, dynamic>{
+      'completion_tokens': instance.completionTokens,
+      'prompt_tokens': instance.promptTokens,
+      'total_tokens': instance.totalTokens,
+      'prompt_cache_hit_tokens': instance.promptCacheHitTokens,
+      'prompt_cache_miss_tokens': instance.promptCacheMissTokens,
+      'completion_tokens_details': instance.completionTokensDetails,
+    };
+
+_ChatCompletionResponseUsageCompletionTokensDetails
+    _$ChatCompletionResponseUsageCompletionTokensDetailsFromJson(
+            Map<String, dynamic> json) =>
+        _ChatCompletionResponseUsageCompletionTokensDetails(
+          reasoningTokens: (json['reasoning_tokens'] as num).toInt(),
+        );
+
+Map<String, dynamic> _$ChatCompletionResponseUsageCompletionTokensDetailsToJson(
+        _ChatCompletionResponseUsageCompletionTokensDetails instance) =>
+    <String, dynamic>{
+      'reasoning_tokens': instance.reasoningTokens,
+    };

--- a/pkgs/mistral_box/lib/src/freezed/model/model/model.dart
+++ b/pkgs/mistral_box/lib/src/freezed/model/model/model.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'model.freezed.dart';
+part 'model.g.dart';
+
+@freezed
+abstract class Model with _$Model {
+  factory Model({
+    required String id,
+    required String object,
+    @JsonKey(name: 'owned_by') required String ownedBy,
+  }) = _Model;
+
+  factory Model.fromJson(Map<String, dynamic> json) => _$ModelFromJson(json);
+  const Model._();
+}

--- a/pkgs/mistral_box/lib/src/freezed/model/model/model.freezed.dart
+++ b/pkgs/mistral_box/lib/src/freezed/model/model/model.freezed.dart
@@ -1,0 +1,353 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Model {
+  String get id;
+  String get object;
+  @JsonKey(name: 'owned_by')
+  String get ownedBy;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ModelCopyWith<Model> get copyWith =>
+      _$ModelCopyWithImpl<Model>(this as Model, _$identity);
+
+  /// Serializes this Model to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Model &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.ownedBy, ownedBy) || other.ownedBy == ownedBy));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, object, ownedBy);
+
+  @override
+  String toString() {
+    return 'Model(id: $id, object: $object, ownedBy: $ownedBy)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ModelCopyWith<$Res> {
+  factory $ModelCopyWith(Model value, $Res Function(Model) _then) =
+      _$ModelCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id, String object, @JsonKey(name: 'owned_by') String ownedBy});
+}
+
+/// @nodoc
+class _$ModelCopyWithImpl<$Res> implements $ModelCopyWith<$Res> {
+  _$ModelCopyWithImpl(this._self, this._then);
+
+  final Model _self;
+  final $Res Function(Model) _then;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? object = null,
+    Object? ownedBy = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      ownedBy: null == ownedBy
+          ? _self.ownedBy
+          : ownedBy // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Model].
+extension ModelPatterns on Model {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Model value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Model value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Model value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String id, String object,
+            @JsonKey(name: 'owned_by') String ownedBy)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that.id, _that.object, _that.ownedBy);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id, String object, @JsonKey(name: 'owned_by') String ownedBy)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model():
+        return $default(_that.id, _that.object, _that.ownedBy);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String id, String object,
+            @JsonKey(name: 'owned_by') String ownedBy)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that.id, _that.object, _that.ownedBy);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _Model extends Model {
+  _Model(
+      {required this.id,
+      required this.object,
+      @JsonKey(name: 'owned_by') required this.ownedBy})
+      : super._();
+  factory _Model.fromJson(Map<String, dynamic> json) => _$ModelFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String object;
+  @override
+  @JsonKey(name: 'owned_by')
+  final String ownedBy;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ModelCopyWith<_Model> get copyWith =>
+      __$ModelCopyWithImpl<_Model>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ModelToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Model &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.ownedBy, ownedBy) || other.ownedBy == ownedBy));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, object, ownedBy);
+
+  @override
+  String toString() {
+    return 'Model(id: $id, object: $object, ownedBy: $ownedBy)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ModelCopyWith<$Res> implements $ModelCopyWith<$Res> {
+  factory _$ModelCopyWith(_Model value, $Res Function(_Model) _then) =
+      __$ModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id, String object, @JsonKey(name: 'owned_by') String ownedBy});
+}
+
+/// @nodoc
+class __$ModelCopyWithImpl<$Res> implements _$ModelCopyWith<$Res> {
+  __$ModelCopyWithImpl(this._self, this._then);
+
+  final _Model _self;
+  final $Res Function(_Model) _then;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? object = null,
+    Object? ownedBy = null,
+  }) {
+    return _then(_Model(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      ownedBy: null == ownedBy
+          ? _self.ownedBy
+          : ownedBy // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/mistral_box/lib/src/freezed/model/model/model.g.dart
+++ b/pkgs/mistral_box/lib/src/freezed/model/model/model.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_Model _$ModelFromJson(Map<String, dynamic> json) => _Model(
+      id: json['id'] as String,
+      object: json['object'] as String,
+      ownedBy: json['owned_by'] as String,
+    );
+
+Map<String, dynamic> _$ModelToJson(_Model instance) => <String, dynamic>{
+      'id': instance.id,
+      'object': instance.object,
+      'owned_by': instance.ownedBy,
+    };

--- a/pkgs/mistral_box/lib/src/freezed/model/model_list/model_list.dart
+++ b/pkgs/mistral_box/lib/src/freezed/model/model_list/model_list.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mistral_box/src/freezed/model/model/model.dart';
+
+part 'model_list.freezed.dart';
+part 'model_list.g.dart';
+
+@freezed
+abstract class ModelList with _$ModelList {
+  factory ModelList({required String object, required List<Model> data}) =
+      _ModelList;
+
+  factory ModelList.fromJson(Map<String, dynamic> json) =>
+      _$ModelListFromJson(json);
+  const ModelList._();
+}

--- a/pkgs/mistral_box/lib/src/freezed/model/model_list/model_list.freezed.dart
+++ b/pkgs/mistral_box/lib/src/freezed/model/model_list/model_list.freezed.dart
@@ -1,0 +1,336 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'model_list.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ModelList {
+  String get object;
+  List<Model> get data;
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ModelListCopyWith<ModelList> get copyWith =>
+      _$ModelListCopyWithImpl<ModelList>(this as ModelList, _$identity);
+
+  /// Serializes this ModelList to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ModelList &&
+            (identical(other.object, object) || other.object == object) &&
+            const DeepCollectionEquality().equals(other.data, data));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, object, const DeepCollectionEquality().hash(data));
+
+  @override
+  String toString() {
+    return 'ModelList(object: $object, data: $data)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ModelListCopyWith<$Res> {
+  factory $ModelListCopyWith(ModelList value, $Res Function(ModelList) _then) =
+      _$ModelListCopyWithImpl;
+  @useResult
+  $Res call({String object, List<Model> data});
+}
+
+/// @nodoc
+class _$ModelListCopyWithImpl<$Res> implements $ModelListCopyWith<$Res> {
+  _$ModelListCopyWithImpl(this._self, this._then);
+
+  final ModelList _self;
+  final $Res Function(ModelList) _then;
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? object = null,
+    Object? data = null,
+  }) {
+    return _then(_self.copyWith(
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      data: null == data
+          ? _self.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as List<Model>,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ModelList].
+extension ModelListPatterns on ModelList {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ModelList value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ModelList value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ModelList value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String object, List<Model> data)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that.object, _that.data);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String object, List<Model> data) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList():
+        return $default(_that.object, _that.data);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String object, List<Model> data)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that.object, _that.data);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ModelList extends ModelList {
+  _ModelList({required this.object, required final List<Model> data})
+      : _data = data,
+        super._();
+  factory _ModelList.fromJson(Map<String, dynamic> json) =>
+      _$ModelListFromJson(json);
+
+  @override
+  final String object;
+  final List<Model> _data;
+  @override
+  List<Model> get data {
+    if (_data is EqualUnmodifiableListView) return _data;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_data);
+  }
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ModelListCopyWith<_ModelList> get copyWith =>
+      __$ModelListCopyWithImpl<_ModelList>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ModelListToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ModelList &&
+            (identical(other.object, object) || other.object == object) &&
+            const DeepCollectionEquality().equals(other._data, _data));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, object, const DeepCollectionEquality().hash(_data));
+
+  @override
+  String toString() {
+    return 'ModelList(object: $object, data: $data)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ModelListCopyWith<$Res>
+    implements $ModelListCopyWith<$Res> {
+  factory _$ModelListCopyWith(
+          _ModelList value, $Res Function(_ModelList) _then) =
+      __$ModelListCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String object, List<Model> data});
+}
+
+/// @nodoc
+class __$ModelListCopyWithImpl<$Res> implements _$ModelListCopyWith<$Res> {
+  __$ModelListCopyWithImpl(this._self, this._then);
+
+  final _ModelList _self;
+  final $Res Function(_ModelList) _then;
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? object = null,
+    Object? data = null,
+  }) {
+    return _then(_ModelList(
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      data: null == data
+          ? _self._data
+          : data // ignore: cast_nullable_to_non_nullable
+              as List<Model>,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/mistral_box/lib/src/freezed/model/model_list/model_list.g.dart
+++ b/pkgs/mistral_box/lib/src/freezed/model/model_list/model_list.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'model_list.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ModelList _$ModelListFromJson(Map<String, dynamic> json) => _ModelList(
+      object: json['object'] as String,
+      data: (json['data'] as List<dynamic>)
+          .map((e) => Model.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$ModelListToJson(_ModelList instance) =>
+    <String, dynamic>{
+      'object': instance.object,
+      'data': instance.data,
+    };

--- a/pkgs/mistral_box/lib/src/mistral.dart
+++ b/pkgs/mistral_box/lib/src/mistral.dart
@@ -1,0 +1,40 @@
+import 'package:ai_box/ai_box.dart';
+import 'package:mistral_box/mistral_box.dart';
+import 'package:mistral_box/src/openai_compat.dart';
+
+class Mistral extends LLMAIBase {
+  Mistral({required super.apiKey});
+
+  static const _url = 'https://api.mistral.ai/v1/chat/completions';
+  static const _provider = 'mistral';
+
+  @override
+  Future<LLMCompletionResponse> completions(
+    LLMCompletionRequest request,
+  ) async {
+    final body = buildOpenAiBody(request, maxTokensKey: 'max_tokens');
+    final data = await postOpenAiJson(
+      url: _url,
+      apiKey: apiKey,
+      provider: _provider,
+      body: body,
+    );
+    return parseOpenAiResponse(data);
+  }
+
+  @override
+  Future<List<AIModel>> getModels() async {
+    final modelList = await MistralCore.listModels(apiKey: apiKey);
+    return modelList.data.map((e) => AIModel(id: e.id)).toList();
+  }
+
+  @override
+  Future<bool> validateKey() async {
+    try {
+      await MistralCore.listModels(apiKey: apiKey);
+      return true;
+    } on Exception catch (_) {
+      return false;
+    }
+  }
+}

--- a/pkgs/mistral_box/lib/src/openai_compat.dart
+++ b/pkgs/mistral_box/lib/src/openai_compat.dart
@@ -1,0 +1,338 @@
+// OpenAI 互換 Chat Completions API のリクエスト構築・レスポンス解析ヘルパー。
+//
+// 画像・音声・ファイル・ツール呼び出し・構造化出力を raw JSON として
+// 組み立てる（freezed のコード生成に依存しない）。
+//
+// このファイルは src/ 配下のパッケージ内部実装であり、公開 API には含めない。
+import 'dart:convert';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:api_http/api_http.dart';
+
+/// [LLMCompletionRequest] を OpenAI 互換のリクエストボディに変換する。
+Map<String, dynamic> buildOpenAiBody(
+  LLMCompletionRequest request, {
+  required String maxTokensKey,
+}) {
+  final body = <String, dynamic>{
+    'model': request.model,
+    'messages': _toOpenAiMessages(request.messages),
+  };
+  if (request.maxTokens != null) body[maxTokensKey] = request.maxTokens;
+  if (request.temperature != null) body['temperature'] = request.temperature;
+  if (request.topP != null) body['top_p'] = request.topP;
+  if (request.stop != null) body['stop'] = request.stop;
+  if (request.seed != null) body['seed'] = request.seed;
+  if (request.frequencyPenalty != null) {
+    body['frequency_penalty'] = request.frequencyPenalty;
+  }
+  if (request.presencePenalty != null) {
+    body['presence_penalty'] = request.presencePenalty;
+  }
+  final rf = _toOpenAiResponseFormat(request.responseFormat);
+  if (rf != null) body['response_format'] = rf;
+  final tools = request.tools;
+  if (tools != null && tools.isNotEmpty) {
+    body['tools'] = [
+      for (final t in tools)
+        {
+          'type': 'function',
+          'function': {
+            'name': t.name,
+            'description': t.description,
+            'parameters': t.parameters,
+          },
+        },
+    ];
+    final tc = _toOpenAiToolChoice(request.toolChoice);
+    if (tc != null) body['tool_choice'] = tc;
+  }
+  return body;
+}
+
+List<Map<String, dynamic>> _toOpenAiMessages(List<LLMContent> messages) {
+  final out = <Map<String, dynamic>>[];
+  for (final m in messages) {
+    final role = switch (m.role) {
+      LLMRole.model => 'assistant',
+      LLMRole.system => 'system',
+      LLMRole.user => 'user',
+    };
+
+    // ツール実行結果は role: 'tool' の独立メッセージとして送る。
+    final toolResults = m.parts.whereType<LLMToolResultPart>().toList();
+    if (toolResults.isNotEmpty) {
+      for (final tr in toolResults) {
+        out.add({
+          'role': 'tool',
+          'tool_call_id': tr.toolCallId,
+          'content': tr.content,
+        });
+      }
+      continue;
+    }
+
+    // assistant のツール呼び出しエコー。
+    final toolCalls = m.parts.whereType<LLMToolCallPart>().toList();
+    if (toolCalls.isNotEmpty) {
+      out.add({
+        'role': 'assistant',
+        if (m.text.isNotEmpty) 'content': m.text,
+        'tool_calls': [
+          for (final tc in toolCalls)
+            {
+              'id': tc.id,
+              'type': 'function',
+              'function': {
+                'name': tc.name,
+                'arguments': jsonEncode(tc.arguments),
+              },
+            },
+        ],
+      });
+      continue;
+    }
+
+    final hasMedia = m.parts.any(
+      (p) => p is LLMImagePart || p is LLMAudioPart || p is LLMFilePart,
+    );
+    if (!hasMedia) {
+      out.add({'role': role, 'content': m.text});
+      continue;
+    }
+
+    out.add({'role': role, 'content': _toOpenAiContentArray(m.parts)});
+  }
+  return out;
+}
+
+List<Map<String, dynamic>> _toOpenAiContentArray(List<LLMContentPart> parts) {
+  final arr = <Map<String, dynamic>>[];
+  for (final p in parts) {
+    if (p is LLMTextPart) {
+      arr.add({'type': 'text', 'text': p.text});
+    } else if (p is LLMImagePart) {
+      arr.add({
+        'type': 'image_url',
+        'image_url': {'url': p.asUrlOrDataUri},
+      });
+    } else if (p is LLMAudioPart) {
+      arr.add({
+        'type': 'input_audio',
+        'input_audio': {
+          'data': p.base64Data ?? '',
+          'format': _audioFormat(p.mimeType),
+        },
+      });
+    } else if (p is LLMFilePart) {
+      arr.add({
+        'type': 'file',
+        'file': {
+          if (p.filename != null) 'filename': p.filename,
+          'file_data': _fileDataField(p),
+        },
+      });
+    }
+  }
+  return arr;
+}
+
+String _fileDataField(LLMFilePart f) {
+  if (f.hasBytes) {
+    final mime = f.mimeType ?? 'application/octet-stream';
+    return 'data:$mime;base64,${f.base64Data}';
+  }
+  return f.url ?? '';
+}
+
+String _audioFormat(String? mimeType) {
+  if (mimeType == null) return 'wav';
+  if (mimeType.contains('mp3') || mimeType.contains('mpeg')) return 'mp3';
+  if (mimeType.contains('wav')) return 'wav';
+  return mimeType.split('/').last;
+}
+
+Map<String, dynamic>? _toOpenAiResponseFormat(LLMResponseFormat? f) {
+  if (f == null) return null;
+  switch (f.type) {
+    case LLMResponseFormatType.text:
+      return {'type': 'text'};
+    case LLMResponseFormatType.jsonObject:
+      return {'type': 'json_object'};
+    case LLMResponseFormatType.jsonSchema:
+      return {
+        'type': 'json_schema',
+        'json_schema': {
+          'name': f.schemaName,
+          'schema': f.schema,
+          'strict': f.strict,
+        },
+      };
+  }
+}
+
+dynamic _toOpenAiToolChoice(LLMToolChoice? tc) {
+  if (tc == null) return null;
+  final toolName = tc.toolName;
+  if (toolName != null) {
+    return {
+      'type': 'function',
+      'function': {'name': toolName},
+    };
+  }
+  switch (tc.mode) {
+    case LLMToolChoiceMode.auto:
+      return 'auto';
+    case LLMToolChoiceMode.none:
+      return 'none';
+    case LLMToolChoiceMode.any:
+      return 'required';
+  }
+}
+
+/// OpenAI 互換のレスポンスボディを [LLMCompletionResponse] に変換する。
+LLMCompletionResponse parseOpenAiResponse(Map<String, dynamic> data) {
+  final choices = (data['choices'] as List?) ?? const [];
+  final choice = choices.isNotEmpty
+      ? choices.first as Map<String, dynamic>
+      : const <String, dynamic>{};
+  final message =
+      (choice['message'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  final parts = <LLMContentPart>[];
+
+  final reasoning = message['reasoning_content'];
+  if (reasoning is String && reasoning.isNotEmpty) {
+    parts.add(LLMReasoningPart(reasoning));
+  }
+
+  final rawContent = message['content'];
+  if (rawContent is String && rawContent.isNotEmpty) {
+    parts.add(LLMTextPart(rawContent));
+  } else if (rawContent is List) {
+    _appendOpenAiContentParts(rawContent, parts);
+  }
+
+  final toolCalls = message['tool_calls'];
+  if (toolCalls is List) {
+    for (final tc in toolCalls) {
+      if (tc is Map<String, dynamic>) {
+        final fn = tc['function'];
+        final fnMap =
+            fn is Map<String, dynamic> ? fn : const <String, dynamic>{};
+        parts.add(
+          LLMToolCallPart(
+            id: (tc['id'] ?? '').toString(),
+            name: (fnMap['name'] ?? '').toString(),
+            arguments: _decodeArgs(fnMap['arguments']),
+          ),
+        );
+      }
+    }
+  }
+
+  final audio = message['audio'];
+  if (audio is Map<String, dynamic>) {
+    final adata = audio['data'];
+    if (adata is String && adata.isNotEmpty) {
+      parts.add(
+        LLMAudioPart.base64(adata, transcript: audio['transcript'] as String?),
+      );
+    }
+  }
+
+  final usage =
+      (data['usage'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  return LLMCompletionResponse(
+    content: LLMContent(role: LLMRole.model, parts: parts),
+    usage: _parseOpenAiUsage(usage),
+    finishReason: LLMFinishReason.parse(choice['finish_reason'] as String?),
+    model: data['model'] as String?,
+    id: data['id'] as String?,
+  );
+}
+
+void _appendOpenAiContentParts(List<dynamic> items, List<LLMContentPart> out) {
+  for (final item in items) {
+    if (item is! Map<String, dynamic>) continue;
+    final type = item['type'];
+    if (type == 'text' && item['text'] is String) {
+      out.add(LLMTextPart(item['text'] as String));
+    } else if (type == 'image_url') {
+      final url = (item['image_url'] as Map<String, dynamic>?)?['url'];
+      if (url is String) out.add(LLMImagePart.dataUri(url));
+    }
+  }
+}
+
+Map<String, dynamic> _decodeArgs(Object? argsRaw) {
+  if (argsRaw is Map<String, dynamic>) return argsRaw;
+  if (argsRaw is String && argsRaw.isNotEmpty) {
+    try {
+      final decoded = jsonDecode(argsRaw);
+      if (decoded is Map<String, dynamic>) return decoded;
+    } on FormatException {
+      return <String, dynamic>{};
+    }
+  }
+  return <String, dynamic>{};
+}
+
+LLMUsage _parseOpenAiUsage(Map<String, dynamic> usage) {
+  final promptDetails = usage['prompt_tokens_details'] as Map<String, dynamic>?;
+  final completionDetails =
+      usage['completion_tokens_details'] as Map<String, dynamic>?;
+  return LLMUsage(
+    inputTokens: (usage['prompt_tokens'] as num?)?.toInt() ?? 0,
+    outputTokens: (usage['completion_tokens'] as num?)?.toInt() ?? 0,
+    cachedInputTokens: (promptDetails?['cached_tokens'] as num?)?.toInt(),
+    reasoningTokens: (completionDetails?['reasoning_tokens'] as num?)?.toInt(),
+  );
+}
+
+/// OpenAI 互換 API に POST し、JSON ボディを返す。失敗時は [LLMException]。
+Future<Map<String, dynamic>> postOpenAiJson({
+  required String url,
+  required String apiKey,
+  required String provider,
+  required Map<String, dynamic> body,
+}) async {
+  try {
+    final response = await Api.post(
+      requestAcc: PostRequestAcc(
+        url: url,
+        headers: RestHeaders({
+          'Authorization': 'Bearer $apiKey',
+          'Content-Type': 'application/json',
+        }),
+        body: JsonRequestBody(body),
+      ),
+    );
+    final statusCode = int.tryParse(response.statusCode) ?? 0;
+    final respBody = response.body;
+    Map<String, dynamic>? mapData;
+    if (respBody is MapJsonResponseBody) {
+      mapData = respBody.data;
+    }
+    if (statusCode < 200 || statusCode >= 300) {
+      throw LLMException.fromHttp(
+        statusCode,
+        provider: provider,
+        body: mapData ?? respBody,
+      );
+    }
+    if (mapData != null) return mapData;
+    throw LLMUnknownException(
+      'Unexpected response body from $provider',
+      provider: provider,
+      raw: respBody,
+    );
+  } on LLMException {
+    rethrow;
+  } catch (e) {
+    throw LLMNetworkException(
+      'Network request failed',
+      provider: provider,
+      raw: e,
+    );
+  }
+}

--- a/pkgs/mistral_box/pubspec.yaml
+++ b/pkgs/mistral_box/pubspec.yaml
@@ -1,0 +1,24 @@
+---
+dependencies:
+  ai_box: ^0.0.1
+  api_http: ^0.0.1
+  freezed_annotation: ^3.0.0
+  json_annotation: ^4.9.0
+description: '''A Mistral AI provider based on ai_box. '''
+dev_dependencies:
+  auto_exporter: any
+  build_runner: ^2.5.4
+  freezed: ^3.0.6
+  json_serializable: ^6.9.5
+  test: ^1.26.0
+  very_good_analysis: any
+environment:
+  sdk: ^3.2.0
+homepage: https://github.com/normidar/ai_box
+name: mistral_box
+topics:
+  - ai
+  - mistral
+  - ai-box
+  - llm
+version: 0.0.1

--- a/pkgs/mistral_box/pubspec_overrides.yaml
+++ b/pkgs/mistral_box/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: ai_box
+dependency_overrides:
+  ai_box:
+    path: ../ai_box

--- a/pkgs/mistral_box/test/mistral_box_test.dart
+++ b/pkgs/mistral_box/test/mistral_box_test.dart
@@ -1,0 +1,194 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:mistral_box/mistral_box.dart';
+import 'package:mistral_box/src/openai_compat.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Mistral client', () {
+    test('exposes apiKey and is an LLMAIBase', () {
+      final ai = Mistral(apiKey: 'test-key');
+      expect(ai.apiKey, 'test-key');
+      expect(ai, isA<LLMAIBase>());
+    });
+  });
+
+  group('ChatCompletion freezed models', () {
+    test('request serializes to OpenAI-shaped JSON', () {
+      final req = ChatCompletionRequest(
+        model: 'mistral-small-latest',
+        messages: [
+          ChatCompletionMessage(role: ChatCompletionRole.user, content: 'hi'),
+        ],
+        maxTokens: 16,
+      );
+      // toJson() keeps nested objects; the wire payload is produced when the
+      // map is encoded (as JsonRequestBody does), so round-trip through JSON.
+      final json = jsonDecode(jsonEncode(req.toJson())) as Map<String, dynamic>;
+      expect(json['model'], 'mistral-small-latest');
+      expect(json['max_tokens'], 16);
+      final msg = (json['messages'] as List).first as Map<String, dynamic>;
+      expect(msg['role'], 'user');
+      expect(msg['content'], 'hi');
+    });
+
+    test('response parses choices + usage', () {
+      final res = ChatCompletionResponse.fromJson({
+        'id': 'x',
+        'object': 'chat.completion',
+        'created': 1,
+        'model': 'mistral-small-latest',
+        'choices': [
+          {
+            'index': 0,
+            'finish_reason': 'stop',
+            'message': {'role': 'assistant', 'content': 'hello'},
+          },
+        ],
+        'usage': {
+          'prompt_tokens': 3,
+          'completion_tokens': 5,
+          'total_tokens': 8,
+        },
+      });
+      expect(res.choices.single.message.content, 'hello');
+      expect(res.choices.single.finishReason, 'stop');
+      expect(res.usage?.totalTokens, 8);
+    });
+
+    test('ModelList parses model entries', () {
+      final list = ModelList.fromJson({
+        'object': 'list',
+        'data': [
+          {'id': 'mistral-large-latest', 'object': 'model', 'owned_by': 'm'},
+        ],
+      });
+      expect(list.data.single.id, 'mistral-large-latest');
+    });
+  });
+
+  group('buildOpenAiBody', () {
+    test('text message maps to role + content with sampling params', () {
+      final body = buildOpenAiBody(
+        LLMCompletionRequest(
+          model: 'm',
+          messages: [LLMContent.user('hi')],
+          maxTokens: 10,
+          temperature: 0.5,
+        ),
+        maxTokensKey: 'max_tokens',
+      );
+      expect(body['model'], 'm');
+      expect(body['max_tokens'], 10);
+      expect(body['temperature'], 0.5);
+      final msg = (body['messages'] as List).single as Map<String, dynamic>;
+      expect(msg['role'], 'user');
+      expect(msg['content'], 'hi');
+    });
+
+    test('image attachment becomes a content array with image_url', () {
+      final bytes = Uint8List.fromList(utf8.encode('img'));
+      final body = buildOpenAiBody(
+        LLMCompletionRequest(
+          model: 'm',
+          messages: [
+            LLMContent.user('see', attachments: [LLMImagePart.bytes(bytes)]),
+          ],
+        ),
+        maxTokensKey: 'max_tokens',
+      );
+      final msg = (body['messages'] as List).single as Map<String, dynamic>;
+      final content = msg['content'] as List;
+      expect((content[0] as Map<String, dynamic>)['type'], 'text');
+      expect((content[1] as Map<String, dynamic>)['type'], 'image_url');
+    });
+
+    test('tools are mapped to function definitions', () {
+      final body = buildOpenAiBody(
+        LLMCompletionRequest(
+          model: 'm',
+          messages: [LLMContent.user('x')],
+          tools: const [
+            LLMTool(
+              name: 'get_weather',
+              description: 'weather',
+              parameters: {'type': 'object'},
+            ),
+          ],
+          toolChoice: LLMToolChoice.auto,
+        ),
+        maxTokensKey: 'max_tokens',
+      );
+      final tool = (body['tools'] as List).single as Map<String, dynamic>;
+      expect(tool['type'], 'function');
+      expect((tool['function'] as Map<String, dynamic>)['name'], 'get_weather');
+      expect(body['tool_choice'], 'auto');
+    });
+  });
+
+  group('parseOpenAiResponse', () {
+    test('text, usage, finish reason, model and id', () {
+      final res = parseOpenAiResponse({
+        'id': 'r',
+        'model': 'm',
+        'choices': [
+          {
+            'finish_reason': 'stop',
+            'message': {'role': 'assistant', 'content': 'hello'},
+          },
+        ],
+        'usage': {'prompt_tokens': 2, 'completion_tokens': 3},
+      });
+      expect(res.text, 'hello');
+      expect(res.finishReason, LLMFinishReason.stop);
+      expect(res.usage.inputTokens, 2);
+      expect(res.usage.outputTokens, 3);
+      expect(res.model, 'm');
+      expect(res.id, 'r');
+    });
+
+    test('tool calls are parsed into LLMToolCallPart', () {
+      final res = parseOpenAiResponse({
+        'choices': [
+          {
+            'finish_reason': 'tool_calls',
+            'message': {
+              'role': 'assistant',
+              'content': null,
+              'tool_calls': [
+                {
+                  'id': 'c1',
+                  'type': 'function',
+                  'function': {'name': 'f', 'arguments': '{"a":1}'},
+                },
+              ],
+            },
+          },
+        ],
+      });
+      final call = res.content.parts.whereType<LLMToolCallPart>().single;
+      expect(call.id, 'c1');
+      expect(call.name, 'f');
+      expect(call.arguments, {'a': 1});
+      expect(res.finishReason, LLMFinishReason.toolCalls);
+    });
+
+    test('reasoning_content becomes an LLMReasoningPart', () {
+      final res = parseOpenAiResponse({
+        'choices': [
+          {
+            'message': {
+              'role': 'assistant',
+              'reasoning_content': 'think',
+              'content': 'ans',
+            },
+          },
+        ],
+      });
+      expect(res.content.reasoning, 'think');
+      expect(res.text, 'ans');
+    });
+  });
+}

--- a/pkgs/perplexity_box/.gitignore
+++ b/pkgs/perplexity_box/.gitignore
@@ -1,0 +1,31 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/

--- a/pkgs/perplexity_box/CHANGELOG.md
+++ b/pkgs/perplexity_box/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+- Initial release.

--- a/pkgs/perplexity_box/README.md
+++ b/pkgs/perplexity_box/README.md
@@ -1,0 +1,6 @@
+# perplexity_box
+
+A Perplexity AI provider based on [ai_box](https://github.com/normidar/ai_box).
+
+Perplexity does not expose a `/models` listing endpoint, so `getModels()`
+returns the documented Sonar model family.

--- a/pkgs/perplexity_box/analysis_options.yaml
+++ b/pkgs/perplexity_box/analysis_options.yaml
@@ -1,0 +1,11 @@
+include: package:very_good_analysis/analysis_options.yaml
+analyzer:
+  exclude: [build/**, lib/**.freezed.dart, lib/**.g.dart]
+  errors:
+    sort_constructors_first: ignore
+    public_member_api_docs: ignore
+    one_member_abstracts: ignore
+    invalid_annotation_target: ignore
+    avoid_positional_boolean_parameters: ignore
+    use_setters_to_change_properties: ignore
+    prefer_asserts_with_message: ignore

--- a/pkgs/perplexity_box/build.yaml
+++ b/pkgs/perplexity_box/build.yaml
@@ -1,0 +1,7 @@
+targets:
+  $default:
+    builders:
+      auto_exporter:
+        options:
+          default_export_all: true
+          project_name: perplexity_box

--- a/pkgs/perplexity_box/lib/perplexity_box.dart
+++ b/pkgs/perplexity_box/lib/perplexity_box.dart
@@ -1,0 +1,10 @@
+export 'package:perplexity_box/src/core/perplexity_core.dart';
+export 'package:perplexity_box/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart';
+export 'package:perplexity_box/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.dart';
+export 'package:perplexity_box/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.dart';
+export 'package:perplexity_box/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart';
+export 'package:perplexity_box/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart';
+export 'package:perplexity_box/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart';
+export 'package:perplexity_box/src/freezed/model/model/model.dart';
+export 'package:perplexity_box/src/freezed/model/model_list/model_list.dart';
+export 'package:perplexity_box/src/perplexity.dart';

--- a/pkgs/perplexity_box/lib/src/core/perplexity_core.dart
+++ b/pkgs/perplexity_box/lib/src/core/perplexity_core.dart
@@ -1,0 +1,32 @@
+import 'package:api_http/api_http.dart';
+import 'package:perplexity_box/perplexity_box.dart';
+
+class PerplexityCore {
+  static const _baseUrl = 'https://api.perplexity.ai';
+
+  static Future<ChatCompletionResponse> chatCompletion({
+    required String apiKey,
+    required ChatCompletionRequest request,
+  }) async {
+    final response = await Api.post(
+      requestAcc: PostRequestAcc(
+        url: '$_baseUrl/chat/completions',
+        headers: _getHeaders(apiKey: apiKey),
+        body: JsonRequestBody(request.toJson()),
+      ),
+    );
+    switch (response.body) {
+      case MapJsonResponseBody(:final data):
+        return ChatCompletionResponse.fromJson(data);
+      case _:
+        throw Exception('Failed to chat completion: ${response.body}');
+    }
+  }
+
+  static RestHeaders _getHeaders({required String apiKey}) {
+    return RestHeaders({
+      'Authorization': 'Bearer $apiKey',
+      'Content-Type': 'application/json',
+    });
+  }
+}

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'chat_completion_message.freezed.dart';
+part 'chat_completion_message.g.dart';
+
+@freezed
+abstract class ChatCompletionMessage with _$ChatCompletionMessage {
+  factory ChatCompletionMessage({
+    required ChatCompletionRole role,
+    required String content,
+    String? name,
+    @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls,
+  }) = _ChatCompletionMessage;
+
+  factory ChatCompletionMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionMessageFromJson(json);
+  const ChatCompletionMessage._();
+}
+
+enum ChatCompletionRole { system, user, assistant, tool }

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.freezed.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.freezed.dart
@@ -1,0 +1,394 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_message.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionMessage {
+  ChatCompletionRole get role;
+  String get content;
+  String? get name;
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls;
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionMessageCopyWith<ChatCompletionMessage> get copyWith =>
+      _$ChatCompletionMessageCopyWithImpl<ChatCompletionMessage>(
+          this as ChatCompletionMessage, _$identity);
+
+  /// Serializes this ChatCompletionMessage to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.name, name) || other.name == name) &&
+            const DeepCollectionEquality().equals(other.toolCalls, toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, name,
+      const DeepCollectionEquality().hash(toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionMessage(role: $role, content: $content, name: $name, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionMessageCopyWith<$Res> {
+  factory $ChatCompletionMessageCopyWith(ChatCompletionMessage value,
+          $Res Function(ChatCompletionMessage) _then) =
+      _$ChatCompletionMessageCopyWithImpl;
+  @useResult
+  $Res call(
+      {ChatCompletionRole role,
+      String content,
+      String? name,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class _$ChatCompletionMessageCopyWithImpl<$Res>
+    implements $ChatCompletionMessageCopyWith<$Res> {
+  _$ChatCompletionMessageCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionMessage _self;
+  final $Res Function(ChatCompletionMessage) _then;
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? role = null,
+    Object? content = null,
+    Object? name = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_self.copyWith(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionRole,
+      content: null == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: freezed == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self.toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionMessage].
+extension ChatCompletionMessagePatterns on ChatCompletionMessage {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionMessage value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionMessage value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionMessage value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(ChatCompletionRole role, String content, String? name,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.name, _that.toolCalls);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(ChatCompletionRole role, String content, String? name,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage():
+        return $default(_that.role, _that.content, _that.name, _that.toolCalls);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(ChatCompletionRole role, String content, String? name,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.name, _that.toolCalls);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionMessage extends ChatCompletionMessage {
+  _ChatCompletionMessage(
+      {required this.role,
+      required this.content,
+      this.name,
+      @JsonKey(name: 'tool_calls') final List<Map<String, dynamic>>? toolCalls})
+      : _toolCalls = toolCalls,
+        super._();
+  factory _ChatCompletionMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionMessageFromJson(json);
+
+  @override
+  final ChatCompletionRole role;
+  @override
+  final String content;
+  @override
+  final String? name;
+  final List<Map<String, dynamic>>? _toolCalls;
+  @override
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls {
+    final value = _toolCalls;
+    if (value == null) return null;
+    if (_toolCalls is EqualUnmodifiableListView) return _toolCalls;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionMessageCopyWith<_ChatCompletionMessage> get copyWith =>
+      __$ChatCompletionMessageCopyWithImpl<_ChatCompletionMessage>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionMessageToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.name, name) || other.name == name) &&
+            const DeepCollectionEquality()
+                .equals(other._toolCalls, _toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, name,
+      const DeepCollectionEquality().hash(_toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionMessage(role: $role, content: $content, name: $name, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionMessageCopyWith<$Res>
+    implements $ChatCompletionMessageCopyWith<$Res> {
+  factory _$ChatCompletionMessageCopyWith(_ChatCompletionMessage value,
+          $Res Function(_ChatCompletionMessage) _then) =
+      __$ChatCompletionMessageCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {ChatCompletionRole role,
+      String content,
+      String? name,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class __$ChatCompletionMessageCopyWithImpl<$Res>
+    implements _$ChatCompletionMessageCopyWith<$Res> {
+  __$ChatCompletionMessageCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionMessage _self;
+  final $Res Function(_ChatCompletionMessage) _then;
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? role = null,
+    Object? content = null,
+    Object? name = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_ChatCompletionMessage(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionRole,
+      content: null == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: freezed == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self._toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.g.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.g.dart
@@ -1,0 +1,34 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_message.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionMessage _$ChatCompletionMessageFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionMessage(
+      role: $enumDecode(_$ChatCompletionRoleEnumMap, json['role']),
+      content: json['content'] as String,
+      name: json['name'] as String?,
+      toolCalls: (json['tool_calls'] as List<dynamic>?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+    );
+
+Map<String, dynamic> _$ChatCompletionMessageToJson(
+        _ChatCompletionMessage instance) =>
+    <String, dynamic>{
+      'role': _$ChatCompletionRoleEnumMap[instance.role]!,
+      'content': instance.content,
+      'name': instance.name,
+      'tool_calls': instance.toolCalls,
+    };
+
+const _$ChatCompletionRoleEnumMap = {
+  ChatCompletionRole.system: 'system',
+  ChatCompletionRole.user: 'user',
+  ChatCompletionRole.assistant: 'assistant',
+  ChatCompletionRole.tool: 'tool',
+};

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:perplexity_box/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart';
+
+part 'chat_completion_request.freezed.dart';
+part 'chat_completion_request.g.dart';
+
+/// https://docs.perplexity.ai/api-reference/chat-completions-post
+@freezed
+abstract class ChatCompletionRequest with _$ChatCompletionRequest {
+  factory ChatCompletionRequest({
+    required List<ChatCompletionMessage> messages,
+    required String model,
+    @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+    @JsonKey(name: 'max_tokens') int? maxTokens,
+    @JsonKey(name: 'presence_penalty') double? presencePenalty,
+    @JsonKey(name: 'response_format') Map<String, dynamic>? responseFormat,
+    int? seed,
+    List<String>? stop,
+    bool? stream,
+    double? temperature,
+    @JsonKey(name: 'top_p') double? topP,
+    List<Map<String, dynamic>>? tools,
+    @JsonKey(name: 'tool_choice') dynamic toolChoice,
+    bool? logprobs,
+    @JsonKey(name: 'top_logprobs') int? topLogprobs,
+  }) = _ChatCompletionRequest;
+
+  factory ChatCompletionRequest.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionRequestFromJson(json);
+  const ChatCompletionRequest._();
+}

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.freezed.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.freezed.dart
@@ -1,0 +1,766 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_request.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionRequest {
+  List<ChatCompletionMessage> get messages;
+  String get model;
+  @JsonKey(name: 'frequency_penalty')
+  double? get frequencyPenalty;
+  @JsonKey(name: 'max_tokens')
+  int? get maxTokens;
+  @JsonKey(name: 'presence_penalty')
+  double? get presencePenalty;
+  @JsonKey(name: 'response_format')
+  Map<String, dynamic>? get responseFormat;
+  int? get seed;
+  List<String>? get stop;
+  bool? get stream;
+  double? get temperature;
+  @JsonKey(name: 'top_p')
+  double? get topP;
+  List<Map<String, dynamic>>? get tools;
+  @JsonKey(name: 'tool_choice')
+  dynamic get toolChoice;
+  bool? get logprobs;
+  @JsonKey(name: 'top_logprobs')
+  int? get topLogprobs;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionRequestCopyWith<ChatCompletionRequest> get copyWith =>
+      _$ChatCompletionRequestCopyWithImpl<ChatCompletionRequest>(
+          this as ChatCompletionRequest, _$identity);
+
+  /// Serializes this ChatCompletionRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionRequest &&
+            const DeepCollectionEquality().equals(other.messages, messages) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.frequencyPenalty, frequencyPenalty) ||
+                other.frequencyPenalty == frequencyPenalty) &&
+            (identical(other.maxTokens, maxTokens) ||
+                other.maxTokens == maxTokens) &&
+            (identical(other.presencePenalty, presencePenalty) ||
+                other.presencePenalty == presencePenalty) &&
+            const DeepCollectionEquality()
+                .equals(other.responseFormat, responseFormat) &&
+            (identical(other.seed, seed) || other.seed == seed) &&
+            const DeepCollectionEquality().equals(other.stop, stop) &&
+            (identical(other.stream, stream) || other.stream == stream) &&
+            (identical(other.temperature, temperature) ||
+                other.temperature == temperature) &&
+            (identical(other.topP, topP) || other.topP == topP) &&
+            const DeepCollectionEquality().equals(other.tools, tools) &&
+            const DeepCollectionEquality()
+                .equals(other.toolChoice, toolChoice) &&
+            (identical(other.logprobs, logprobs) ||
+                other.logprobs == logprobs) &&
+            (identical(other.topLogprobs, topLogprobs) ||
+                other.topLogprobs == topLogprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(messages),
+      model,
+      frequencyPenalty,
+      maxTokens,
+      presencePenalty,
+      const DeepCollectionEquality().hash(responseFormat),
+      seed,
+      const DeepCollectionEquality().hash(stop),
+      stream,
+      temperature,
+      topP,
+      const DeepCollectionEquality().hash(tools),
+      const DeepCollectionEquality().hash(toolChoice),
+      logprobs,
+      topLogprobs);
+
+  @override
+  String toString() {
+    return 'ChatCompletionRequest(messages: $messages, model: $model, frequencyPenalty: $frequencyPenalty, maxTokens: $maxTokens, presencePenalty: $presencePenalty, responseFormat: $responseFormat, seed: $seed, stop: $stop, stream: $stream, temperature: $temperature, topP: $topP, tools: $tools, toolChoice: $toolChoice, logprobs: $logprobs, topLogprobs: $topLogprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionRequestCopyWith<$Res> {
+  factory $ChatCompletionRequestCopyWith(ChatCompletionRequest value,
+          $Res Function(ChatCompletionRequest) _then) =
+      _$ChatCompletionRequestCopyWithImpl;
+  @useResult
+  $Res call(
+      {List<ChatCompletionMessage> messages,
+      String model,
+      @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+      @JsonKey(name: 'max_tokens') int? maxTokens,
+      @JsonKey(name: 'presence_penalty') double? presencePenalty,
+      @JsonKey(name: 'response_format') Map<String, dynamic>? responseFormat,
+      int? seed,
+      List<String>? stop,
+      bool? stream,
+      double? temperature,
+      @JsonKey(name: 'top_p') double? topP,
+      List<Map<String, dynamic>>? tools,
+      @JsonKey(name: 'tool_choice') dynamic toolChoice,
+      bool? logprobs,
+      @JsonKey(name: 'top_logprobs') int? topLogprobs});
+}
+
+/// @nodoc
+class _$ChatCompletionRequestCopyWithImpl<$Res>
+    implements $ChatCompletionRequestCopyWith<$Res> {
+  _$ChatCompletionRequestCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionRequest _self;
+  final $Res Function(ChatCompletionRequest) _then;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? messages = null,
+    Object? model = null,
+    Object? frequencyPenalty = freezed,
+    Object? maxTokens = freezed,
+    Object? presencePenalty = freezed,
+    Object? responseFormat = freezed,
+    Object? seed = freezed,
+    Object? stop = freezed,
+    Object? stream = freezed,
+    Object? temperature = freezed,
+    Object? topP = freezed,
+    Object? tools = freezed,
+    Object? toolChoice = freezed,
+    Object? logprobs = freezed,
+    Object? topLogprobs = freezed,
+  }) {
+    return _then(_self.copyWith(
+      messages: null == messages
+          ? _self.messages
+          : messages // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionMessage>,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      frequencyPenalty: freezed == frequencyPenalty
+          ? _self.frequencyPenalty
+          : frequencyPenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      maxTokens: freezed == maxTokens
+          ? _self.maxTokens
+          : maxTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      presencePenalty: freezed == presencePenalty
+          ? _self.presencePenalty
+          : presencePenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      responseFormat: freezed == responseFormat
+          ? _self.responseFormat
+          : responseFormat // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+      seed: freezed == seed
+          ? _self.seed
+          : seed // ignore: cast_nullable_to_non_nullable
+              as int?,
+      stop: freezed == stop
+          ? _self.stop
+          : stop // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      stream: freezed == stream
+          ? _self.stream
+          : stream // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      temperature: freezed == temperature
+          ? _self.temperature
+          : temperature // ignore: cast_nullable_to_non_nullable
+              as double?,
+      topP: freezed == topP
+          ? _self.topP
+          : topP // ignore: cast_nullable_to_non_nullable
+              as double?,
+      tools: freezed == tools
+          ? _self.tools
+          : tools // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+      toolChoice: freezed == toolChoice
+          ? _self.toolChoice
+          : toolChoice // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      logprobs: freezed == logprobs
+          ? _self.logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      topLogprobs: freezed == topLogprobs
+          ? _self.topLogprobs
+          : topLogprobs // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionRequest].
+extension ChatCompletionRequestPatterns on ChatCompletionRequest {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionRequest value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionRequest value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionRequest value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionMessage> messages,
+            String model,
+            @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+            @JsonKey(name: 'max_tokens') int? maxTokens,
+            @JsonKey(name: 'presence_penalty') double? presencePenalty,
+            @JsonKey(name: 'response_format')
+            Map<String, dynamic>? responseFormat,
+            int? seed,
+            List<String>? stop,
+            bool? stream,
+            double? temperature,
+            @JsonKey(name: 'top_p') double? topP,
+            List<Map<String, dynamic>>? tools,
+            @JsonKey(name: 'tool_choice') dynamic toolChoice,
+            bool? logprobs,
+            @JsonKey(name: 'top_logprobs') int? topLogprobs)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(
+            _that.messages,
+            _that.model,
+            _that.frequencyPenalty,
+            _that.maxTokens,
+            _that.presencePenalty,
+            _that.responseFormat,
+            _that.seed,
+            _that.stop,
+            _that.stream,
+            _that.temperature,
+            _that.topP,
+            _that.tools,
+            _that.toolChoice,
+            _that.logprobs,
+            _that.topLogprobs);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionMessage> messages,
+            String model,
+            @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+            @JsonKey(name: 'max_tokens') int? maxTokens,
+            @JsonKey(name: 'presence_penalty') double? presencePenalty,
+            @JsonKey(name: 'response_format')
+            Map<String, dynamic>? responseFormat,
+            int? seed,
+            List<String>? stop,
+            bool? stream,
+            double? temperature,
+            @JsonKey(name: 'top_p') double? topP,
+            List<Map<String, dynamic>>? tools,
+            @JsonKey(name: 'tool_choice') dynamic toolChoice,
+            bool? logprobs,
+            @JsonKey(name: 'top_logprobs') int? topLogprobs)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest():
+        return $default(
+            _that.messages,
+            _that.model,
+            _that.frequencyPenalty,
+            _that.maxTokens,
+            _that.presencePenalty,
+            _that.responseFormat,
+            _that.seed,
+            _that.stop,
+            _that.stream,
+            _that.temperature,
+            _that.topP,
+            _that.tools,
+            _that.toolChoice,
+            _that.logprobs,
+            _that.topLogprobs);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            List<ChatCompletionMessage> messages,
+            String model,
+            @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+            @JsonKey(name: 'max_tokens') int? maxTokens,
+            @JsonKey(name: 'presence_penalty') double? presencePenalty,
+            @JsonKey(name: 'response_format')
+            Map<String, dynamic>? responseFormat,
+            int? seed,
+            List<String>? stop,
+            bool? stream,
+            double? temperature,
+            @JsonKey(name: 'top_p') double? topP,
+            List<Map<String, dynamic>>? tools,
+            @JsonKey(name: 'tool_choice') dynamic toolChoice,
+            bool? logprobs,
+            @JsonKey(name: 'top_logprobs') int? topLogprobs)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(
+            _that.messages,
+            _that.model,
+            _that.frequencyPenalty,
+            _that.maxTokens,
+            _that.presencePenalty,
+            _that.responseFormat,
+            _that.seed,
+            _that.stop,
+            _that.stream,
+            _that.temperature,
+            _that.topP,
+            _that.tools,
+            _that.toolChoice,
+            _that.logprobs,
+            _that.topLogprobs);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionRequest extends ChatCompletionRequest {
+  _ChatCompletionRequest(
+      {required final List<ChatCompletionMessage> messages,
+      required this.model,
+      @JsonKey(name: 'frequency_penalty') this.frequencyPenalty,
+      @JsonKey(name: 'max_tokens') this.maxTokens,
+      @JsonKey(name: 'presence_penalty') this.presencePenalty,
+      @JsonKey(name: 'response_format')
+      final Map<String, dynamic>? responseFormat,
+      this.seed,
+      final List<String>? stop,
+      this.stream,
+      this.temperature,
+      @JsonKey(name: 'top_p') this.topP,
+      final List<Map<String, dynamic>>? tools,
+      @JsonKey(name: 'tool_choice') this.toolChoice,
+      this.logprobs,
+      @JsonKey(name: 'top_logprobs') this.topLogprobs})
+      : _messages = messages,
+        _responseFormat = responseFormat,
+        _stop = stop,
+        _tools = tools,
+        super._();
+  factory _ChatCompletionRequest.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionRequestFromJson(json);
+
+  final List<ChatCompletionMessage> _messages;
+  @override
+  List<ChatCompletionMessage> get messages {
+    if (_messages is EqualUnmodifiableListView) return _messages;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_messages);
+  }
+
+  @override
+  final String model;
+  @override
+  @JsonKey(name: 'frequency_penalty')
+  final double? frequencyPenalty;
+  @override
+  @JsonKey(name: 'max_tokens')
+  final int? maxTokens;
+  @override
+  @JsonKey(name: 'presence_penalty')
+  final double? presencePenalty;
+  final Map<String, dynamic>? _responseFormat;
+  @override
+  @JsonKey(name: 'response_format')
+  Map<String, dynamic>? get responseFormat {
+    final value = _responseFormat;
+    if (value == null) return null;
+    if (_responseFormat is EqualUnmodifiableMapView) return _responseFormat;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(value);
+  }
+
+  @override
+  final int? seed;
+  final List<String>? _stop;
+  @override
+  List<String>? get stop {
+    final value = _stop;
+    if (value == null) return null;
+    if (_stop is EqualUnmodifiableListView) return _stop;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  final bool? stream;
+  @override
+  final double? temperature;
+  @override
+  @JsonKey(name: 'top_p')
+  final double? topP;
+  final List<Map<String, dynamic>>? _tools;
+  @override
+  List<Map<String, dynamic>>? get tools {
+    final value = _tools;
+    if (value == null) return null;
+    if (_tools is EqualUnmodifiableListView) return _tools;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  @JsonKey(name: 'tool_choice')
+  final dynamic toolChoice;
+  @override
+  final bool? logprobs;
+  @override
+  @JsonKey(name: 'top_logprobs')
+  final int? topLogprobs;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionRequestCopyWith<_ChatCompletionRequest> get copyWith =>
+      __$ChatCompletionRequestCopyWithImpl<_ChatCompletionRequest>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionRequestToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionRequest &&
+            const DeepCollectionEquality().equals(other._messages, _messages) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.frequencyPenalty, frequencyPenalty) ||
+                other.frequencyPenalty == frequencyPenalty) &&
+            (identical(other.maxTokens, maxTokens) ||
+                other.maxTokens == maxTokens) &&
+            (identical(other.presencePenalty, presencePenalty) ||
+                other.presencePenalty == presencePenalty) &&
+            const DeepCollectionEquality()
+                .equals(other._responseFormat, _responseFormat) &&
+            (identical(other.seed, seed) || other.seed == seed) &&
+            const DeepCollectionEquality().equals(other._stop, _stop) &&
+            (identical(other.stream, stream) || other.stream == stream) &&
+            (identical(other.temperature, temperature) ||
+                other.temperature == temperature) &&
+            (identical(other.topP, topP) || other.topP == topP) &&
+            const DeepCollectionEquality().equals(other._tools, _tools) &&
+            const DeepCollectionEquality()
+                .equals(other.toolChoice, toolChoice) &&
+            (identical(other.logprobs, logprobs) ||
+                other.logprobs == logprobs) &&
+            (identical(other.topLogprobs, topLogprobs) ||
+                other.topLogprobs == topLogprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_messages),
+      model,
+      frequencyPenalty,
+      maxTokens,
+      presencePenalty,
+      const DeepCollectionEquality().hash(_responseFormat),
+      seed,
+      const DeepCollectionEquality().hash(_stop),
+      stream,
+      temperature,
+      topP,
+      const DeepCollectionEquality().hash(_tools),
+      const DeepCollectionEquality().hash(toolChoice),
+      logprobs,
+      topLogprobs);
+
+  @override
+  String toString() {
+    return 'ChatCompletionRequest(messages: $messages, model: $model, frequencyPenalty: $frequencyPenalty, maxTokens: $maxTokens, presencePenalty: $presencePenalty, responseFormat: $responseFormat, seed: $seed, stop: $stop, stream: $stream, temperature: $temperature, topP: $topP, tools: $tools, toolChoice: $toolChoice, logprobs: $logprobs, topLogprobs: $topLogprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionRequestCopyWith<$Res>
+    implements $ChatCompletionRequestCopyWith<$Res> {
+  factory _$ChatCompletionRequestCopyWith(_ChatCompletionRequest value,
+          $Res Function(_ChatCompletionRequest) _then) =
+      __$ChatCompletionRequestCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {List<ChatCompletionMessage> messages,
+      String model,
+      @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+      @JsonKey(name: 'max_tokens') int? maxTokens,
+      @JsonKey(name: 'presence_penalty') double? presencePenalty,
+      @JsonKey(name: 'response_format') Map<String, dynamic>? responseFormat,
+      int? seed,
+      List<String>? stop,
+      bool? stream,
+      double? temperature,
+      @JsonKey(name: 'top_p') double? topP,
+      List<Map<String, dynamic>>? tools,
+      @JsonKey(name: 'tool_choice') dynamic toolChoice,
+      bool? logprobs,
+      @JsonKey(name: 'top_logprobs') int? topLogprobs});
+}
+
+/// @nodoc
+class __$ChatCompletionRequestCopyWithImpl<$Res>
+    implements _$ChatCompletionRequestCopyWith<$Res> {
+  __$ChatCompletionRequestCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionRequest _self;
+  final $Res Function(_ChatCompletionRequest) _then;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? messages = null,
+    Object? model = null,
+    Object? frequencyPenalty = freezed,
+    Object? maxTokens = freezed,
+    Object? presencePenalty = freezed,
+    Object? responseFormat = freezed,
+    Object? seed = freezed,
+    Object? stop = freezed,
+    Object? stream = freezed,
+    Object? temperature = freezed,
+    Object? topP = freezed,
+    Object? tools = freezed,
+    Object? toolChoice = freezed,
+    Object? logprobs = freezed,
+    Object? topLogprobs = freezed,
+  }) {
+    return _then(_ChatCompletionRequest(
+      messages: null == messages
+          ? _self._messages
+          : messages // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionMessage>,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      frequencyPenalty: freezed == frequencyPenalty
+          ? _self.frequencyPenalty
+          : frequencyPenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      maxTokens: freezed == maxTokens
+          ? _self.maxTokens
+          : maxTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      presencePenalty: freezed == presencePenalty
+          ? _self.presencePenalty
+          : presencePenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      responseFormat: freezed == responseFormat
+          ? _self._responseFormat
+          : responseFormat // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+      seed: freezed == seed
+          ? _self.seed
+          : seed // ignore: cast_nullable_to_non_nullable
+              as int?,
+      stop: freezed == stop
+          ? _self._stop
+          : stop // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      stream: freezed == stream
+          ? _self.stream
+          : stream // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      temperature: freezed == temperature
+          ? _self.temperature
+          : temperature // ignore: cast_nullable_to_non_nullable
+              as double?,
+      topP: freezed == topP
+          ? _self.topP
+          : topP // ignore: cast_nullable_to_non_nullable
+              as double?,
+      tools: freezed == tools
+          ? _self._tools
+          : tools // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+      toolChoice: freezed == toolChoice
+          ? _self.toolChoice
+          : toolChoice // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      logprobs: freezed == logprobs
+          ? _self.logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      topLogprobs: freezed == topLogprobs
+          ? _self.topLogprobs
+          : topLogprobs // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.g.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.g.dart
@@ -1,0 +1,51 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionRequest _$ChatCompletionRequestFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionRequest(
+      messages: (json['messages'] as List<dynamic>)
+          .map((e) => ChatCompletionMessage.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      model: json['model'] as String,
+      frequencyPenalty: (json['frequency_penalty'] as num?)?.toDouble(),
+      maxTokens: (json['max_tokens'] as num?)?.toInt(),
+      presencePenalty: (json['presence_penalty'] as num?)?.toDouble(),
+      responseFormat: json['response_format'] as Map<String, dynamic>?,
+      seed: (json['seed'] as num?)?.toInt(),
+      stop: (json['stop'] as List<dynamic>?)?.map((e) => e as String).toList(),
+      stream: json['stream'] as bool?,
+      temperature: (json['temperature'] as num?)?.toDouble(),
+      topP: (json['top_p'] as num?)?.toDouble(),
+      tools: (json['tools'] as List<dynamic>?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+      toolChoice: json['tool_choice'],
+      logprobs: json['logprobs'] as bool?,
+      topLogprobs: (json['top_logprobs'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$ChatCompletionRequestToJson(
+        _ChatCompletionRequest instance) =>
+    <String, dynamic>{
+      'messages': instance.messages,
+      'model': instance.model,
+      'frequency_penalty': instance.frequencyPenalty,
+      'max_tokens': instance.maxTokens,
+      'presence_penalty': instance.presencePenalty,
+      'response_format': instance.responseFormat,
+      'seed': instance.seed,
+      'stop': instance.stop,
+      'stream': instance.stream,
+      'temperature': instance.temperature,
+      'top_p': instance.topP,
+      'tools': instance.tools,
+      'tool_choice': instance.toolChoice,
+      'logprobs': instance.logprobs,
+      'top_logprobs': instance.topLogprobs,
+    };

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:perplexity_box/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart';
+import 'package:perplexity_box/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart';
+
+part 'chat_completion_response.freezed.dart';
+part 'chat_completion_response.g.dart';
+
+/// https://docs.perplexity.ai/api-reference/chat-completions-post
+@freezed
+abstract class ChatCompletionResponse with _$ChatCompletionResponse {
+  factory ChatCompletionResponse({
+    required List<ChatCompletionResponseChoice> choices,
+    required int created,
+    required String id,
+    required String model,
+    required String object,
+    @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+    ChatCompletionResponseUsage? usage,
+  }) = _ChatCompletionResponse;
+
+  factory ChatCompletionResponse.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseFromJson(json);
+  const ChatCompletionResponse._();
+}

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.freezed.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.freezed.dart
@@ -1,0 +1,516 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponse {
+  List<ChatCompletionResponseChoice> get choices;
+  int get created;
+  String get id;
+  String get model;
+  String get object;
+  @JsonKey(name: 'system_fingerprint')
+  String? get systemFingerprint;
+  ChatCompletionResponseUsage? get usage;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseCopyWith<ChatCompletionResponse> get copyWith =>
+      _$ChatCompletionResponseCopyWithImpl<ChatCompletionResponse>(
+          this as ChatCompletionResponse, _$identity);
+
+  /// Serializes this ChatCompletionResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponse &&
+            const DeepCollectionEquality().equals(other.choices, choices) &&
+            (identical(other.created, created) || other.created == created) &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.systemFingerprint, systemFingerprint) ||
+                other.systemFingerprint == systemFingerprint) &&
+            (identical(other.usage, usage) || other.usage == usage));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(choices),
+      created,
+      id,
+      model,
+      object,
+      systemFingerprint,
+      usage);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponse(choices: $choices, created: $created, id: $id, model: $model, object: $object, systemFingerprint: $systemFingerprint, usage: $usage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseCopyWith<$Res> {
+  factory $ChatCompletionResponseCopyWith(ChatCompletionResponse value,
+          $Res Function(ChatCompletionResponse) _then) =
+      _$ChatCompletionResponseCopyWithImpl;
+  @useResult
+  $Res call(
+      {List<ChatCompletionResponseChoice> choices,
+      int created,
+      String id,
+      String model,
+      String object,
+      @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+      ChatCompletionResponseUsage? usage});
+
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage;
+}
+
+/// @nodoc
+class _$ChatCompletionResponseCopyWithImpl<$Res>
+    implements $ChatCompletionResponseCopyWith<$Res> {
+  _$ChatCompletionResponseCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponse _self;
+  final $Res Function(ChatCompletionResponse) _then;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? choices = null,
+    Object? created = null,
+    Object? id = null,
+    Object? model = null,
+    Object? object = null,
+    Object? systemFingerprint = freezed,
+    Object? usage = freezed,
+  }) {
+    return _then(_self.copyWith(
+      choices: null == choices
+          ? _self.choices
+          : choices // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionResponseChoice>,
+      created: null == created
+          ? _self.created
+          : created // ignore: cast_nullable_to_non_nullable
+              as int,
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      systemFingerprint: freezed == systemFingerprint
+          ? _self.systemFingerprint
+          : systemFingerprint // ignore: cast_nullable_to_non_nullable
+              as String?,
+      usage: freezed == usage
+          ? _self.usage
+          : usage // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsage?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage {
+    if (_self.usage == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCopyWith<$Res>(_self.usage!, (value) {
+      return _then(_self.copyWith(usage: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponse].
+extension ChatCompletionResponsePatterns on ChatCompletionResponse {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponse value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponse value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponse value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionResponseChoice> choices,
+            int created,
+            String id,
+            String model,
+            String object,
+            @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+            ChatCompletionResponseUsage? usage)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that.choices, _that.created, _that.id, _that.model,
+            _that.object, _that.systemFingerprint, _that.usage);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionResponseChoice> choices,
+            int created,
+            String id,
+            String model,
+            String object,
+            @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+            ChatCompletionResponseUsage? usage)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse():
+        return $default(_that.choices, _that.created, _that.id, _that.model,
+            _that.object, _that.systemFingerprint, _that.usage);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            List<ChatCompletionResponseChoice> choices,
+            int created,
+            String id,
+            String model,
+            String object,
+            @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+            ChatCompletionResponseUsage? usage)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that.choices, _that.created, _that.id, _that.model,
+            _that.object, _that.systemFingerprint, _that.usage);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponse extends ChatCompletionResponse {
+  _ChatCompletionResponse(
+      {required final List<ChatCompletionResponseChoice> choices,
+      required this.created,
+      required this.id,
+      required this.model,
+      required this.object,
+      @JsonKey(name: 'system_fingerprint') this.systemFingerprint,
+      this.usage})
+      : _choices = choices,
+        super._();
+  factory _ChatCompletionResponse.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseFromJson(json);
+
+  final List<ChatCompletionResponseChoice> _choices;
+  @override
+  List<ChatCompletionResponseChoice> get choices {
+    if (_choices is EqualUnmodifiableListView) return _choices;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_choices);
+  }
+
+  @override
+  final int created;
+  @override
+  final String id;
+  @override
+  final String model;
+  @override
+  final String object;
+  @override
+  @JsonKey(name: 'system_fingerprint')
+  final String? systemFingerprint;
+  @override
+  final ChatCompletionResponseUsage? usage;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseCopyWith<_ChatCompletionResponse> get copyWith =>
+      __$ChatCompletionResponseCopyWithImpl<_ChatCompletionResponse>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponse &&
+            const DeepCollectionEquality().equals(other._choices, _choices) &&
+            (identical(other.created, created) || other.created == created) &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.systemFingerprint, systemFingerprint) ||
+                other.systemFingerprint == systemFingerprint) &&
+            (identical(other.usage, usage) || other.usage == usage));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_choices),
+      created,
+      id,
+      model,
+      object,
+      systemFingerprint,
+      usage);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponse(choices: $choices, created: $created, id: $id, model: $model, object: $object, systemFingerprint: $systemFingerprint, usage: $usage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseCopyWith<$Res>
+    implements $ChatCompletionResponseCopyWith<$Res> {
+  factory _$ChatCompletionResponseCopyWith(_ChatCompletionResponse value,
+          $Res Function(_ChatCompletionResponse) _then) =
+      __$ChatCompletionResponseCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {List<ChatCompletionResponseChoice> choices,
+      int created,
+      String id,
+      String model,
+      String object,
+      @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+      ChatCompletionResponseUsage? usage});
+
+  @override
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage;
+}
+
+/// @nodoc
+class __$ChatCompletionResponseCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseCopyWith<$Res> {
+  __$ChatCompletionResponseCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponse _self;
+  final $Res Function(_ChatCompletionResponse) _then;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? choices = null,
+    Object? created = null,
+    Object? id = null,
+    Object? model = null,
+    Object? object = null,
+    Object? systemFingerprint = freezed,
+    Object? usage = freezed,
+  }) {
+    return _then(_ChatCompletionResponse(
+      choices: null == choices
+          ? _self._choices
+          : choices // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionResponseChoice>,
+      created: null == created
+          ? _self.created
+          : created // ignore: cast_nullable_to_non_nullable
+              as int,
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      systemFingerprint: freezed == systemFingerprint
+          ? _self.systemFingerprint
+          : systemFingerprint // ignore: cast_nullable_to_non_nullable
+              as String?,
+      usage: freezed == usage
+          ? _self.usage
+          : usage // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsage?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage {
+    if (_self.usage == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCopyWith<$Res>(_self.usage!, (value) {
+      return _then(_self.copyWith(usage: value));
+    });
+  }
+}
+
+// dart format on

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.g.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponse _$ChatCompletionResponseFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponse(
+      choices: (json['choices'] as List<dynamic>)
+          .map((e) =>
+              ChatCompletionResponseChoice.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      created: (json['created'] as num).toInt(),
+      id: json['id'] as String,
+      model: json['model'] as String,
+      object: json['object'] as String,
+      systemFingerprint: json['system_fingerprint'] as String?,
+      usage: json['usage'] == null
+          ? null
+          : ChatCompletionResponseUsage.fromJson(
+              json['usage'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseToJson(
+        _ChatCompletionResponse instance) =>
+    <String, dynamic>{
+      'choices': instance.choices,
+      'created': instance.created,
+      'id': instance.id,
+      'model': instance.model,
+      'object': instance.object,
+      'system_fingerprint': instance.systemFingerprint,
+      'usage': instance.usage,
+    };

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:perplexity_box/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart';
+
+part 'chat_completion_response_choice.freezed.dart';
+part 'chat_completion_response_choice.g.dart';
+
+@freezed
+abstract class ChatCompletionResponseChoice
+    with _$ChatCompletionResponseChoice {
+  factory ChatCompletionResponseChoice({
+    required int index,
+    required ChatCompletionResponseMessage message,
+    @JsonKey(name: 'finish_reason') String? finishReason,
+    Map<String, dynamic>? logprobs,
+  }) = _ChatCompletionResponseChoice;
+
+  factory ChatCompletionResponseChoice.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseChoiceFromJson(json);
+  const ChatCompletionResponseChoice._();
+}

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.freezed.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.freezed.dart
@@ -1,0 +1,435 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response_choice.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponseChoice {
+  int get index;
+  ChatCompletionResponseMessage get message;
+  @JsonKey(name: 'finish_reason')
+  String? get finishReason;
+  Map<String, dynamic>? get logprobs;
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseChoiceCopyWith<ChatCompletionResponseChoice>
+      get copyWith => _$ChatCompletionResponseChoiceCopyWithImpl<
+              ChatCompletionResponseChoice>(
+          this as ChatCompletionResponseChoice, _$identity);
+
+  /// Serializes this ChatCompletionResponseChoice to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseChoice &&
+            (identical(other.index, index) || other.index == index) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.finishReason, finishReason) ||
+                other.finishReason == finishReason) &&
+            const DeepCollectionEquality().equals(other.logprobs, logprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, index, message, finishReason,
+      const DeepCollectionEquality().hash(logprobs));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseChoice(index: $index, message: $message, finishReason: $finishReason, logprobs: $logprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseChoiceCopyWith<$Res> {
+  factory $ChatCompletionResponseChoiceCopyWith(
+          ChatCompletionResponseChoice value,
+          $Res Function(ChatCompletionResponseChoice) _then) =
+      _$ChatCompletionResponseChoiceCopyWithImpl;
+  @useResult
+  $Res call(
+      {int index,
+      ChatCompletionResponseMessage message,
+      @JsonKey(name: 'finish_reason') String? finishReason,
+      Map<String, dynamic>? logprobs});
+
+  $ChatCompletionResponseMessageCopyWith<$Res> get message;
+}
+
+/// @nodoc
+class _$ChatCompletionResponseChoiceCopyWithImpl<$Res>
+    implements $ChatCompletionResponseChoiceCopyWith<$Res> {
+  _$ChatCompletionResponseChoiceCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponseChoice _self;
+  final $Res Function(ChatCompletionResponseChoice) _then;
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? index = null,
+    Object? message = null,
+    Object? finishReason = freezed,
+    Object? logprobs = freezed,
+  }) {
+    return _then(_self.copyWith(
+      index: null == index
+          ? _self.index
+          : index // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseMessage,
+      finishReason: freezed == finishReason
+          ? _self.finishReason
+          : finishReason // ignore: cast_nullable_to_non_nullable
+              as String?,
+      logprobs: freezed == logprobs
+          ? _self.logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseMessageCopyWith<$Res> get message {
+    return $ChatCompletionResponseMessageCopyWith<$Res>(_self.message, (value) {
+      return _then(_self.copyWith(message: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseChoice].
+extension ChatCompletionResponseChoicePatterns on ChatCompletionResponseChoice {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseChoice value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseChoice value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponseChoice value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            int index,
+            ChatCompletionResponseMessage message,
+            @JsonKey(name: 'finish_reason') String? finishReason,
+            Map<String, dynamic>? logprobs)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(
+            _that.index, _that.message, _that.finishReason, _that.logprobs);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            int index,
+            ChatCompletionResponseMessage message,
+            @JsonKey(name: 'finish_reason') String? finishReason,
+            Map<String, dynamic>? logprobs)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice():
+        return $default(
+            _that.index, _that.message, _that.finishReason, _that.logprobs);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            int index,
+            ChatCompletionResponseMessage message,
+            @JsonKey(name: 'finish_reason') String? finishReason,
+            Map<String, dynamic>? logprobs)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(
+            _that.index, _that.message, _that.finishReason, _that.logprobs);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseChoice extends ChatCompletionResponseChoice {
+  _ChatCompletionResponseChoice(
+      {required this.index,
+      required this.message,
+      @JsonKey(name: 'finish_reason') this.finishReason,
+      final Map<String, dynamic>? logprobs})
+      : _logprobs = logprobs,
+        super._();
+  factory _ChatCompletionResponseChoice.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseChoiceFromJson(json);
+
+  @override
+  final int index;
+  @override
+  final ChatCompletionResponseMessage message;
+  @override
+  @JsonKey(name: 'finish_reason')
+  final String? finishReason;
+  final Map<String, dynamic>? _logprobs;
+  @override
+  Map<String, dynamic>? get logprobs {
+    final value = _logprobs;
+    if (value == null) return null;
+    if (_logprobs is EqualUnmodifiableMapView) return _logprobs;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(value);
+  }
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseChoiceCopyWith<_ChatCompletionResponseChoice>
+      get copyWith => __$ChatCompletionResponseChoiceCopyWithImpl<
+          _ChatCompletionResponseChoice>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseChoiceToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseChoice &&
+            (identical(other.index, index) || other.index == index) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.finishReason, finishReason) ||
+                other.finishReason == finishReason) &&
+            const DeepCollectionEquality().equals(other._logprobs, _logprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, index, message, finishReason,
+      const DeepCollectionEquality().hash(_logprobs));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseChoice(index: $index, message: $message, finishReason: $finishReason, logprobs: $logprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseChoiceCopyWith<$Res>
+    implements $ChatCompletionResponseChoiceCopyWith<$Res> {
+  factory _$ChatCompletionResponseChoiceCopyWith(
+          _ChatCompletionResponseChoice value,
+          $Res Function(_ChatCompletionResponseChoice) _then) =
+      __$ChatCompletionResponseChoiceCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {int index,
+      ChatCompletionResponseMessage message,
+      @JsonKey(name: 'finish_reason') String? finishReason,
+      Map<String, dynamic>? logprobs});
+
+  @override
+  $ChatCompletionResponseMessageCopyWith<$Res> get message;
+}
+
+/// @nodoc
+class __$ChatCompletionResponseChoiceCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseChoiceCopyWith<$Res> {
+  __$ChatCompletionResponseChoiceCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponseChoice _self;
+  final $Res Function(_ChatCompletionResponseChoice) _then;
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? index = null,
+    Object? message = null,
+    Object? finishReason = freezed,
+    Object? logprobs = freezed,
+  }) {
+    return _then(_ChatCompletionResponseChoice(
+      index: null == index
+          ? _self.index
+          : index // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseMessage,
+      finishReason: freezed == finishReason
+          ? _self.finishReason
+          : finishReason // ignore: cast_nullable_to_non_nullable
+              as String?,
+      logprobs: freezed == logprobs
+          ? _self._logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseMessageCopyWith<$Res> get message {
+    return $ChatCompletionResponseMessageCopyWith<$Res>(_self.message, (value) {
+      return _then(_self.copyWith(message: value));
+    });
+  }
+}
+
+// dart format on

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.g.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response_choice.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponseChoice _$ChatCompletionResponseChoiceFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponseChoice(
+      index: (json['index'] as num).toInt(),
+      message: ChatCompletionResponseMessage.fromJson(
+          json['message'] as Map<String, dynamic>),
+      finishReason: json['finish_reason'] as String?,
+      logprobs: json['logprobs'] as Map<String, dynamic>?,
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseChoiceToJson(
+        _ChatCompletionResponseChoice instance) =>
+    <String, dynamic>{
+      'index': instance.index,
+      'message': instance.message,
+      'finish_reason': instance.finishReason,
+      'logprobs': instance.logprobs,
+    };

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'chat_completion_response_message.freezed.dart';
+part 'chat_completion_response_message.g.dart';
+
+@freezed
+abstract class ChatCompletionResponseMessage
+    with _$ChatCompletionResponseMessage {
+  factory ChatCompletionResponseMessage({
+    required String role,
+    String? content,
+    @JsonKey(name: 'reasoning_content') String? reasoningContent,
+    String? refusal,
+    @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls,
+  }) = _ChatCompletionResponseMessage;
+
+  factory ChatCompletionResponseMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseMessageFromJson(json);
+  const ChatCompletionResponseMessage._();
+}

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.freezed.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.freezed.dart
@@ -1,0 +1,435 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response_message.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponseMessage {
+  String get role;
+  String? get content;
+  @JsonKey(name: 'reasoning_content')
+  String? get reasoningContent;
+  String? get refusal;
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls;
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseMessageCopyWith<ChatCompletionResponseMessage>
+      get copyWith => _$ChatCompletionResponseMessageCopyWithImpl<
+              ChatCompletionResponseMessage>(
+          this as ChatCompletionResponseMessage, _$identity);
+
+  /// Serializes this ChatCompletionResponseMessage to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.reasoningContent, reasoningContent) ||
+                other.reasoningContent == reasoningContent) &&
+            (identical(other.refusal, refusal) || other.refusal == refusal) &&
+            const DeepCollectionEquality().equals(other.toolCalls, toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, reasoningContent,
+      refusal, const DeepCollectionEquality().hash(toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseMessage(role: $role, content: $content, reasoningContent: $reasoningContent, refusal: $refusal, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseMessageCopyWith<$Res> {
+  factory $ChatCompletionResponseMessageCopyWith(
+          ChatCompletionResponseMessage value,
+          $Res Function(ChatCompletionResponseMessage) _then) =
+      _$ChatCompletionResponseMessageCopyWithImpl;
+  @useResult
+  $Res call(
+      {String role,
+      String? content,
+      @JsonKey(name: 'reasoning_content') String? reasoningContent,
+      String? refusal,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class _$ChatCompletionResponseMessageCopyWithImpl<$Res>
+    implements $ChatCompletionResponseMessageCopyWith<$Res> {
+  _$ChatCompletionResponseMessageCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponseMessage _self;
+  final $Res Function(ChatCompletionResponseMessage) _then;
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? role = null,
+    Object? content = freezed,
+    Object? reasoningContent = freezed,
+    Object? refusal = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_self.copyWith(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: freezed == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String?,
+      reasoningContent: freezed == reasoningContent
+          ? _self.reasoningContent
+          : reasoningContent // ignore: cast_nullable_to_non_nullable
+              as String?,
+      refusal: freezed == refusal
+          ? _self.refusal
+          : refusal // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self.toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseMessage].
+extension ChatCompletionResponseMessagePatterns
+    on ChatCompletionResponseMessage {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseMessage value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseMessage value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponseMessage value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String role,
+            String? content,
+            @JsonKey(name: 'reasoning_content') String? reasoningContent,
+            String? refusal,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.reasoningContent,
+            _that.refusal, _that.toolCalls);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String role,
+            String? content,
+            @JsonKey(name: 'reasoning_content') String? reasoningContent,
+            String? refusal,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage():
+        return $default(_that.role, _that.content, _that.reasoningContent,
+            _that.refusal, _that.toolCalls);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String role,
+            String? content,
+            @JsonKey(name: 'reasoning_content') String? reasoningContent,
+            String? refusal,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.reasoningContent,
+            _that.refusal, _that.toolCalls);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseMessage extends ChatCompletionResponseMessage {
+  _ChatCompletionResponseMessage(
+      {required this.role,
+      this.content,
+      @JsonKey(name: 'reasoning_content') this.reasoningContent,
+      this.refusal,
+      @JsonKey(name: 'tool_calls') final List<Map<String, dynamic>>? toolCalls})
+      : _toolCalls = toolCalls,
+        super._();
+  factory _ChatCompletionResponseMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseMessageFromJson(json);
+
+  @override
+  final String role;
+  @override
+  final String? content;
+  @override
+  @JsonKey(name: 'reasoning_content')
+  final String? reasoningContent;
+  @override
+  final String? refusal;
+  final List<Map<String, dynamic>>? _toolCalls;
+  @override
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls {
+    final value = _toolCalls;
+    if (value == null) return null;
+    if (_toolCalls is EqualUnmodifiableListView) return _toolCalls;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseMessageCopyWith<_ChatCompletionResponseMessage>
+      get copyWith => __$ChatCompletionResponseMessageCopyWithImpl<
+          _ChatCompletionResponseMessage>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseMessageToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.reasoningContent, reasoningContent) ||
+                other.reasoningContent == reasoningContent) &&
+            (identical(other.refusal, refusal) || other.refusal == refusal) &&
+            const DeepCollectionEquality()
+                .equals(other._toolCalls, _toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, reasoningContent,
+      refusal, const DeepCollectionEquality().hash(_toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseMessage(role: $role, content: $content, reasoningContent: $reasoningContent, refusal: $refusal, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseMessageCopyWith<$Res>
+    implements $ChatCompletionResponseMessageCopyWith<$Res> {
+  factory _$ChatCompletionResponseMessageCopyWith(
+          _ChatCompletionResponseMessage value,
+          $Res Function(_ChatCompletionResponseMessage) _then) =
+      __$ChatCompletionResponseMessageCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String role,
+      String? content,
+      @JsonKey(name: 'reasoning_content') String? reasoningContent,
+      String? refusal,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class __$ChatCompletionResponseMessageCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseMessageCopyWith<$Res> {
+  __$ChatCompletionResponseMessageCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponseMessage _self;
+  final $Res Function(_ChatCompletionResponseMessage) _then;
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? role = null,
+    Object? content = freezed,
+    Object? reasoningContent = freezed,
+    Object? refusal = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_ChatCompletionResponseMessage(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: freezed == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String?,
+      reasoningContent: freezed == reasoningContent
+          ? _self.reasoningContent
+          : reasoningContent // ignore: cast_nullable_to_non_nullable
+              as String?,
+      refusal: freezed == refusal
+          ? _self.refusal
+          : refusal // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self._toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.g.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response_message.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponseMessage _$ChatCompletionResponseMessageFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponseMessage(
+      role: json['role'] as String,
+      content: json['content'] as String?,
+      reasoningContent: json['reasoning_content'] as String?,
+      refusal: json['refusal'] as String?,
+      toolCalls: (json['tool_calls'] as List<dynamic>?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseMessageToJson(
+        _ChatCompletionResponseMessage instance) =>
+    <String, dynamic>{
+      'role': instance.role,
+      'content': instance.content,
+      'reasoning_content': instance.reasoningContent,
+      'refusal': instance.refusal,
+      'tool_calls': instance.toolCalls,
+    };

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart
@@ -1,0 +1,35 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'chat_completion_response_usage.freezed.dart';
+part 'chat_completion_response_usage.g.dart';
+
+@freezed
+abstract class ChatCompletionResponseUsage with _$ChatCompletionResponseUsage {
+  factory ChatCompletionResponseUsage({
+    @JsonKey(name: 'completion_tokens') required int completionTokens,
+    @JsonKey(name: 'prompt_tokens') required int promptTokens,
+    @JsonKey(name: 'total_tokens') required int totalTokens,
+    @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+    @JsonKey(name: 'prompt_cache_miss_tokens') int? promptCacheMissTokens,
+    @JsonKey(name: 'completion_tokens_details')
+    ChatCompletionResponseUsageCompletionTokensDetails? completionTokensDetails,
+  }) = _ChatCompletionResponseUsage;
+
+  factory ChatCompletionResponseUsage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseUsageFromJson(json);
+  const ChatCompletionResponseUsage._();
+}
+
+@freezed
+abstract class ChatCompletionResponseUsageCompletionTokensDetails
+    with _$ChatCompletionResponseUsageCompletionTokensDetails {
+  factory ChatCompletionResponseUsageCompletionTokensDetails({
+    @JsonKey(name: 'reasoning_tokens') required int reasoningTokens,
+  }) = _ChatCompletionResponseUsageCompletionTokensDetails;
+
+  factory ChatCompletionResponseUsageCompletionTokensDetails.fromJson(
+    Map<String, dynamic> json,
+  ) =>
+      _$ChatCompletionResponseUsageCompletionTokensDetailsFromJson(json);
+  const ChatCompletionResponseUsageCompletionTokensDetails._();
+}

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.freezed.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.freezed.dart
@@ -1,0 +1,888 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response_usage.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponseUsage {
+  @JsonKey(name: 'completion_tokens')
+  int get completionTokens;
+  @JsonKey(name: 'prompt_tokens')
+  int get promptTokens;
+  @JsonKey(name: 'total_tokens')
+  int get totalTokens;
+  @JsonKey(name: 'prompt_cache_hit_tokens')
+  int? get promptCacheHitTokens;
+  @JsonKey(name: 'prompt_cache_miss_tokens')
+  int? get promptCacheMissTokens;
+  @JsonKey(name: 'completion_tokens_details')
+  ChatCompletionResponseUsageCompletionTokensDetails?
+      get completionTokensDetails;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCopyWith<ChatCompletionResponseUsage>
+      get copyWith => _$ChatCompletionResponseUsageCopyWithImpl<
+              ChatCompletionResponseUsage>(
+          this as ChatCompletionResponseUsage, _$identity);
+
+  /// Serializes this ChatCompletionResponseUsage to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseUsage &&
+            (identical(other.completionTokens, completionTokens) ||
+                other.completionTokens == completionTokens) &&
+            (identical(other.promptTokens, promptTokens) ||
+                other.promptTokens == promptTokens) &&
+            (identical(other.totalTokens, totalTokens) ||
+                other.totalTokens == totalTokens) &&
+            (identical(other.promptCacheHitTokens, promptCacheHitTokens) ||
+                other.promptCacheHitTokens == promptCacheHitTokens) &&
+            (identical(other.promptCacheMissTokens, promptCacheMissTokens) ||
+                other.promptCacheMissTokens == promptCacheMissTokens) &&
+            (identical(
+                    other.completionTokensDetails, completionTokensDetails) ||
+                other.completionTokensDetails == completionTokensDetails));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      completionTokens,
+      promptTokens,
+      totalTokens,
+      promptCacheHitTokens,
+      promptCacheMissTokens,
+      completionTokensDetails);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsage(completionTokens: $completionTokens, promptTokens: $promptTokens, totalTokens: $totalTokens, promptCacheHitTokens: $promptCacheHitTokens, promptCacheMissTokens: $promptCacheMissTokens, completionTokensDetails: $completionTokensDetails)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseUsageCopyWith<$Res> {
+  factory $ChatCompletionResponseUsageCopyWith(
+          ChatCompletionResponseUsage value,
+          $Res Function(ChatCompletionResponseUsage) _then) =
+      _$ChatCompletionResponseUsageCopyWithImpl;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'completion_tokens') int completionTokens,
+      @JsonKey(name: 'prompt_tokens') int promptTokens,
+      @JsonKey(name: 'total_tokens') int totalTokens,
+      @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+      @JsonKey(name: 'prompt_cache_miss_tokens') int? promptCacheMissTokens,
+      @JsonKey(name: 'completion_tokens_details')
+      ChatCompletionResponseUsageCompletionTokensDetails?
+          completionTokensDetails});
+
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails;
+}
+
+/// @nodoc
+class _$ChatCompletionResponseUsageCopyWithImpl<$Res>
+    implements $ChatCompletionResponseUsageCopyWith<$Res> {
+  _$ChatCompletionResponseUsageCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponseUsage _self;
+  final $Res Function(ChatCompletionResponseUsage) _then;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? completionTokens = null,
+    Object? promptTokens = null,
+    Object? totalTokens = null,
+    Object? promptCacheHitTokens = freezed,
+    Object? promptCacheMissTokens = freezed,
+    Object? completionTokensDetails = freezed,
+  }) {
+    return _then(_self.copyWith(
+      completionTokens: null == completionTokens
+          ? _self.completionTokens
+          : completionTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptTokens: null == promptTokens
+          ? _self.promptTokens
+          : promptTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalTokens: null == totalTokens
+          ? _self.totalTokens
+          : totalTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptCacheHitTokens: freezed == promptCacheHitTokens
+          ? _self.promptCacheHitTokens
+          : promptCacheHitTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      promptCacheMissTokens: freezed == promptCacheMissTokens
+          ? _self.promptCacheMissTokens
+          : promptCacheMissTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      completionTokensDetails: freezed == completionTokensDetails
+          ? _self.completionTokensDetails
+          : completionTokensDetails // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsageCompletionTokensDetails?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails {
+    if (_self.completionTokensDetails == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>(
+        _self.completionTokensDetails!, (value) {
+      return _then(_self.copyWith(completionTokensDetails: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseUsage].
+extension ChatCompletionResponseUsagePatterns on ChatCompletionResponseUsage {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsage value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsage value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponseUsage value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: 'completion_tokens') int completionTokens,
+            @JsonKey(name: 'prompt_tokens') int promptTokens,
+            @JsonKey(name: 'total_tokens') int totalTokens,
+            @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+            @JsonKey(name: 'prompt_cache_miss_tokens')
+            int? promptCacheMissTokens,
+            @JsonKey(name: 'completion_tokens_details')
+            ChatCompletionResponseUsageCompletionTokensDetails?
+                completionTokensDetails)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(
+            _that.completionTokens,
+            _that.promptTokens,
+            _that.totalTokens,
+            _that.promptCacheHitTokens,
+            _that.promptCacheMissTokens,
+            _that.completionTokensDetails);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: 'completion_tokens') int completionTokens,
+            @JsonKey(name: 'prompt_tokens') int promptTokens,
+            @JsonKey(name: 'total_tokens') int totalTokens,
+            @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+            @JsonKey(name: 'prompt_cache_miss_tokens')
+            int? promptCacheMissTokens,
+            @JsonKey(name: 'completion_tokens_details')
+            ChatCompletionResponseUsageCompletionTokensDetails?
+                completionTokensDetails)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage():
+        return $default(
+            _that.completionTokens,
+            _that.promptTokens,
+            _that.totalTokens,
+            _that.promptCacheHitTokens,
+            _that.promptCacheMissTokens,
+            _that.completionTokensDetails);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @JsonKey(name: 'completion_tokens') int completionTokens,
+            @JsonKey(name: 'prompt_tokens') int promptTokens,
+            @JsonKey(name: 'total_tokens') int totalTokens,
+            @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+            @JsonKey(name: 'prompt_cache_miss_tokens')
+            int? promptCacheMissTokens,
+            @JsonKey(name: 'completion_tokens_details')
+            ChatCompletionResponseUsageCompletionTokensDetails?
+                completionTokensDetails)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(
+            _that.completionTokens,
+            _that.promptTokens,
+            _that.totalTokens,
+            _that.promptCacheHitTokens,
+            _that.promptCacheMissTokens,
+            _that.completionTokensDetails);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseUsage extends ChatCompletionResponseUsage {
+  _ChatCompletionResponseUsage(
+      {@JsonKey(name: 'completion_tokens') required this.completionTokens,
+      @JsonKey(name: 'prompt_tokens') required this.promptTokens,
+      @JsonKey(name: 'total_tokens') required this.totalTokens,
+      @JsonKey(name: 'prompt_cache_hit_tokens') this.promptCacheHitTokens,
+      @JsonKey(name: 'prompt_cache_miss_tokens') this.promptCacheMissTokens,
+      @JsonKey(name: 'completion_tokens_details') this.completionTokensDetails})
+      : super._();
+  factory _ChatCompletionResponseUsage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseUsageFromJson(json);
+
+  @override
+  @JsonKey(name: 'completion_tokens')
+  final int completionTokens;
+  @override
+  @JsonKey(name: 'prompt_tokens')
+  final int promptTokens;
+  @override
+  @JsonKey(name: 'total_tokens')
+  final int totalTokens;
+  @override
+  @JsonKey(name: 'prompt_cache_hit_tokens')
+  final int? promptCacheHitTokens;
+  @override
+  @JsonKey(name: 'prompt_cache_miss_tokens')
+  final int? promptCacheMissTokens;
+  @override
+  @JsonKey(name: 'completion_tokens_details')
+  final ChatCompletionResponseUsageCompletionTokensDetails?
+      completionTokensDetails;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseUsageCopyWith<_ChatCompletionResponseUsage>
+      get copyWith => __$ChatCompletionResponseUsageCopyWithImpl<
+          _ChatCompletionResponseUsage>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseUsageToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseUsage &&
+            (identical(other.completionTokens, completionTokens) ||
+                other.completionTokens == completionTokens) &&
+            (identical(other.promptTokens, promptTokens) ||
+                other.promptTokens == promptTokens) &&
+            (identical(other.totalTokens, totalTokens) ||
+                other.totalTokens == totalTokens) &&
+            (identical(other.promptCacheHitTokens, promptCacheHitTokens) ||
+                other.promptCacheHitTokens == promptCacheHitTokens) &&
+            (identical(other.promptCacheMissTokens, promptCacheMissTokens) ||
+                other.promptCacheMissTokens == promptCacheMissTokens) &&
+            (identical(
+                    other.completionTokensDetails, completionTokensDetails) ||
+                other.completionTokensDetails == completionTokensDetails));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      completionTokens,
+      promptTokens,
+      totalTokens,
+      promptCacheHitTokens,
+      promptCacheMissTokens,
+      completionTokensDetails);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsage(completionTokens: $completionTokens, promptTokens: $promptTokens, totalTokens: $totalTokens, promptCacheHitTokens: $promptCacheHitTokens, promptCacheMissTokens: $promptCacheMissTokens, completionTokensDetails: $completionTokensDetails)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseUsageCopyWith<$Res>
+    implements $ChatCompletionResponseUsageCopyWith<$Res> {
+  factory _$ChatCompletionResponseUsageCopyWith(
+          _ChatCompletionResponseUsage value,
+          $Res Function(_ChatCompletionResponseUsage) _then) =
+      __$ChatCompletionResponseUsageCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'completion_tokens') int completionTokens,
+      @JsonKey(name: 'prompt_tokens') int promptTokens,
+      @JsonKey(name: 'total_tokens') int totalTokens,
+      @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+      @JsonKey(name: 'prompt_cache_miss_tokens') int? promptCacheMissTokens,
+      @JsonKey(name: 'completion_tokens_details')
+      ChatCompletionResponseUsageCompletionTokensDetails?
+          completionTokensDetails});
+
+  @override
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails;
+}
+
+/// @nodoc
+class __$ChatCompletionResponseUsageCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseUsageCopyWith<$Res> {
+  __$ChatCompletionResponseUsageCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponseUsage _self;
+  final $Res Function(_ChatCompletionResponseUsage) _then;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? completionTokens = null,
+    Object? promptTokens = null,
+    Object? totalTokens = null,
+    Object? promptCacheHitTokens = freezed,
+    Object? promptCacheMissTokens = freezed,
+    Object? completionTokensDetails = freezed,
+  }) {
+    return _then(_ChatCompletionResponseUsage(
+      completionTokens: null == completionTokens
+          ? _self.completionTokens
+          : completionTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptTokens: null == promptTokens
+          ? _self.promptTokens
+          : promptTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalTokens: null == totalTokens
+          ? _self.totalTokens
+          : totalTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptCacheHitTokens: freezed == promptCacheHitTokens
+          ? _self.promptCacheHitTokens
+          : promptCacheHitTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      promptCacheMissTokens: freezed == promptCacheMissTokens
+          ? _self.promptCacheMissTokens
+          : promptCacheMissTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      completionTokensDetails: freezed == completionTokensDetails
+          ? _self.completionTokensDetails
+          : completionTokensDetails // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsageCompletionTokensDetails?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails {
+    if (_self.completionTokensDetails == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>(
+        _self.completionTokensDetails!, (value) {
+      return _then(_self.copyWith(completionTokensDetails: value));
+    });
+  }
+}
+
+/// @nodoc
+mixin _$ChatCompletionResponseUsageCompletionTokensDetails {
+  @JsonKey(name: 'reasoning_tokens')
+  int get reasoningTokens;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+          ChatCompletionResponseUsageCompletionTokensDetails>
+      get copyWith =>
+          _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<
+                  ChatCompletionResponseUsageCompletionTokensDetails>(
+              this as ChatCompletionResponseUsageCompletionTokensDetails,
+              _$identity);
+
+  /// Serializes this ChatCompletionResponseUsageCompletionTokensDetails to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseUsageCompletionTokensDetails &&
+            (identical(other.reasoningTokens, reasoningTokens) ||
+                other.reasoningTokens == reasoningTokens));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, reasoningTokens);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsageCompletionTokensDetails(reasoningTokens: $reasoningTokens)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+    $Res> {
+  factory $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith(
+          ChatCompletionResponseUsageCompletionTokensDetails value,
+          $Res Function(ChatCompletionResponseUsageCompletionTokensDetails)
+              _then) =
+      _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl;
+  @useResult
+  $Res call({@JsonKey(name: 'reasoning_tokens') int reasoningTokens});
+}
+
+/// @nodoc
+class _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<$Res>
+    implements
+        $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res> {
+  _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl(
+      this._self, this._then);
+
+  final ChatCompletionResponseUsageCompletionTokensDetails _self;
+  final $Res Function(ChatCompletionResponseUsageCompletionTokensDetails) _then;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? reasoningTokens = null,
+  }) {
+    return _then(_self.copyWith(
+      reasoningTokens: null == reasoningTokens
+          ? _self.reasoningTokens
+          : reasoningTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseUsageCompletionTokensDetails].
+extension ChatCompletionResponseUsageCompletionTokensDetailsPatterns
+    on ChatCompletionResponseUsageCompletionTokensDetails {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsageCompletionTokensDetails value)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsageCompletionTokensDetails value)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(
+            _ChatCompletionResponseUsageCompletionTokensDetails value)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@JsonKey(name: 'reasoning_tokens') int reasoningTokens)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that.reasoningTokens);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@JsonKey(name: 'reasoning_tokens') int reasoningTokens)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails():
+        return $default(_that.reasoningTokens);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@JsonKey(name: 'reasoning_tokens') int reasoningTokens)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that.reasoningTokens);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseUsageCompletionTokensDetails
+    extends ChatCompletionResponseUsageCompletionTokensDetails {
+  _ChatCompletionResponseUsageCompletionTokensDetails(
+      {@JsonKey(name: 'reasoning_tokens') required this.reasoningTokens})
+      : super._();
+  factory _ChatCompletionResponseUsageCompletionTokensDetails.fromJson(
+          Map<String, dynamic> json) =>
+      _$ChatCompletionResponseUsageCompletionTokensDetailsFromJson(json);
+
+  @override
+  @JsonKey(name: 'reasoning_tokens')
+  final int reasoningTokens;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+          _ChatCompletionResponseUsageCompletionTokensDetails>
+      get copyWith =>
+          __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<
+                  _ChatCompletionResponseUsageCompletionTokensDetails>(
+              this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseUsageCompletionTokensDetailsToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseUsageCompletionTokensDetails &&
+            (identical(other.reasoningTokens, reasoningTokens) ||
+                other.reasoningTokens == reasoningTokens));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, reasoningTokens);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsageCompletionTokensDetails(reasoningTokens: $reasoningTokens)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+        $Res>
+    implements
+        $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res> {
+  factory _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith(
+          _ChatCompletionResponseUsageCompletionTokensDetails value,
+          $Res Function(_ChatCompletionResponseUsageCompletionTokensDetails)
+              _then) =
+      __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl;
+  @override
+  @useResult
+  $Res call({@JsonKey(name: 'reasoning_tokens') int reasoningTokens});
+}
+
+/// @nodoc
+class __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<$Res>
+    implements
+        _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res> {
+  __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl(
+      this._self, this._then);
+
+  final _ChatCompletionResponseUsageCompletionTokensDetails _self;
+  final $Res Function(_ChatCompletionResponseUsageCompletionTokensDetails)
+      _then;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? reasoningTokens = null,
+  }) {
+    return _then(_ChatCompletionResponseUsageCompletionTokensDetails(
+      reasoningTokens: null == reasoningTokens
+          ? _self.reasoningTokens
+          : reasoningTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.g.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response_usage.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponseUsage _$ChatCompletionResponseUsageFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponseUsage(
+      completionTokens: (json['completion_tokens'] as num).toInt(),
+      promptTokens: (json['prompt_tokens'] as num).toInt(),
+      totalTokens: (json['total_tokens'] as num).toInt(),
+      promptCacheHitTokens: (json['prompt_cache_hit_tokens'] as num?)?.toInt(),
+      promptCacheMissTokens:
+          (json['prompt_cache_miss_tokens'] as num?)?.toInt(),
+      completionTokensDetails: json['completion_tokens_details'] == null
+          ? null
+          : ChatCompletionResponseUsageCompletionTokensDetails.fromJson(
+              json['completion_tokens_details'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseUsageToJson(
+        _ChatCompletionResponseUsage instance) =>
+    <String, dynamic>{
+      'completion_tokens': instance.completionTokens,
+      'prompt_tokens': instance.promptTokens,
+      'total_tokens': instance.totalTokens,
+      'prompt_cache_hit_tokens': instance.promptCacheHitTokens,
+      'prompt_cache_miss_tokens': instance.promptCacheMissTokens,
+      'completion_tokens_details': instance.completionTokensDetails,
+    };
+
+_ChatCompletionResponseUsageCompletionTokensDetails
+    _$ChatCompletionResponseUsageCompletionTokensDetailsFromJson(
+            Map<String, dynamic> json) =>
+        _ChatCompletionResponseUsageCompletionTokensDetails(
+          reasoningTokens: (json['reasoning_tokens'] as num).toInt(),
+        );
+
+Map<String, dynamic> _$ChatCompletionResponseUsageCompletionTokensDetailsToJson(
+        _ChatCompletionResponseUsageCompletionTokensDetails instance) =>
+    <String, dynamic>{
+      'reasoning_tokens': instance.reasoningTokens,
+    };

--- a/pkgs/perplexity_box/lib/src/freezed/model/model/model.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/model/model/model.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'model.freezed.dart';
+part 'model.g.dart';
+
+@freezed
+abstract class Model with _$Model {
+  factory Model({
+    required String id,
+    required String object,
+    @JsonKey(name: 'owned_by') required String ownedBy,
+  }) = _Model;
+
+  factory Model.fromJson(Map<String, dynamic> json) => _$ModelFromJson(json);
+  const Model._();
+}

--- a/pkgs/perplexity_box/lib/src/freezed/model/model/model.freezed.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/model/model/model.freezed.dart
@@ -1,0 +1,353 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Model {
+  String get id;
+  String get object;
+  @JsonKey(name: 'owned_by')
+  String get ownedBy;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ModelCopyWith<Model> get copyWith =>
+      _$ModelCopyWithImpl<Model>(this as Model, _$identity);
+
+  /// Serializes this Model to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Model &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.ownedBy, ownedBy) || other.ownedBy == ownedBy));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, object, ownedBy);
+
+  @override
+  String toString() {
+    return 'Model(id: $id, object: $object, ownedBy: $ownedBy)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ModelCopyWith<$Res> {
+  factory $ModelCopyWith(Model value, $Res Function(Model) _then) =
+      _$ModelCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id, String object, @JsonKey(name: 'owned_by') String ownedBy});
+}
+
+/// @nodoc
+class _$ModelCopyWithImpl<$Res> implements $ModelCopyWith<$Res> {
+  _$ModelCopyWithImpl(this._self, this._then);
+
+  final Model _self;
+  final $Res Function(Model) _then;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? object = null,
+    Object? ownedBy = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      ownedBy: null == ownedBy
+          ? _self.ownedBy
+          : ownedBy // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Model].
+extension ModelPatterns on Model {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Model value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Model value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Model value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String id, String object,
+            @JsonKey(name: 'owned_by') String ownedBy)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that.id, _that.object, _that.ownedBy);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id, String object, @JsonKey(name: 'owned_by') String ownedBy)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model():
+        return $default(_that.id, _that.object, _that.ownedBy);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String id, String object,
+            @JsonKey(name: 'owned_by') String ownedBy)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that.id, _that.object, _that.ownedBy);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _Model extends Model {
+  _Model(
+      {required this.id,
+      required this.object,
+      @JsonKey(name: 'owned_by') required this.ownedBy})
+      : super._();
+  factory _Model.fromJson(Map<String, dynamic> json) => _$ModelFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String object;
+  @override
+  @JsonKey(name: 'owned_by')
+  final String ownedBy;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ModelCopyWith<_Model> get copyWith =>
+      __$ModelCopyWithImpl<_Model>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ModelToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Model &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.ownedBy, ownedBy) || other.ownedBy == ownedBy));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, object, ownedBy);
+
+  @override
+  String toString() {
+    return 'Model(id: $id, object: $object, ownedBy: $ownedBy)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ModelCopyWith<$Res> implements $ModelCopyWith<$Res> {
+  factory _$ModelCopyWith(_Model value, $Res Function(_Model) _then) =
+      __$ModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id, String object, @JsonKey(name: 'owned_by') String ownedBy});
+}
+
+/// @nodoc
+class __$ModelCopyWithImpl<$Res> implements _$ModelCopyWith<$Res> {
+  __$ModelCopyWithImpl(this._self, this._then);
+
+  final _Model _self;
+  final $Res Function(_Model) _then;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? object = null,
+    Object? ownedBy = null,
+  }) {
+    return _then(_Model(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      ownedBy: null == ownedBy
+          ? _self.ownedBy
+          : ownedBy // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/perplexity_box/lib/src/freezed/model/model/model.g.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/model/model/model.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_Model _$ModelFromJson(Map<String, dynamic> json) => _Model(
+      id: json['id'] as String,
+      object: json['object'] as String,
+      ownedBy: json['owned_by'] as String,
+    );
+
+Map<String, dynamic> _$ModelToJson(_Model instance) => <String, dynamic>{
+      'id': instance.id,
+      'object': instance.object,
+      'owned_by': instance.ownedBy,
+    };

--- a/pkgs/perplexity_box/lib/src/freezed/model/model_list/model_list.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/model/model_list/model_list.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:perplexity_box/src/freezed/model/model/model.dart';
+
+part 'model_list.freezed.dart';
+part 'model_list.g.dart';
+
+@freezed
+abstract class ModelList with _$ModelList {
+  factory ModelList({required String object, required List<Model> data}) =
+      _ModelList;
+
+  factory ModelList.fromJson(Map<String, dynamic> json) =>
+      _$ModelListFromJson(json);
+  const ModelList._();
+}

--- a/pkgs/perplexity_box/lib/src/freezed/model/model_list/model_list.freezed.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/model/model_list/model_list.freezed.dart
@@ -1,0 +1,336 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'model_list.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ModelList {
+  String get object;
+  List<Model> get data;
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ModelListCopyWith<ModelList> get copyWith =>
+      _$ModelListCopyWithImpl<ModelList>(this as ModelList, _$identity);
+
+  /// Serializes this ModelList to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ModelList &&
+            (identical(other.object, object) || other.object == object) &&
+            const DeepCollectionEquality().equals(other.data, data));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, object, const DeepCollectionEquality().hash(data));
+
+  @override
+  String toString() {
+    return 'ModelList(object: $object, data: $data)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ModelListCopyWith<$Res> {
+  factory $ModelListCopyWith(ModelList value, $Res Function(ModelList) _then) =
+      _$ModelListCopyWithImpl;
+  @useResult
+  $Res call({String object, List<Model> data});
+}
+
+/// @nodoc
+class _$ModelListCopyWithImpl<$Res> implements $ModelListCopyWith<$Res> {
+  _$ModelListCopyWithImpl(this._self, this._then);
+
+  final ModelList _self;
+  final $Res Function(ModelList) _then;
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? object = null,
+    Object? data = null,
+  }) {
+    return _then(_self.copyWith(
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      data: null == data
+          ? _self.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as List<Model>,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ModelList].
+extension ModelListPatterns on ModelList {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ModelList value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ModelList value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ModelList value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String object, List<Model> data)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that.object, _that.data);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String object, List<Model> data) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList():
+        return $default(_that.object, _that.data);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String object, List<Model> data)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that.object, _that.data);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ModelList extends ModelList {
+  _ModelList({required this.object, required final List<Model> data})
+      : _data = data,
+        super._();
+  factory _ModelList.fromJson(Map<String, dynamic> json) =>
+      _$ModelListFromJson(json);
+
+  @override
+  final String object;
+  final List<Model> _data;
+  @override
+  List<Model> get data {
+    if (_data is EqualUnmodifiableListView) return _data;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_data);
+  }
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ModelListCopyWith<_ModelList> get copyWith =>
+      __$ModelListCopyWithImpl<_ModelList>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ModelListToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ModelList &&
+            (identical(other.object, object) || other.object == object) &&
+            const DeepCollectionEquality().equals(other._data, _data));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, object, const DeepCollectionEquality().hash(_data));
+
+  @override
+  String toString() {
+    return 'ModelList(object: $object, data: $data)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ModelListCopyWith<$Res>
+    implements $ModelListCopyWith<$Res> {
+  factory _$ModelListCopyWith(
+          _ModelList value, $Res Function(_ModelList) _then) =
+      __$ModelListCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String object, List<Model> data});
+}
+
+/// @nodoc
+class __$ModelListCopyWithImpl<$Res> implements _$ModelListCopyWith<$Res> {
+  __$ModelListCopyWithImpl(this._self, this._then);
+
+  final _ModelList _self;
+  final $Res Function(_ModelList) _then;
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? object = null,
+    Object? data = null,
+  }) {
+    return _then(_ModelList(
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      data: null == data
+          ? _self._data
+          : data // ignore: cast_nullable_to_non_nullable
+              as List<Model>,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/perplexity_box/lib/src/freezed/model/model_list/model_list.g.dart
+++ b/pkgs/perplexity_box/lib/src/freezed/model/model_list/model_list.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'model_list.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ModelList _$ModelListFromJson(Map<String, dynamic> json) => _ModelList(
+      object: json['object'] as String,
+      data: (json['data'] as List<dynamic>)
+          .map((e) => Model.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$ModelListToJson(_ModelList instance) =>
+    <String, dynamic>{
+      'object': instance.object,
+      'data': instance.data,
+    };

--- a/pkgs/perplexity_box/lib/src/openai_compat.dart
+++ b/pkgs/perplexity_box/lib/src/openai_compat.dart
@@ -1,0 +1,338 @@
+// OpenAI 互換 Chat Completions API のリクエスト構築・レスポンス解析ヘルパー。
+//
+// 画像・音声・ファイル・ツール呼び出し・構造化出力を raw JSON として
+// 組み立てる（freezed のコード生成に依存しない）。
+//
+// このファイルは src/ 配下のパッケージ内部実装であり、公開 API には含めない。
+import 'dart:convert';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:api_http/api_http.dart';
+
+/// [LLMCompletionRequest] を OpenAI 互換のリクエストボディに変換する。
+Map<String, dynamic> buildOpenAiBody(
+  LLMCompletionRequest request, {
+  required String maxTokensKey,
+}) {
+  final body = <String, dynamic>{
+    'model': request.model,
+    'messages': _toOpenAiMessages(request.messages),
+  };
+  if (request.maxTokens != null) body[maxTokensKey] = request.maxTokens;
+  if (request.temperature != null) body['temperature'] = request.temperature;
+  if (request.topP != null) body['top_p'] = request.topP;
+  if (request.stop != null) body['stop'] = request.stop;
+  if (request.seed != null) body['seed'] = request.seed;
+  if (request.frequencyPenalty != null) {
+    body['frequency_penalty'] = request.frequencyPenalty;
+  }
+  if (request.presencePenalty != null) {
+    body['presence_penalty'] = request.presencePenalty;
+  }
+  final rf = _toOpenAiResponseFormat(request.responseFormat);
+  if (rf != null) body['response_format'] = rf;
+  final tools = request.tools;
+  if (tools != null && tools.isNotEmpty) {
+    body['tools'] = [
+      for (final t in tools)
+        {
+          'type': 'function',
+          'function': {
+            'name': t.name,
+            'description': t.description,
+            'parameters': t.parameters,
+          },
+        },
+    ];
+    final tc = _toOpenAiToolChoice(request.toolChoice);
+    if (tc != null) body['tool_choice'] = tc;
+  }
+  return body;
+}
+
+List<Map<String, dynamic>> _toOpenAiMessages(List<LLMContent> messages) {
+  final out = <Map<String, dynamic>>[];
+  for (final m in messages) {
+    final role = switch (m.role) {
+      LLMRole.model => 'assistant',
+      LLMRole.system => 'system',
+      LLMRole.user => 'user',
+    };
+
+    // ツール実行結果は role: 'tool' の独立メッセージとして送る。
+    final toolResults = m.parts.whereType<LLMToolResultPart>().toList();
+    if (toolResults.isNotEmpty) {
+      for (final tr in toolResults) {
+        out.add({
+          'role': 'tool',
+          'tool_call_id': tr.toolCallId,
+          'content': tr.content,
+        });
+      }
+      continue;
+    }
+
+    // assistant のツール呼び出しエコー。
+    final toolCalls = m.parts.whereType<LLMToolCallPart>().toList();
+    if (toolCalls.isNotEmpty) {
+      out.add({
+        'role': 'assistant',
+        if (m.text.isNotEmpty) 'content': m.text,
+        'tool_calls': [
+          for (final tc in toolCalls)
+            {
+              'id': tc.id,
+              'type': 'function',
+              'function': {
+                'name': tc.name,
+                'arguments': jsonEncode(tc.arguments),
+              },
+            },
+        ],
+      });
+      continue;
+    }
+
+    final hasMedia = m.parts.any(
+      (p) => p is LLMImagePart || p is LLMAudioPart || p is LLMFilePart,
+    );
+    if (!hasMedia) {
+      out.add({'role': role, 'content': m.text});
+      continue;
+    }
+
+    out.add({'role': role, 'content': _toOpenAiContentArray(m.parts)});
+  }
+  return out;
+}
+
+List<Map<String, dynamic>> _toOpenAiContentArray(List<LLMContentPart> parts) {
+  final arr = <Map<String, dynamic>>[];
+  for (final p in parts) {
+    if (p is LLMTextPart) {
+      arr.add({'type': 'text', 'text': p.text});
+    } else if (p is LLMImagePart) {
+      arr.add({
+        'type': 'image_url',
+        'image_url': {'url': p.asUrlOrDataUri},
+      });
+    } else if (p is LLMAudioPart) {
+      arr.add({
+        'type': 'input_audio',
+        'input_audio': {
+          'data': p.base64Data ?? '',
+          'format': _audioFormat(p.mimeType),
+        },
+      });
+    } else if (p is LLMFilePart) {
+      arr.add({
+        'type': 'file',
+        'file': {
+          if (p.filename != null) 'filename': p.filename,
+          'file_data': _fileDataField(p),
+        },
+      });
+    }
+  }
+  return arr;
+}
+
+String _fileDataField(LLMFilePart f) {
+  if (f.hasBytes) {
+    final mime = f.mimeType ?? 'application/octet-stream';
+    return 'data:$mime;base64,${f.base64Data}';
+  }
+  return f.url ?? '';
+}
+
+String _audioFormat(String? mimeType) {
+  if (mimeType == null) return 'wav';
+  if (mimeType.contains('mp3') || mimeType.contains('mpeg')) return 'mp3';
+  if (mimeType.contains('wav')) return 'wav';
+  return mimeType.split('/').last;
+}
+
+Map<String, dynamic>? _toOpenAiResponseFormat(LLMResponseFormat? f) {
+  if (f == null) return null;
+  switch (f.type) {
+    case LLMResponseFormatType.text:
+      return {'type': 'text'};
+    case LLMResponseFormatType.jsonObject:
+      return {'type': 'json_object'};
+    case LLMResponseFormatType.jsonSchema:
+      return {
+        'type': 'json_schema',
+        'json_schema': {
+          'name': f.schemaName,
+          'schema': f.schema,
+          'strict': f.strict,
+        },
+      };
+  }
+}
+
+dynamic _toOpenAiToolChoice(LLMToolChoice? tc) {
+  if (tc == null) return null;
+  final toolName = tc.toolName;
+  if (toolName != null) {
+    return {
+      'type': 'function',
+      'function': {'name': toolName},
+    };
+  }
+  switch (tc.mode) {
+    case LLMToolChoiceMode.auto:
+      return 'auto';
+    case LLMToolChoiceMode.none:
+      return 'none';
+    case LLMToolChoiceMode.any:
+      return 'required';
+  }
+}
+
+/// OpenAI 互換のレスポンスボディを [LLMCompletionResponse] に変換する。
+LLMCompletionResponse parseOpenAiResponse(Map<String, dynamic> data) {
+  final choices = (data['choices'] as List?) ?? const [];
+  final choice = choices.isNotEmpty
+      ? choices.first as Map<String, dynamic>
+      : const <String, dynamic>{};
+  final message =
+      (choice['message'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  final parts = <LLMContentPart>[];
+
+  final reasoning = message['reasoning_content'];
+  if (reasoning is String && reasoning.isNotEmpty) {
+    parts.add(LLMReasoningPart(reasoning));
+  }
+
+  final rawContent = message['content'];
+  if (rawContent is String && rawContent.isNotEmpty) {
+    parts.add(LLMTextPart(rawContent));
+  } else if (rawContent is List) {
+    _appendOpenAiContentParts(rawContent, parts);
+  }
+
+  final toolCalls = message['tool_calls'];
+  if (toolCalls is List) {
+    for (final tc in toolCalls) {
+      if (tc is Map<String, dynamic>) {
+        final fn = tc['function'];
+        final fnMap =
+            fn is Map<String, dynamic> ? fn : const <String, dynamic>{};
+        parts.add(
+          LLMToolCallPart(
+            id: (tc['id'] ?? '').toString(),
+            name: (fnMap['name'] ?? '').toString(),
+            arguments: _decodeArgs(fnMap['arguments']),
+          ),
+        );
+      }
+    }
+  }
+
+  final audio = message['audio'];
+  if (audio is Map<String, dynamic>) {
+    final adata = audio['data'];
+    if (adata is String && adata.isNotEmpty) {
+      parts.add(
+        LLMAudioPart.base64(adata, transcript: audio['transcript'] as String?),
+      );
+    }
+  }
+
+  final usage =
+      (data['usage'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  return LLMCompletionResponse(
+    content: LLMContent(role: LLMRole.model, parts: parts),
+    usage: _parseOpenAiUsage(usage),
+    finishReason: LLMFinishReason.parse(choice['finish_reason'] as String?),
+    model: data['model'] as String?,
+    id: data['id'] as String?,
+  );
+}
+
+void _appendOpenAiContentParts(List<dynamic> items, List<LLMContentPart> out) {
+  for (final item in items) {
+    if (item is! Map<String, dynamic>) continue;
+    final type = item['type'];
+    if (type == 'text' && item['text'] is String) {
+      out.add(LLMTextPart(item['text'] as String));
+    } else if (type == 'image_url') {
+      final url = (item['image_url'] as Map<String, dynamic>?)?['url'];
+      if (url is String) out.add(LLMImagePart.dataUri(url));
+    }
+  }
+}
+
+Map<String, dynamic> _decodeArgs(Object? argsRaw) {
+  if (argsRaw is Map<String, dynamic>) return argsRaw;
+  if (argsRaw is String && argsRaw.isNotEmpty) {
+    try {
+      final decoded = jsonDecode(argsRaw);
+      if (decoded is Map<String, dynamic>) return decoded;
+    } on FormatException {
+      return <String, dynamic>{};
+    }
+  }
+  return <String, dynamic>{};
+}
+
+LLMUsage _parseOpenAiUsage(Map<String, dynamic> usage) {
+  final promptDetails = usage['prompt_tokens_details'] as Map<String, dynamic>?;
+  final completionDetails =
+      usage['completion_tokens_details'] as Map<String, dynamic>?;
+  return LLMUsage(
+    inputTokens: (usage['prompt_tokens'] as num?)?.toInt() ?? 0,
+    outputTokens: (usage['completion_tokens'] as num?)?.toInt() ?? 0,
+    cachedInputTokens: (promptDetails?['cached_tokens'] as num?)?.toInt(),
+    reasoningTokens: (completionDetails?['reasoning_tokens'] as num?)?.toInt(),
+  );
+}
+
+/// OpenAI 互換 API に POST し、JSON ボディを返す。失敗時は [LLMException]。
+Future<Map<String, dynamic>> postOpenAiJson({
+  required String url,
+  required String apiKey,
+  required String provider,
+  required Map<String, dynamic> body,
+}) async {
+  try {
+    final response = await Api.post(
+      requestAcc: PostRequestAcc(
+        url: url,
+        headers: RestHeaders({
+          'Authorization': 'Bearer $apiKey',
+          'Content-Type': 'application/json',
+        }),
+        body: JsonRequestBody(body),
+      ),
+    );
+    final statusCode = int.tryParse(response.statusCode) ?? 0;
+    final respBody = response.body;
+    Map<String, dynamic>? mapData;
+    if (respBody is MapJsonResponseBody) {
+      mapData = respBody.data;
+    }
+    if (statusCode < 200 || statusCode >= 300) {
+      throw LLMException.fromHttp(
+        statusCode,
+        provider: provider,
+        body: mapData ?? respBody,
+      );
+    }
+    if (mapData != null) return mapData;
+    throw LLMUnknownException(
+      'Unexpected response body from $provider',
+      provider: provider,
+      raw: respBody,
+    );
+  } on LLMException {
+    rethrow;
+  } catch (e) {
+    throw LLMNetworkException(
+      'Network request failed',
+      provider: provider,
+      raw: e,
+    );
+  }
+}

--- a/pkgs/perplexity_box/lib/src/perplexity.dart
+++ b/pkgs/perplexity_box/lib/src/perplexity.dart
@@ -1,0 +1,68 @@
+import 'package:ai_box/ai_box.dart';
+import 'package:perplexity_box/src/openai_compat.dart';
+
+class Perplexity extends LLMAIBase {
+  Perplexity({required super.apiKey});
+
+  static const _url = 'https://api.perplexity.ai/chat/completions';
+  static const _provider = 'perplexity';
+
+  /// Perplexity が公開している既知の Sonar モデル。
+  ///
+  /// Perplexity は OpenAI 互換の `/models` 一覧エンドポイントを提供して
+  /// いないため、ドキュメント記載のモデルを静的に返す。
+  /// https://docs.perplexity.ai/getting-started/models
+  static const _knownModels = <String>[
+    'sonar',
+    'sonar-pro',
+    'sonar-reasoning',
+    'sonar-reasoning-pro',
+    'sonar-deep-research',
+  ];
+
+  @override
+  Future<LLMCompletionResponse> completions(
+    LLMCompletionRequest request,
+  ) async {
+    final body = buildOpenAiBody(request, maxTokensKey: 'max_tokens');
+    final data = await postOpenAiJson(
+      url: _url,
+      apiKey: apiKey,
+      provider: _provider,
+      body: body,
+    );
+    return parseOpenAiResponse(data);
+  }
+
+  @override
+  Future<List<AIModel>> getModels() async {
+    return _knownModels.map((id) => AIModel(id: id)).toList();
+  }
+
+  @override
+  Future<bool> validateKey() async {
+    // Perplexity には軽量な検証用エンドポイントが無いため、最小の補完
+    // リクエストを送って認証エラー（401/403）かどうかで判定する。
+    try {
+      await postOpenAiJson(
+        url: _url,
+        apiKey: apiKey,
+        provider: _provider,
+        body: {
+          'model': 'sonar',
+          'messages': [
+            {'role': 'user', 'content': 'hi'},
+          ],
+          'max_tokens': 1,
+        },
+      );
+      return true;
+    } on LLMAuthException {
+      return false;
+    } on LLMException catch (_) {
+      // 認証は通ったが別の理由（残高不足・レート制限など）で失敗した
+      // 場合、キー自体は有効とみなす。
+      return true;
+    }
+  }
+}

--- a/pkgs/perplexity_box/pubspec.yaml
+++ b/pkgs/perplexity_box/pubspec.yaml
@@ -1,0 +1,24 @@
+---
+dependencies:
+  ai_box: ^0.0.1
+  api_http: ^0.0.1
+  freezed_annotation: ^3.0.0
+  json_annotation: ^4.9.0
+description: '''A Perplexity AI provider based on ai_box. '''
+dev_dependencies:
+  auto_exporter: any
+  build_runner: ^2.5.4
+  freezed: ^3.0.6
+  json_serializable: ^6.9.5
+  test: ^1.26.0
+  very_good_analysis: any
+environment:
+  sdk: ^3.2.0
+homepage: https://github.com/normidar/ai_box
+name: perplexity_box
+topics:
+  - ai
+  - perplexity
+  - ai-box
+  - llm
+version: 0.0.1

--- a/pkgs/perplexity_box/pubspec_overrides.yaml
+++ b/pkgs/perplexity_box/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: ai_box
+dependency_overrides:
+  ai_box:
+    path: ../ai_box

--- a/pkgs/perplexity_box/test/perplexity_box_test.dart
+++ b/pkgs/perplexity_box/test/perplexity_box_test.dart
@@ -1,0 +1,205 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:perplexity_box/perplexity_box.dart';
+import 'package:perplexity_box/src/openai_compat.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Perplexity client', () {
+    test('exposes apiKey and is an LLMAIBase', () {
+      final ai = Perplexity(apiKey: 'test-key');
+      expect(ai.apiKey, 'test-key');
+      expect(ai, isA<LLMAIBase>());
+    });
+
+    test('getModels returns the documented Sonar family without network',
+        () async {
+      final ai = Perplexity(apiKey: 'test-key');
+      final models = await ai.getModels();
+      final ids = models.map((m) => m.id).toList();
+      expect(ids, containsAll(<String>['sonar', 'sonar-pro']));
+      expect(ids.length, 5);
+      // getModelIds is the inherited convenience over getModels.
+      expect(await ai.getModelIds(), ids);
+    });
+  });
+
+  group('ChatCompletion freezed models', () {
+    test('request serializes to OpenAI-shaped JSON', () {
+      final req = ChatCompletionRequest(
+        model: 'sonar',
+        messages: [
+          ChatCompletionMessage(role: ChatCompletionRole.user, content: 'hi'),
+        ],
+        maxTokens: 16,
+      );
+      // toJson() keeps nested objects; the wire payload is produced when the
+      // map is encoded (as JsonRequestBody does), so round-trip through JSON.
+      final json = jsonDecode(jsonEncode(req.toJson())) as Map<String, dynamic>;
+      expect(json['model'], 'sonar');
+      expect(json['max_tokens'], 16);
+      final msg = (json['messages'] as List).first as Map<String, dynamic>;
+      expect(msg['role'], 'user');
+      expect(msg['content'], 'hi');
+    });
+
+    test('response parses choices + usage', () {
+      final res = ChatCompletionResponse.fromJson({
+        'id': 'x',
+        'object': 'chat.completion',
+        'created': 1,
+        'model': 'sonar',
+        'choices': [
+          {
+            'index': 0,
+            'finish_reason': 'stop',
+            'message': {'role': 'assistant', 'content': 'hello'},
+          },
+        ],
+        'usage': {
+          'prompt_tokens': 3,
+          'completion_tokens': 5,
+          'total_tokens': 8,
+        },
+      });
+      expect(res.choices.single.message.content, 'hello');
+      expect(res.choices.single.finishReason, 'stop');
+      expect(res.usage?.totalTokens, 8);
+    });
+
+    test('ModelList parses model entries', () {
+      final list = ModelList.fromJson({
+        'object': 'list',
+        'data': [
+          {'id': 'sonar-pro', 'object': 'model', 'owned_by': 'perplexity'},
+        ],
+      });
+      expect(list.data.single.id, 'sonar-pro');
+    });
+  });
+
+  group('buildOpenAiBody', () {
+    test('text message maps to role + content with sampling params', () {
+      final body = buildOpenAiBody(
+        LLMCompletionRequest(
+          model: 'sonar',
+          messages: [LLMContent.user('hi')],
+          maxTokens: 10,
+          temperature: 0.5,
+        ),
+        maxTokensKey: 'max_tokens',
+      );
+      expect(body['model'], 'sonar');
+      expect(body['max_tokens'], 10);
+      expect(body['temperature'], 0.5);
+      final msg = (body['messages'] as List).single as Map<String, dynamic>;
+      expect(msg['role'], 'user');
+      expect(msg['content'], 'hi');
+    });
+
+    test('image attachment becomes a content array with image_url', () {
+      final bytes = Uint8List.fromList(utf8.encode('img'));
+      final body = buildOpenAiBody(
+        LLMCompletionRequest(
+          model: 'sonar',
+          messages: [
+            LLMContent.user('see', attachments: [LLMImagePart.bytes(bytes)]),
+          ],
+        ),
+        maxTokensKey: 'max_tokens',
+      );
+      final msg = (body['messages'] as List).single as Map<String, dynamic>;
+      final content = msg['content'] as List;
+      expect((content[0] as Map<String, dynamic>)['type'], 'text');
+      expect((content[1] as Map<String, dynamic>)['type'], 'image_url');
+    });
+
+    test('tools are mapped to function definitions', () {
+      final body = buildOpenAiBody(
+        LLMCompletionRequest(
+          model: 'sonar',
+          messages: [LLMContent.user('x')],
+          tools: const [
+            LLMTool(
+              name: 'get_weather',
+              description: 'weather',
+              parameters: {'type': 'object'},
+            ),
+          ],
+          toolChoice: LLMToolChoice.auto,
+        ),
+        maxTokensKey: 'max_tokens',
+      );
+      final tool = (body['tools'] as List).single as Map<String, dynamic>;
+      expect(tool['type'], 'function');
+      expect((tool['function'] as Map<String, dynamic>)['name'], 'get_weather');
+      expect(body['tool_choice'], 'auto');
+    });
+  });
+
+  group('parseOpenAiResponse', () {
+    test('text, usage, finish reason, model and id', () {
+      final res = parseOpenAiResponse({
+        'id': 'r',
+        'model': 'sonar',
+        'choices': [
+          {
+            'finish_reason': 'stop',
+            'message': {'role': 'assistant', 'content': 'hello'},
+          },
+        ],
+        'usage': {'prompt_tokens': 2, 'completion_tokens': 3},
+      });
+      expect(res.text, 'hello');
+      expect(res.finishReason, LLMFinishReason.stop);
+      expect(res.usage.inputTokens, 2);
+      expect(res.usage.outputTokens, 3);
+      expect(res.model, 'sonar');
+      expect(res.id, 'r');
+    });
+
+    test('tool calls are parsed into LLMToolCallPart', () {
+      final res = parseOpenAiResponse({
+        'choices': [
+          {
+            'finish_reason': 'tool_calls',
+            'message': {
+              'role': 'assistant',
+              'content': null,
+              'tool_calls': [
+                {
+                  'id': 'c1',
+                  'type': 'function',
+                  'function': {'name': 'f', 'arguments': '{"a":1}'},
+                },
+              ],
+            },
+          },
+        ],
+      });
+      final call = res.content.parts.whereType<LLMToolCallPart>().single;
+      expect(call.id, 'c1');
+      expect(call.name, 'f');
+      expect(call.arguments, {'a': 1});
+      expect(res.finishReason, LLMFinishReason.toolCalls);
+    });
+
+    test('reasoning_content becomes an LLMReasoningPart', () {
+      final res = parseOpenAiResponse({
+        'choices': [
+          {
+            'message': {
+              'role': 'assistant',
+              'reasoning_content': 'think',
+              'content': 'ans',
+            },
+          },
+        ],
+      });
+      expect(res.content.reasoning, 'think');
+      expect(res.text, 'ans');
+    });
+  });
+}

--- a/pkgs/qwen_box/.gitignore
+++ b/pkgs/qwen_box/.gitignore
@@ -1,0 +1,31 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/

--- a/pkgs/qwen_box/CHANGELOG.md
+++ b/pkgs/qwen_box/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+- Initial release.

--- a/pkgs/qwen_box/README.md
+++ b/pkgs/qwen_box/README.md
@@ -1,0 +1,4 @@
+# qwen_box
+
+A Qwen (Alibaba Cloud Model Studio / DashScope) AI provider based on
+[ai_box](https://github.com/normidar/ai_box).

--- a/pkgs/qwen_box/analysis_options.yaml
+++ b/pkgs/qwen_box/analysis_options.yaml
@@ -1,0 +1,11 @@
+include: package:very_good_analysis/analysis_options.yaml
+analyzer:
+  exclude: [build/**, lib/**.freezed.dart, lib/**.g.dart]
+  errors:
+    sort_constructors_first: ignore
+    public_member_api_docs: ignore
+    one_member_abstracts: ignore
+    invalid_annotation_target: ignore
+    avoid_positional_boolean_parameters: ignore
+    use_setters_to_change_properties: ignore
+    prefer_asserts_with_message: ignore

--- a/pkgs/qwen_box/build.yaml
+++ b/pkgs/qwen_box/build.yaml
@@ -1,0 +1,7 @@
+targets:
+  $default:
+    builders:
+      auto_exporter:
+        options:
+          default_export_all: true
+          project_name: qwen_box

--- a/pkgs/qwen_box/lib/qwen_box.dart
+++ b/pkgs/qwen_box/lib/qwen_box.dart
@@ -1,0 +1,10 @@
+export 'package:qwen_box/src/core/qwen_core.dart';
+export 'package:qwen_box/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart';
+export 'package:qwen_box/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.dart';
+export 'package:qwen_box/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.dart';
+export 'package:qwen_box/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart';
+export 'package:qwen_box/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart';
+export 'package:qwen_box/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart';
+export 'package:qwen_box/src/freezed/model/model/model.dart';
+export 'package:qwen_box/src/freezed/model/model_list/model_list.dart';
+export 'package:qwen_box/src/qwen.dart';

--- a/pkgs/qwen_box/lib/src/core/qwen_core.dart
+++ b/pkgs/qwen_box/lib/src/core/qwen_core.dart
@@ -1,0 +1,48 @@
+import 'package:api_http/api_http.dart';
+import 'package:qwen_box/qwen_box.dart';
+
+class QwenCore {
+  static const _baseUrl =
+      'https://dashscope-intl.aliyuncs.com/compatible-mode/v1';
+
+  static Future<ChatCompletionResponse> chatCompletion({
+    required String apiKey,
+    required ChatCompletionRequest request,
+  }) async {
+    final response = await Api.post(
+      requestAcc: PostRequestAcc(
+        url: '$_baseUrl/chat/completions',
+        headers: _getHeaders(apiKey: apiKey),
+        body: JsonRequestBody(request.toJson()),
+      ),
+    );
+    switch (response.body) {
+      case MapJsonResponseBody(:final data):
+        return ChatCompletionResponse.fromJson(data);
+      case _:
+        throw Exception('Failed to chat completion: ${response.body}');
+    }
+  }
+
+  static Future<ModelList> listModels({required String apiKey}) async {
+    final response = await Api.get(
+      requestAcc: GetRequestAcc(
+        url: '$_baseUrl/models',
+        headers: _getHeaders(apiKey: apiKey),
+      ),
+    );
+    switch (response.body) {
+      case MapJsonResponseBody(:final data):
+        return ModelList.fromJson(data);
+      case _:
+        throw Exception('Failed to list models: ${response.body}');
+    }
+  }
+
+  static RestHeaders _getHeaders({required String apiKey}) {
+    return RestHeaders({
+      'Authorization': 'Bearer $apiKey',
+      'Content-Type': 'application/json',
+    });
+  }
+}

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'chat_completion_message.freezed.dart';
+part 'chat_completion_message.g.dart';
+
+@freezed
+abstract class ChatCompletionMessage with _$ChatCompletionMessage {
+  factory ChatCompletionMessage({
+    required ChatCompletionRole role,
+    required String content,
+    String? name,
+    @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls,
+  }) = _ChatCompletionMessage;
+
+  factory ChatCompletionMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionMessageFromJson(json);
+  const ChatCompletionMessage._();
+}
+
+enum ChatCompletionRole { system, user, assistant, tool }

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.freezed.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.freezed.dart
@@ -1,0 +1,394 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_message.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionMessage {
+  ChatCompletionRole get role;
+  String get content;
+  String? get name;
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls;
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionMessageCopyWith<ChatCompletionMessage> get copyWith =>
+      _$ChatCompletionMessageCopyWithImpl<ChatCompletionMessage>(
+          this as ChatCompletionMessage, _$identity);
+
+  /// Serializes this ChatCompletionMessage to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.name, name) || other.name == name) &&
+            const DeepCollectionEquality().equals(other.toolCalls, toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, name,
+      const DeepCollectionEquality().hash(toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionMessage(role: $role, content: $content, name: $name, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionMessageCopyWith<$Res> {
+  factory $ChatCompletionMessageCopyWith(ChatCompletionMessage value,
+          $Res Function(ChatCompletionMessage) _then) =
+      _$ChatCompletionMessageCopyWithImpl;
+  @useResult
+  $Res call(
+      {ChatCompletionRole role,
+      String content,
+      String? name,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class _$ChatCompletionMessageCopyWithImpl<$Res>
+    implements $ChatCompletionMessageCopyWith<$Res> {
+  _$ChatCompletionMessageCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionMessage _self;
+  final $Res Function(ChatCompletionMessage) _then;
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? role = null,
+    Object? content = null,
+    Object? name = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_self.copyWith(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionRole,
+      content: null == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: freezed == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self.toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionMessage].
+extension ChatCompletionMessagePatterns on ChatCompletionMessage {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionMessage value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionMessage value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionMessage value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(ChatCompletionRole role, String content, String? name,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.name, _that.toolCalls);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(ChatCompletionRole role, String content, String? name,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage():
+        return $default(_that.role, _that.content, _that.name, _that.toolCalls);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(ChatCompletionRole role, String content, String? name,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.name, _that.toolCalls);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionMessage extends ChatCompletionMessage {
+  _ChatCompletionMessage(
+      {required this.role,
+      required this.content,
+      this.name,
+      @JsonKey(name: 'tool_calls') final List<Map<String, dynamic>>? toolCalls})
+      : _toolCalls = toolCalls,
+        super._();
+  factory _ChatCompletionMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionMessageFromJson(json);
+
+  @override
+  final ChatCompletionRole role;
+  @override
+  final String content;
+  @override
+  final String? name;
+  final List<Map<String, dynamic>>? _toolCalls;
+  @override
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls {
+    final value = _toolCalls;
+    if (value == null) return null;
+    if (_toolCalls is EqualUnmodifiableListView) return _toolCalls;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionMessageCopyWith<_ChatCompletionMessage> get copyWith =>
+      __$ChatCompletionMessageCopyWithImpl<_ChatCompletionMessage>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionMessageToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.name, name) || other.name == name) &&
+            const DeepCollectionEquality()
+                .equals(other._toolCalls, _toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, name,
+      const DeepCollectionEquality().hash(_toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionMessage(role: $role, content: $content, name: $name, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionMessageCopyWith<$Res>
+    implements $ChatCompletionMessageCopyWith<$Res> {
+  factory _$ChatCompletionMessageCopyWith(_ChatCompletionMessage value,
+          $Res Function(_ChatCompletionMessage) _then) =
+      __$ChatCompletionMessageCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {ChatCompletionRole role,
+      String content,
+      String? name,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class __$ChatCompletionMessageCopyWithImpl<$Res>
+    implements _$ChatCompletionMessageCopyWith<$Res> {
+  __$ChatCompletionMessageCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionMessage _self;
+  final $Res Function(_ChatCompletionMessage) _then;
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? role = null,
+    Object? content = null,
+    Object? name = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_ChatCompletionMessage(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionRole,
+      content: null == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: freezed == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self._toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.g.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.g.dart
@@ -1,0 +1,34 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_message.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionMessage _$ChatCompletionMessageFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionMessage(
+      role: $enumDecode(_$ChatCompletionRoleEnumMap, json['role']),
+      content: json['content'] as String,
+      name: json['name'] as String?,
+      toolCalls: (json['tool_calls'] as List<dynamic>?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+    );
+
+Map<String, dynamic> _$ChatCompletionMessageToJson(
+        _ChatCompletionMessage instance) =>
+    <String, dynamic>{
+      'role': _$ChatCompletionRoleEnumMap[instance.role]!,
+      'content': instance.content,
+      'name': instance.name,
+      'tool_calls': instance.toolCalls,
+    };
+
+const _$ChatCompletionRoleEnumMap = {
+  ChatCompletionRole.system: 'system',
+  ChatCompletionRole.user: 'user',
+  ChatCompletionRole.assistant: 'assistant',
+  ChatCompletionRole.tool: 'tool',
+};

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:qwen_box/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart';
+
+part 'chat_completion_request.freezed.dart';
+part 'chat_completion_request.g.dart';
+
+/// https://www.alibabacloud.com/help/en/model-studio/text-generation
+@freezed
+abstract class ChatCompletionRequest with _$ChatCompletionRequest {
+  factory ChatCompletionRequest({
+    required List<ChatCompletionMessage> messages,
+    required String model,
+    @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+    @JsonKey(name: 'max_tokens') int? maxTokens,
+    @JsonKey(name: 'presence_penalty') double? presencePenalty,
+    @JsonKey(name: 'response_format') Map<String, dynamic>? responseFormat,
+    int? seed,
+    List<String>? stop,
+    bool? stream,
+    double? temperature,
+    @JsonKey(name: 'top_p') double? topP,
+    List<Map<String, dynamic>>? tools,
+    @JsonKey(name: 'tool_choice') dynamic toolChoice,
+    bool? logprobs,
+    @JsonKey(name: 'top_logprobs') int? topLogprobs,
+  }) = _ChatCompletionRequest;
+
+  factory ChatCompletionRequest.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionRequestFromJson(json);
+  const ChatCompletionRequest._();
+}

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.freezed.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.freezed.dart
@@ -1,0 +1,766 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_request.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionRequest {
+  List<ChatCompletionMessage> get messages;
+  String get model;
+  @JsonKey(name: 'frequency_penalty')
+  double? get frequencyPenalty;
+  @JsonKey(name: 'max_tokens')
+  int? get maxTokens;
+  @JsonKey(name: 'presence_penalty')
+  double? get presencePenalty;
+  @JsonKey(name: 'response_format')
+  Map<String, dynamic>? get responseFormat;
+  int? get seed;
+  List<String>? get stop;
+  bool? get stream;
+  double? get temperature;
+  @JsonKey(name: 'top_p')
+  double? get topP;
+  List<Map<String, dynamic>>? get tools;
+  @JsonKey(name: 'tool_choice')
+  dynamic get toolChoice;
+  bool? get logprobs;
+  @JsonKey(name: 'top_logprobs')
+  int? get topLogprobs;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionRequestCopyWith<ChatCompletionRequest> get copyWith =>
+      _$ChatCompletionRequestCopyWithImpl<ChatCompletionRequest>(
+          this as ChatCompletionRequest, _$identity);
+
+  /// Serializes this ChatCompletionRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionRequest &&
+            const DeepCollectionEquality().equals(other.messages, messages) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.frequencyPenalty, frequencyPenalty) ||
+                other.frequencyPenalty == frequencyPenalty) &&
+            (identical(other.maxTokens, maxTokens) ||
+                other.maxTokens == maxTokens) &&
+            (identical(other.presencePenalty, presencePenalty) ||
+                other.presencePenalty == presencePenalty) &&
+            const DeepCollectionEquality()
+                .equals(other.responseFormat, responseFormat) &&
+            (identical(other.seed, seed) || other.seed == seed) &&
+            const DeepCollectionEquality().equals(other.stop, stop) &&
+            (identical(other.stream, stream) || other.stream == stream) &&
+            (identical(other.temperature, temperature) ||
+                other.temperature == temperature) &&
+            (identical(other.topP, topP) || other.topP == topP) &&
+            const DeepCollectionEquality().equals(other.tools, tools) &&
+            const DeepCollectionEquality()
+                .equals(other.toolChoice, toolChoice) &&
+            (identical(other.logprobs, logprobs) ||
+                other.logprobs == logprobs) &&
+            (identical(other.topLogprobs, topLogprobs) ||
+                other.topLogprobs == topLogprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(messages),
+      model,
+      frequencyPenalty,
+      maxTokens,
+      presencePenalty,
+      const DeepCollectionEquality().hash(responseFormat),
+      seed,
+      const DeepCollectionEquality().hash(stop),
+      stream,
+      temperature,
+      topP,
+      const DeepCollectionEquality().hash(tools),
+      const DeepCollectionEquality().hash(toolChoice),
+      logprobs,
+      topLogprobs);
+
+  @override
+  String toString() {
+    return 'ChatCompletionRequest(messages: $messages, model: $model, frequencyPenalty: $frequencyPenalty, maxTokens: $maxTokens, presencePenalty: $presencePenalty, responseFormat: $responseFormat, seed: $seed, stop: $stop, stream: $stream, temperature: $temperature, topP: $topP, tools: $tools, toolChoice: $toolChoice, logprobs: $logprobs, topLogprobs: $topLogprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionRequestCopyWith<$Res> {
+  factory $ChatCompletionRequestCopyWith(ChatCompletionRequest value,
+          $Res Function(ChatCompletionRequest) _then) =
+      _$ChatCompletionRequestCopyWithImpl;
+  @useResult
+  $Res call(
+      {List<ChatCompletionMessage> messages,
+      String model,
+      @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+      @JsonKey(name: 'max_tokens') int? maxTokens,
+      @JsonKey(name: 'presence_penalty') double? presencePenalty,
+      @JsonKey(name: 'response_format') Map<String, dynamic>? responseFormat,
+      int? seed,
+      List<String>? stop,
+      bool? stream,
+      double? temperature,
+      @JsonKey(name: 'top_p') double? topP,
+      List<Map<String, dynamic>>? tools,
+      @JsonKey(name: 'tool_choice') dynamic toolChoice,
+      bool? logprobs,
+      @JsonKey(name: 'top_logprobs') int? topLogprobs});
+}
+
+/// @nodoc
+class _$ChatCompletionRequestCopyWithImpl<$Res>
+    implements $ChatCompletionRequestCopyWith<$Res> {
+  _$ChatCompletionRequestCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionRequest _self;
+  final $Res Function(ChatCompletionRequest) _then;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? messages = null,
+    Object? model = null,
+    Object? frequencyPenalty = freezed,
+    Object? maxTokens = freezed,
+    Object? presencePenalty = freezed,
+    Object? responseFormat = freezed,
+    Object? seed = freezed,
+    Object? stop = freezed,
+    Object? stream = freezed,
+    Object? temperature = freezed,
+    Object? topP = freezed,
+    Object? tools = freezed,
+    Object? toolChoice = freezed,
+    Object? logprobs = freezed,
+    Object? topLogprobs = freezed,
+  }) {
+    return _then(_self.copyWith(
+      messages: null == messages
+          ? _self.messages
+          : messages // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionMessage>,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      frequencyPenalty: freezed == frequencyPenalty
+          ? _self.frequencyPenalty
+          : frequencyPenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      maxTokens: freezed == maxTokens
+          ? _self.maxTokens
+          : maxTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      presencePenalty: freezed == presencePenalty
+          ? _self.presencePenalty
+          : presencePenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      responseFormat: freezed == responseFormat
+          ? _self.responseFormat
+          : responseFormat // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+      seed: freezed == seed
+          ? _self.seed
+          : seed // ignore: cast_nullable_to_non_nullable
+              as int?,
+      stop: freezed == stop
+          ? _self.stop
+          : stop // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      stream: freezed == stream
+          ? _self.stream
+          : stream // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      temperature: freezed == temperature
+          ? _self.temperature
+          : temperature // ignore: cast_nullable_to_non_nullable
+              as double?,
+      topP: freezed == topP
+          ? _self.topP
+          : topP // ignore: cast_nullable_to_non_nullable
+              as double?,
+      tools: freezed == tools
+          ? _self.tools
+          : tools // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+      toolChoice: freezed == toolChoice
+          ? _self.toolChoice
+          : toolChoice // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      logprobs: freezed == logprobs
+          ? _self.logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      topLogprobs: freezed == topLogprobs
+          ? _self.topLogprobs
+          : topLogprobs // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionRequest].
+extension ChatCompletionRequestPatterns on ChatCompletionRequest {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionRequest value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionRequest value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionRequest value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionMessage> messages,
+            String model,
+            @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+            @JsonKey(name: 'max_tokens') int? maxTokens,
+            @JsonKey(name: 'presence_penalty') double? presencePenalty,
+            @JsonKey(name: 'response_format')
+            Map<String, dynamic>? responseFormat,
+            int? seed,
+            List<String>? stop,
+            bool? stream,
+            double? temperature,
+            @JsonKey(name: 'top_p') double? topP,
+            List<Map<String, dynamic>>? tools,
+            @JsonKey(name: 'tool_choice') dynamic toolChoice,
+            bool? logprobs,
+            @JsonKey(name: 'top_logprobs') int? topLogprobs)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(
+            _that.messages,
+            _that.model,
+            _that.frequencyPenalty,
+            _that.maxTokens,
+            _that.presencePenalty,
+            _that.responseFormat,
+            _that.seed,
+            _that.stop,
+            _that.stream,
+            _that.temperature,
+            _that.topP,
+            _that.tools,
+            _that.toolChoice,
+            _that.logprobs,
+            _that.topLogprobs);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionMessage> messages,
+            String model,
+            @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+            @JsonKey(name: 'max_tokens') int? maxTokens,
+            @JsonKey(name: 'presence_penalty') double? presencePenalty,
+            @JsonKey(name: 'response_format')
+            Map<String, dynamic>? responseFormat,
+            int? seed,
+            List<String>? stop,
+            bool? stream,
+            double? temperature,
+            @JsonKey(name: 'top_p') double? topP,
+            List<Map<String, dynamic>>? tools,
+            @JsonKey(name: 'tool_choice') dynamic toolChoice,
+            bool? logprobs,
+            @JsonKey(name: 'top_logprobs') int? topLogprobs)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest():
+        return $default(
+            _that.messages,
+            _that.model,
+            _that.frequencyPenalty,
+            _that.maxTokens,
+            _that.presencePenalty,
+            _that.responseFormat,
+            _that.seed,
+            _that.stop,
+            _that.stream,
+            _that.temperature,
+            _that.topP,
+            _that.tools,
+            _that.toolChoice,
+            _that.logprobs,
+            _that.topLogprobs);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            List<ChatCompletionMessage> messages,
+            String model,
+            @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+            @JsonKey(name: 'max_tokens') int? maxTokens,
+            @JsonKey(name: 'presence_penalty') double? presencePenalty,
+            @JsonKey(name: 'response_format')
+            Map<String, dynamic>? responseFormat,
+            int? seed,
+            List<String>? stop,
+            bool? stream,
+            double? temperature,
+            @JsonKey(name: 'top_p') double? topP,
+            List<Map<String, dynamic>>? tools,
+            @JsonKey(name: 'tool_choice') dynamic toolChoice,
+            bool? logprobs,
+            @JsonKey(name: 'top_logprobs') int? topLogprobs)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(
+            _that.messages,
+            _that.model,
+            _that.frequencyPenalty,
+            _that.maxTokens,
+            _that.presencePenalty,
+            _that.responseFormat,
+            _that.seed,
+            _that.stop,
+            _that.stream,
+            _that.temperature,
+            _that.topP,
+            _that.tools,
+            _that.toolChoice,
+            _that.logprobs,
+            _that.topLogprobs);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionRequest extends ChatCompletionRequest {
+  _ChatCompletionRequest(
+      {required final List<ChatCompletionMessage> messages,
+      required this.model,
+      @JsonKey(name: 'frequency_penalty') this.frequencyPenalty,
+      @JsonKey(name: 'max_tokens') this.maxTokens,
+      @JsonKey(name: 'presence_penalty') this.presencePenalty,
+      @JsonKey(name: 'response_format')
+      final Map<String, dynamic>? responseFormat,
+      this.seed,
+      final List<String>? stop,
+      this.stream,
+      this.temperature,
+      @JsonKey(name: 'top_p') this.topP,
+      final List<Map<String, dynamic>>? tools,
+      @JsonKey(name: 'tool_choice') this.toolChoice,
+      this.logprobs,
+      @JsonKey(name: 'top_logprobs') this.topLogprobs})
+      : _messages = messages,
+        _responseFormat = responseFormat,
+        _stop = stop,
+        _tools = tools,
+        super._();
+  factory _ChatCompletionRequest.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionRequestFromJson(json);
+
+  final List<ChatCompletionMessage> _messages;
+  @override
+  List<ChatCompletionMessage> get messages {
+    if (_messages is EqualUnmodifiableListView) return _messages;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_messages);
+  }
+
+  @override
+  final String model;
+  @override
+  @JsonKey(name: 'frequency_penalty')
+  final double? frequencyPenalty;
+  @override
+  @JsonKey(name: 'max_tokens')
+  final int? maxTokens;
+  @override
+  @JsonKey(name: 'presence_penalty')
+  final double? presencePenalty;
+  final Map<String, dynamic>? _responseFormat;
+  @override
+  @JsonKey(name: 'response_format')
+  Map<String, dynamic>? get responseFormat {
+    final value = _responseFormat;
+    if (value == null) return null;
+    if (_responseFormat is EqualUnmodifiableMapView) return _responseFormat;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(value);
+  }
+
+  @override
+  final int? seed;
+  final List<String>? _stop;
+  @override
+  List<String>? get stop {
+    final value = _stop;
+    if (value == null) return null;
+    if (_stop is EqualUnmodifiableListView) return _stop;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  final bool? stream;
+  @override
+  final double? temperature;
+  @override
+  @JsonKey(name: 'top_p')
+  final double? topP;
+  final List<Map<String, dynamic>>? _tools;
+  @override
+  List<Map<String, dynamic>>? get tools {
+    final value = _tools;
+    if (value == null) return null;
+    if (_tools is EqualUnmodifiableListView) return _tools;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  @JsonKey(name: 'tool_choice')
+  final dynamic toolChoice;
+  @override
+  final bool? logprobs;
+  @override
+  @JsonKey(name: 'top_logprobs')
+  final int? topLogprobs;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionRequestCopyWith<_ChatCompletionRequest> get copyWith =>
+      __$ChatCompletionRequestCopyWithImpl<_ChatCompletionRequest>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionRequestToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionRequest &&
+            const DeepCollectionEquality().equals(other._messages, _messages) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.frequencyPenalty, frequencyPenalty) ||
+                other.frequencyPenalty == frequencyPenalty) &&
+            (identical(other.maxTokens, maxTokens) ||
+                other.maxTokens == maxTokens) &&
+            (identical(other.presencePenalty, presencePenalty) ||
+                other.presencePenalty == presencePenalty) &&
+            const DeepCollectionEquality()
+                .equals(other._responseFormat, _responseFormat) &&
+            (identical(other.seed, seed) || other.seed == seed) &&
+            const DeepCollectionEquality().equals(other._stop, _stop) &&
+            (identical(other.stream, stream) || other.stream == stream) &&
+            (identical(other.temperature, temperature) ||
+                other.temperature == temperature) &&
+            (identical(other.topP, topP) || other.topP == topP) &&
+            const DeepCollectionEquality().equals(other._tools, _tools) &&
+            const DeepCollectionEquality()
+                .equals(other.toolChoice, toolChoice) &&
+            (identical(other.logprobs, logprobs) ||
+                other.logprobs == logprobs) &&
+            (identical(other.topLogprobs, topLogprobs) ||
+                other.topLogprobs == topLogprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_messages),
+      model,
+      frequencyPenalty,
+      maxTokens,
+      presencePenalty,
+      const DeepCollectionEquality().hash(_responseFormat),
+      seed,
+      const DeepCollectionEquality().hash(_stop),
+      stream,
+      temperature,
+      topP,
+      const DeepCollectionEquality().hash(_tools),
+      const DeepCollectionEquality().hash(toolChoice),
+      logprobs,
+      topLogprobs);
+
+  @override
+  String toString() {
+    return 'ChatCompletionRequest(messages: $messages, model: $model, frequencyPenalty: $frequencyPenalty, maxTokens: $maxTokens, presencePenalty: $presencePenalty, responseFormat: $responseFormat, seed: $seed, stop: $stop, stream: $stream, temperature: $temperature, topP: $topP, tools: $tools, toolChoice: $toolChoice, logprobs: $logprobs, topLogprobs: $topLogprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionRequestCopyWith<$Res>
+    implements $ChatCompletionRequestCopyWith<$Res> {
+  factory _$ChatCompletionRequestCopyWith(_ChatCompletionRequest value,
+          $Res Function(_ChatCompletionRequest) _then) =
+      __$ChatCompletionRequestCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {List<ChatCompletionMessage> messages,
+      String model,
+      @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+      @JsonKey(name: 'max_tokens') int? maxTokens,
+      @JsonKey(name: 'presence_penalty') double? presencePenalty,
+      @JsonKey(name: 'response_format') Map<String, dynamic>? responseFormat,
+      int? seed,
+      List<String>? stop,
+      bool? stream,
+      double? temperature,
+      @JsonKey(name: 'top_p') double? topP,
+      List<Map<String, dynamic>>? tools,
+      @JsonKey(name: 'tool_choice') dynamic toolChoice,
+      bool? logprobs,
+      @JsonKey(name: 'top_logprobs') int? topLogprobs});
+}
+
+/// @nodoc
+class __$ChatCompletionRequestCopyWithImpl<$Res>
+    implements _$ChatCompletionRequestCopyWith<$Res> {
+  __$ChatCompletionRequestCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionRequest _self;
+  final $Res Function(_ChatCompletionRequest) _then;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? messages = null,
+    Object? model = null,
+    Object? frequencyPenalty = freezed,
+    Object? maxTokens = freezed,
+    Object? presencePenalty = freezed,
+    Object? responseFormat = freezed,
+    Object? seed = freezed,
+    Object? stop = freezed,
+    Object? stream = freezed,
+    Object? temperature = freezed,
+    Object? topP = freezed,
+    Object? tools = freezed,
+    Object? toolChoice = freezed,
+    Object? logprobs = freezed,
+    Object? topLogprobs = freezed,
+  }) {
+    return _then(_ChatCompletionRequest(
+      messages: null == messages
+          ? _self._messages
+          : messages // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionMessage>,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      frequencyPenalty: freezed == frequencyPenalty
+          ? _self.frequencyPenalty
+          : frequencyPenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      maxTokens: freezed == maxTokens
+          ? _self.maxTokens
+          : maxTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      presencePenalty: freezed == presencePenalty
+          ? _self.presencePenalty
+          : presencePenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      responseFormat: freezed == responseFormat
+          ? _self._responseFormat
+          : responseFormat // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+      seed: freezed == seed
+          ? _self.seed
+          : seed // ignore: cast_nullable_to_non_nullable
+              as int?,
+      stop: freezed == stop
+          ? _self._stop
+          : stop // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      stream: freezed == stream
+          ? _self.stream
+          : stream // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      temperature: freezed == temperature
+          ? _self.temperature
+          : temperature // ignore: cast_nullable_to_non_nullable
+              as double?,
+      topP: freezed == topP
+          ? _self.topP
+          : topP // ignore: cast_nullable_to_non_nullable
+              as double?,
+      tools: freezed == tools
+          ? _self._tools
+          : tools // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+      toolChoice: freezed == toolChoice
+          ? _self.toolChoice
+          : toolChoice // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      logprobs: freezed == logprobs
+          ? _self.logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      topLogprobs: freezed == topLogprobs
+          ? _self.topLogprobs
+          : topLogprobs // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.g.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.g.dart
@@ -1,0 +1,51 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionRequest _$ChatCompletionRequestFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionRequest(
+      messages: (json['messages'] as List<dynamic>)
+          .map((e) => ChatCompletionMessage.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      model: json['model'] as String,
+      frequencyPenalty: (json['frequency_penalty'] as num?)?.toDouble(),
+      maxTokens: (json['max_tokens'] as num?)?.toInt(),
+      presencePenalty: (json['presence_penalty'] as num?)?.toDouble(),
+      responseFormat: json['response_format'] as Map<String, dynamic>?,
+      seed: (json['seed'] as num?)?.toInt(),
+      stop: (json['stop'] as List<dynamic>?)?.map((e) => e as String).toList(),
+      stream: json['stream'] as bool?,
+      temperature: (json['temperature'] as num?)?.toDouble(),
+      topP: (json['top_p'] as num?)?.toDouble(),
+      tools: (json['tools'] as List<dynamic>?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+      toolChoice: json['tool_choice'],
+      logprobs: json['logprobs'] as bool?,
+      topLogprobs: (json['top_logprobs'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$ChatCompletionRequestToJson(
+        _ChatCompletionRequest instance) =>
+    <String, dynamic>{
+      'messages': instance.messages,
+      'model': instance.model,
+      'frequency_penalty': instance.frequencyPenalty,
+      'max_tokens': instance.maxTokens,
+      'presence_penalty': instance.presencePenalty,
+      'response_format': instance.responseFormat,
+      'seed': instance.seed,
+      'stop': instance.stop,
+      'stream': instance.stream,
+      'temperature': instance.temperature,
+      'top_p': instance.topP,
+      'tools': instance.tools,
+      'tool_choice': instance.toolChoice,
+      'logprobs': instance.logprobs,
+      'top_logprobs': instance.topLogprobs,
+    };

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:qwen_box/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart';
+import 'package:qwen_box/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart';
+
+part 'chat_completion_response.freezed.dart';
+part 'chat_completion_response.g.dart';
+
+/// https://www.alibabacloud.com/help/en/model-studio/text-generation
+@freezed
+abstract class ChatCompletionResponse with _$ChatCompletionResponse {
+  factory ChatCompletionResponse({
+    required List<ChatCompletionResponseChoice> choices,
+    required int created,
+    required String id,
+    required String model,
+    required String object,
+    @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+    ChatCompletionResponseUsage? usage,
+  }) = _ChatCompletionResponse;
+
+  factory ChatCompletionResponse.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseFromJson(json);
+  const ChatCompletionResponse._();
+}

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.freezed.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.freezed.dart
@@ -1,0 +1,516 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponse {
+  List<ChatCompletionResponseChoice> get choices;
+  int get created;
+  String get id;
+  String get model;
+  String get object;
+  @JsonKey(name: 'system_fingerprint')
+  String? get systemFingerprint;
+  ChatCompletionResponseUsage? get usage;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseCopyWith<ChatCompletionResponse> get copyWith =>
+      _$ChatCompletionResponseCopyWithImpl<ChatCompletionResponse>(
+          this as ChatCompletionResponse, _$identity);
+
+  /// Serializes this ChatCompletionResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponse &&
+            const DeepCollectionEquality().equals(other.choices, choices) &&
+            (identical(other.created, created) || other.created == created) &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.systemFingerprint, systemFingerprint) ||
+                other.systemFingerprint == systemFingerprint) &&
+            (identical(other.usage, usage) || other.usage == usage));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(choices),
+      created,
+      id,
+      model,
+      object,
+      systemFingerprint,
+      usage);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponse(choices: $choices, created: $created, id: $id, model: $model, object: $object, systemFingerprint: $systemFingerprint, usage: $usage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseCopyWith<$Res> {
+  factory $ChatCompletionResponseCopyWith(ChatCompletionResponse value,
+          $Res Function(ChatCompletionResponse) _then) =
+      _$ChatCompletionResponseCopyWithImpl;
+  @useResult
+  $Res call(
+      {List<ChatCompletionResponseChoice> choices,
+      int created,
+      String id,
+      String model,
+      String object,
+      @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+      ChatCompletionResponseUsage? usage});
+
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage;
+}
+
+/// @nodoc
+class _$ChatCompletionResponseCopyWithImpl<$Res>
+    implements $ChatCompletionResponseCopyWith<$Res> {
+  _$ChatCompletionResponseCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponse _self;
+  final $Res Function(ChatCompletionResponse) _then;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? choices = null,
+    Object? created = null,
+    Object? id = null,
+    Object? model = null,
+    Object? object = null,
+    Object? systemFingerprint = freezed,
+    Object? usage = freezed,
+  }) {
+    return _then(_self.copyWith(
+      choices: null == choices
+          ? _self.choices
+          : choices // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionResponseChoice>,
+      created: null == created
+          ? _self.created
+          : created // ignore: cast_nullable_to_non_nullable
+              as int,
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      systemFingerprint: freezed == systemFingerprint
+          ? _self.systemFingerprint
+          : systemFingerprint // ignore: cast_nullable_to_non_nullable
+              as String?,
+      usage: freezed == usage
+          ? _self.usage
+          : usage // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsage?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage {
+    if (_self.usage == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCopyWith<$Res>(_self.usage!, (value) {
+      return _then(_self.copyWith(usage: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponse].
+extension ChatCompletionResponsePatterns on ChatCompletionResponse {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponse value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponse value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponse value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionResponseChoice> choices,
+            int created,
+            String id,
+            String model,
+            String object,
+            @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+            ChatCompletionResponseUsage? usage)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that.choices, _that.created, _that.id, _that.model,
+            _that.object, _that.systemFingerprint, _that.usage);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionResponseChoice> choices,
+            int created,
+            String id,
+            String model,
+            String object,
+            @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+            ChatCompletionResponseUsage? usage)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse():
+        return $default(_that.choices, _that.created, _that.id, _that.model,
+            _that.object, _that.systemFingerprint, _that.usage);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            List<ChatCompletionResponseChoice> choices,
+            int created,
+            String id,
+            String model,
+            String object,
+            @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+            ChatCompletionResponseUsage? usage)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that.choices, _that.created, _that.id, _that.model,
+            _that.object, _that.systemFingerprint, _that.usage);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponse extends ChatCompletionResponse {
+  _ChatCompletionResponse(
+      {required final List<ChatCompletionResponseChoice> choices,
+      required this.created,
+      required this.id,
+      required this.model,
+      required this.object,
+      @JsonKey(name: 'system_fingerprint') this.systemFingerprint,
+      this.usage})
+      : _choices = choices,
+        super._();
+  factory _ChatCompletionResponse.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseFromJson(json);
+
+  final List<ChatCompletionResponseChoice> _choices;
+  @override
+  List<ChatCompletionResponseChoice> get choices {
+    if (_choices is EqualUnmodifiableListView) return _choices;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_choices);
+  }
+
+  @override
+  final int created;
+  @override
+  final String id;
+  @override
+  final String model;
+  @override
+  final String object;
+  @override
+  @JsonKey(name: 'system_fingerprint')
+  final String? systemFingerprint;
+  @override
+  final ChatCompletionResponseUsage? usage;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseCopyWith<_ChatCompletionResponse> get copyWith =>
+      __$ChatCompletionResponseCopyWithImpl<_ChatCompletionResponse>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponse &&
+            const DeepCollectionEquality().equals(other._choices, _choices) &&
+            (identical(other.created, created) || other.created == created) &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.systemFingerprint, systemFingerprint) ||
+                other.systemFingerprint == systemFingerprint) &&
+            (identical(other.usage, usage) || other.usage == usage));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_choices),
+      created,
+      id,
+      model,
+      object,
+      systemFingerprint,
+      usage);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponse(choices: $choices, created: $created, id: $id, model: $model, object: $object, systemFingerprint: $systemFingerprint, usage: $usage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseCopyWith<$Res>
+    implements $ChatCompletionResponseCopyWith<$Res> {
+  factory _$ChatCompletionResponseCopyWith(_ChatCompletionResponse value,
+          $Res Function(_ChatCompletionResponse) _then) =
+      __$ChatCompletionResponseCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {List<ChatCompletionResponseChoice> choices,
+      int created,
+      String id,
+      String model,
+      String object,
+      @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+      ChatCompletionResponseUsage? usage});
+
+  @override
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage;
+}
+
+/// @nodoc
+class __$ChatCompletionResponseCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseCopyWith<$Res> {
+  __$ChatCompletionResponseCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponse _self;
+  final $Res Function(_ChatCompletionResponse) _then;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? choices = null,
+    Object? created = null,
+    Object? id = null,
+    Object? model = null,
+    Object? object = null,
+    Object? systemFingerprint = freezed,
+    Object? usage = freezed,
+  }) {
+    return _then(_ChatCompletionResponse(
+      choices: null == choices
+          ? _self._choices
+          : choices // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionResponseChoice>,
+      created: null == created
+          ? _self.created
+          : created // ignore: cast_nullable_to_non_nullable
+              as int,
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      systemFingerprint: freezed == systemFingerprint
+          ? _self.systemFingerprint
+          : systemFingerprint // ignore: cast_nullable_to_non_nullable
+              as String?,
+      usage: freezed == usage
+          ? _self.usage
+          : usage // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsage?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage {
+    if (_self.usage == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCopyWith<$Res>(_self.usage!, (value) {
+      return _then(_self.copyWith(usage: value));
+    });
+  }
+}
+
+// dart format on

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.g.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponse _$ChatCompletionResponseFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponse(
+      choices: (json['choices'] as List<dynamic>)
+          .map((e) =>
+              ChatCompletionResponseChoice.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      created: (json['created'] as num).toInt(),
+      id: json['id'] as String,
+      model: json['model'] as String,
+      object: json['object'] as String,
+      systemFingerprint: json['system_fingerprint'] as String?,
+      usage: json['usage'] == null
+          ? null
+          : ChatCompletionResponseUsage.fromJson(
+              json['usage'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseToJson(
+        _ChatCompletionResponse instance) =>
+    <String, dynamic>{
+      'choices': instance.choices,
+      'created': instance.created,
+      'id': instance.id,
+      'model': instance.model,
+      'object': instance.object,
+      'system_fingerprint': instance.systemFingerprint,
+      'usage': instance.usage,
+    };

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:qwen_box/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart';
+
+part 'chat_completion_response_choice.freezed.dart';
+part 'chat_completion_response_choice.g.dart';
+
+@freezed
+abstract class ChatCompletionResponseChoice
+    with _$ChatCompletionResponseChoice {
+  factory ChatCompletionResponseChoice({
+    required int index,
+    required ChatCompletionResponseMessage message,
+    @JsonKey(name: 'finish_reason') String? finishReason,
+    Map<String, dynamic>? logprobs,
+  }) = _ChatCompletionResponseChoice;
+
+  factory ChatCompletionResponseChoice.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseChoiceFromJson(json);
+  const ChatCompletionResponseChoice._();
+}

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.freezed.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.freezed.dart
@@ -1,0 +1,435 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response_choice.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponseChoice {
+  int get index;
+  ChatCompletionResponseMessage get message;
+  @JsonKey(name: 'finish_reason')
+  String? get finishReason;
+  Map<String, dynamic>? get logprobs;
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseChoiceCopyWith<ChatCompletionResponseChoice>
+      get copyWith => _$ChatCompletionResponseChoiceCopyWithImpl<
+              ChatCompletionResponseChoice>(
+          this as ChatCompletionResponseChoice, _$identity);
+
+  /// Serializes this ChatCompletionResponseChoice to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseChoice &&
+            (identical(other.index, index) || other.index == index) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.finishReason, finishReason) ||
+                other.finishReason == finishReason) &&
+            const DeepCollectionEquality().equals(other.logprobs, logprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, index, message, finishReason,
+      const DeepCollectionEquality().hash(logprobs));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseChoice(index: $index, message: $message, finishReason: $finishReason, logprobs: $logprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseChoiceCopyWith<$Res> {
+  factory $ChatCompletionResponseChoiceCopyWith(
+          ChatCompletionResponseChoice value,
+          $Res Function(ChatCompletionResponseChoice) _then) =
+      _$ChatCompletionResponseChoiceCopyWithImpl;
+  @useResult
+  $Res call(
+      {int index,
+      ChatCompletionResponseMessage message,
+      @JsonKey(name: 'finish_reason') String? finishReason,
+      Map<String, dynamic>? logprobs});
+
+  $ChatCompletionResponseMessageCopyWith<$Res> get message;
+}
+
+/// @nodoc
+class _$ChatCompletionResponseChoiceCopyWithImpl<$Res>
+    implements $ChatCompletionResponseChoiceCopyWith<$Res> {
+  _$ChatCompletionResponseChoiceCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponseChoice _self;
+  final $Res Function(ChatCompletionResponseChoice) _then;
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? index = null,
+    Object? message = null,
+    Object? finishReason = freezed,
+    Object? logprobs = freezed,
+  }) {
+    return _then(_self.copyWith(
+      index: null == index
+          ? _self.index
+          : index // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseMessage,
+      finishReason: freezed == finishReason
+          ? _self.finishReason
+          : finishReason // ignore: cast_nullable_to_non_nullable
+              as String?,
+      logprobs: freezed == logprobs
+          ? _self.logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseMessageCopyWith<$Res> get message {
+    return $ChatCompletionResponseMessageCopyWith<$Res>(_self.message, (value) {
+      return _then(_self.copyWith(message: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseChoice].
+extension ChatCompletionResponseChoicePatterns on ChatCompletionResponseChoice {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseChoice value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseChoice value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponseChoice value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            int index,
+            ChatCompletionResponseMessage message,
+            @JsonKey(name: 'finish_reason') String? finishReason,
+            Map<String, dynamic>? logprobs)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(
+            _that.index, _that.message, _that.finishReason, _that.logprobs);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            int index,
+            ChatCompletionResponseMessage message,
+            @JsonKey(name: 'finish_reason') String? finishReason,
+            Map<String, dynamic>? logprobs)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice():
+        return $default(
+            _that.index, _that.message, _that.finishReason, _that.logprobs);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            int index,
+            ChatCompletionResponseMessage message,
+            @JsonKey(name: 'finish_reason') String? finishReason,
+            Map<String, dynamic>? logprobs)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(
+            _that.index, _that.message, _that.finishReason, _that.logprobs);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseChoice extends ChatCompletionResponseChoice {
+  _ChatCompletionResponseChoice(
+      {required this.index,
+      required this.message,
+      @JsonKey(name: 'finish_reason') this.finishReason,
+      final Map<String, dynamic>? logprobs})
+      : _logprobs = logprobs,
+        super._();
+  factory _ChatCompletionResponseChoice.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseChoiceFromJson(json);
+
+  @override
+  final int index;
+  @override
+  final ChatCompletionResponseMessage message;
+  @override
+  @JsonKey(name: 'finish_reason')
+  final String? finishReason;
+  final Map<String, dynamic>? _logprobs;
+  @override
+  Map<String, dynamic>? get logprobs {
+    final value = _logprobs;
+    if (value == null) return null;
+    if (_logprobs is EqualUnmodifiableMapView) return _logprobs;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(value);
+  }
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseChoiceCopyWith<_ChatCompletionResponseChoice>
+      get copyWith => __$ChatCompletionResponseChoiceCopyWithImpl<
+          _ChatCompletionResponseChoice>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseChoiceToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseChoice &&
+            (identical(other.index, index) || other.index == index) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.finishReason, finishReason) ||
+                other.finishReason == finishReason) &&
+            const DeepCollectionEquality().equals(other._logprobs, _logprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, index, message, finishReason,
+      const DeepCollectionEquality().hash(_logprobs));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseChoice(index: $index, message: $message, finishReason: $finishReason, logprobs: $logprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseChoiceCopyWith<$Res>
+    implements $ChatCompletionResponseChoiceCopyWith<$Res> {
+  factory _$ChatCompletionResponseChoiceCopyWith(
+          _ChatCompletionResponseChoice value,
+          $Res Function(_ChatCompletionResponseChoice) _then) =
+      __$ChatCompletionResponseChoiceCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {int index,
+      ChatCompletionResponseMessage message,
+      @JsonKey(name: 'finish_reason') String? finishReason,
+      Map<String, dynamic>? logprobs});
+
+  @override
+  $ChatCompletionResponseMessageCopyWith<$Res> get message;
+}
+
+/// @nodoc
+class __$ChatCompletionResponseChoiceCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseChoiceCopyWith<$Res> {
+  __$ChatCompletionResponseChoiceCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponseChoice _self;
+  final $Res Function(_ChatCompletionResponseChoice) _then;
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? index = null,
+    Object? message = null,
+    Object? finishReason = freezed,
+    Object? logprobs = freezed,
+  }) {
+    return _then(_ChatCompletionResponseChoice(
+      index: null == index
+          ? _self.index
+          : index // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseMessage,
+      finishReason: freezed == finishReason
+          ? _self.finishReason
+          : finishReason // ignore: cast_nullable_to_non_nullable
+              as String?,
+      logprobs: freezed == logprobs
+          ? _self._logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseMessageCopyWith<$Res> get message {
+    return $ChatCompletionResponseMessageCopyWith<$Res>(_self.message, (value) {
+      return _then(_self.copyWith(message: value));
+    });
+  }
+}
+
+// dart format on

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.g.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response_choice.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponseChoice _$ChatCompletionResponseChoiceFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponseChoice(
+      index: (json['index'] as num).toInt(),
+      message: ChatCompletionResponseMessage.fromJson(
+          json['message'] as Map<String, dynamic>),
+      finishReason: json['finish_reason'] as String?,
+      logprobs: json['logprobs'] as Map<String, dynamic>?,
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseChoiceToJson(
+        _ChatCompletionResponseChoice instance) =>
+    <String, dynamic>{
+      'index': instance.index,
+      'message': instance.message,
+      'finish_reason': instance.finishReason,
+      'logprobs': instance.logprobs,
+    };

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'chat_completion_response_message.freezed.dart';
+part 'chat_completion_response_message.g.dart';
+
+@freezed
+abstract class ChatCompletionResponseMessage
+    with _$ChatCompletionResponseMessage {
+  factory ChatCompletionResponseMessage({
+    required String role,
+    String? content,
+    @JsonKey(name: 'reasoning_content') String? reasoningContent,
+    String? refusal,
+    @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls,
+  }) = _ChatCompletionResponseMessage;
+
+  factory ChatCompletionResponseMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseMessageFromJson(json);
+  const ChatCompletionResponseMessage._();
+}

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.freezed.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.freezed.dart
@@ -1,0 +1,435 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response_message.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponseMessage {
+  String get role;
+  String? get content;
+  @JsonKey(name: 'reasoning_content')
+  String? get reasoningContent;
+  String? get refusal;
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls;
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseMessageCopyWith<ChatCompletionResponseMessage>
+      get copyWith => _$ChatCompletionResponseMessageCopyWithImpl<
+              ChatCompletionResponseMessage>(
+          this as ChatCompletionResponseMessage, _$identity);
+
+  /// Serializes this ChatCompletionResponseMessage to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.reasoningContent, reasoningContent) ||
+                other.reasoningContent == reasoningContent) &&
+            (identical(other.refusal, refusal) || other.refusal == refusal) &&
+            const DeepCollectionEquality().equals(other.toolCalls, toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, reasoningContent,
+      refusal, const DeepCollectionEquality().hash(toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseMessage(role: $role, content: $content, reasoningContent: $reasoningContent, refusal: $refusal, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseMessageCopyWith<$Res> {
+  factory $ChatCompletionResponseMessageCopyWith(
+          ChatCompletionResponseMessage value,
+          $Res Function(ChatCompletionResponseMessage) _then) =
+      _$ChatCompletionResponseMessageCopyWithImpl;
+  @useResult
+  $Res call(
+      {String role,
+      String? content,
+      @JsonKey(name: 'reasoning_content') String? reasoningContent,
+      String? refusal,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class _$ChatCompletionResponseMessageCopyWithImpl<$Res>
+    implements $ChatCompletionResponseMessageCopyWith<$Res> {
+  _$ChatCompletionResponseMessageCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponseMessage _self;
+  final $Res Function(ChatCompletionResponseMessage) _then;
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? role = null,
+    Object? content = freezed,
+    Object? reasoningContent = freezed,
+    Object? refusal = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_self.copyWith(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: freezed == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String?,
+      reasoningContent: freezed == reasoningContent
+          ? _self.reasoningContent
+          : reasoningContent // ignore: cast_nullable_to_non_nullable
+              as String?,
+      refusal: freezed == refusal
+          ? _self.refusal
+          : refusal // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self.toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseMessage].
+extension ChatCompletionResponseMessagePatterns
+    on ChatCompletionResponseMessage {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseMessage value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseMessage value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponseMessage value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String role,
+            String? content,
+            @JsonKey(name: 'reasoning_content') String? reasoningContent,
+            String? refusal,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.reasoningContent,
+            _that.refusal, _that.toolCalls);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String role,
+            String? content,
+            @JsonKey(name: 'reasoning_content') String? reasoningContent,
+            String? refusal,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage():
+        return $default(_that.role, _that.content, _that.reasoningContent,
+            _that.refusal, _that.toolCalls);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String role,
+            String? content,
+            @JsonKey(name: 'reasoning_content') String? reasoningContent,
+            String? refusal,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.reasoningContent,
+            _that.refusal, _that.toolCalls);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseMessage extends ChatCompletionResponseMessage {
+  _ChatCompletionResponseMessage(
+      {required this.role,
+      this.content,
+      @JsonKey(name: 'reasoning_content') this.reasoningContent,
+      this.refusal,
+      @JsonKey(name: 'tool_calls') final List<Map<String, dynamic>>? toolCalls})
+      : _toolCalls = toolCalls,
+        super._();
+  factory _ChatCompletionResponseMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseMessageFromJson(json);
+
+  @override
+  final String role;
+  @override
+  final String? content;
+  @override
+  @JsonKey(name: 'reasoning_content')
+  final String? reasoningContent;
+  @override
+  final String? refusal;
+  final List<Map<String, dynamic>>? _toolCalls;
+  @override
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls {
+    final value = _toolCalls;
+    if (value == null) return null;
+    if (_toolCalls is EqualUnmodifiableListView) return _toolCalls;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseMessageCopyWith<_ChatCompletionResponseMessage>
+      get copyWith => __$ChatCompletionResponseMessageCopyWithImpl<
+          _ChatCompletionResponseMessage>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseMessageToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.reasoningContent, reasoningContent) ||
+                other.reasoningContent == reasoningContent) &&
+            (identical(other.refusal, refusal) || other.refusal == refusal) &&
+            const DeepCollectionEquality()
+                .equals(other._toolCalls, _toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, reasoningContent,
+      refusal, const DeepCollectionEquality().hash(_toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseMessage(role: $role, content: $content, reasoningContent: $reasoningContent, refusal: $refusal, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseMessageCopyWith<$Res>
+    implements $ChatCompletionResponseMessageCopyWith<$Res> {
+  factory _$ChatCompletionResponseMessageCopyWith(
+          _ChatCompletionResponseMessage value,
+          $Res Function(_ChatCompletionResponseMessage) _then) =
+      __$ChatCompletionResponseMessageCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String role,
+      String? content,
+      @JsonKey(name: 'reasoning_content') String? reasoningContent,
+      String? refusal,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class __$ChatCompletionResponseMessageCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseMessageCopyWith<$Res> {
+  __$ChatCompletionResponseMessageCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponseMessage _self;
+  final $Res Function(_ChatCompletionResponseMessage) _then;
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? role = null,
+    Object? content = freezed,
+    Object? reasoningContent = freezed,
+    Object? refusal = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_ChatCompletionResponseMessage(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: freezed == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String?,
+      reasoningContent: freezed == reasoningContent
+          ? _self.reasoningContent
+          : reasoningContent // ignore: cast_nullable_to_non_nullable
+              as String?,
+      refusal: freezed == refusal
+          ? _self.refusal
+          : refusal // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self._toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.g.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response_message.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponseMessage _$ChatCompletionResponseMessageFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponseMessage(
+      role: json['role'] as String,
+      content: json['content'] as String?,
+      reasoningContent: json['reasoning_content'] as String?,
+      refusal: json['refusal'] as String?,
+      toolCalls: (json['tool_calls'] as List<dynamic>?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseMessageToJson(
+        _ChatCompletionResponseMessage instance) =>
+    <String, dynamic>{
+      'role': instance.role,
+      'content': instance.content,
+      'reasoning_content': instance.reasoningContent,
+      'refusal': instance.refusal,
+      'tool_calls': instance.toolCalls,
+    };

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart
@@ -1,0 +1,35 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'chat_completion_response_usage.freezed.dart';
+part 'chat_completion_response_usage.g.dart';
+
+@freezed
+abstract class ChatCompletionResponseUsage with _$ChatCompletionResponseUsage {
+  factory ChatCompletionResponseUsage({
+    @JsonKey(name: 'completion_tokens') required int completionTokens,
+    @JsonKey(name: 'prompt_tokens') required int promptTokens,
+    @JsonKey(name: 'total_tokens') required int totalTokens,
+    @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+    @JsonKey(name: 'prompt_cache_miss_tokens') int? promptCacheMissTokens,
+    @JsonKey(name: 'completion_tokens_details')
+    ChatCompletionResponseUsageCompletionTokensDetails? completionTokensDetails,
+  }) = _ChatCompletionResponseUsage;
+
+  factory ChatCompletionResponseUsage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseUsageFromJson(json);
+  const ChatCompletionResponseUsage._();
+}
+
+@freezed
+abstract class ChatCompletionResponseUsageCompletionTokensDetails
+    with _$ChatCompletionResponseUsageCompletionTokensDetails {
+  factory ChatCompletionResponseUsageCompletionTokensDetails({
+    @JsonKey(name: 'reasoning_tokens') required int reasoningTokens,
+  }) = _ChatCompletionResponseUsageCompletionTokensDetails;
+
+  factory ChatCompletionResponseUsageCompletionTokensDetails.fromJson(
+    Map<String, dynamic> json,
+  ) =>
+      _$ChatCompletionResponseUsageCompletionTokensDetailsFromJson(json);
+  const ChatCompletionResponseUsageCompletionTokensDetails._();
+}

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.freezed.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.freezed.dart
@@ -1,0 +1,888 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response_usage.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponseUsage {
+  @JsonKey(name: 'completion_tokens')
+  int get completionTokens;
+  @JsonKey(name: 'prompt_tokens')
+  int get promptTokens;
+  @JsonKey(name: 'total_tokens')
+  int get totalTokens;
+  @JsonKey(name: 'prompt_cache_hit_tokens')
+  int? get promptCacheHitTokens;
+  @JsonKey(name: 'prompt_cache_miss_tokens')
+  int? get promptCacheMissTokens;
+  @JsonKey(name: 'completion_tokens_details')
+  ChatCompletionResponseUsageCompletionTokensDetails?
+      get completionTokensDetails;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCopyWith<ChatCompletionResponseUsage>
+      get copyWith => _$ChatCompletionResponseUsageCopyWithImpl<
+              ChatCompletionResponseUsage>(
+          this as ChatCompletionResponseUsage, _$identity);
+
+  /// Serializes this ChatCompletionResponseUsage to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseUsage &&
+            (identical(other.completionTokens, completionTokens) ||
+                other.completionTokens == completionTokens) &&
+            (identical(other.promptTokens, promptTokens) ||
+                other.promptTokens == promptTokens) &&
+            (identical(other.totalTokens, totalTokens) ||
+                other.totalTokens == totalTokens) &&
+            (identical(other.promptCacheHitTokens, promptCacheHitTokens) ||
+                other.promptCacheHitTokens == promptCacheHitTokens) &&
+            (identical(other.promptCacheMissTokens, promptCacheMissTokens) ||
+                other.promptCacheMissTokens == promptCacheMissTokens) &&
+            (identical(
+                    other.completionTokensDetails, completionTokensDetails) ||
+                other.completionTokensDetails == completionTokensDetails));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      completionTokens,
+      promptTokens,
+      totalTokens,
+      promptCacheHitTokens,
+      promptCacheMissTokens,
+      completionTokensDetails);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsage(completionTokens: $completionTokens, promptTokens: $promptTokens, totalTokens: $totalTokens, promptCacheHitTokens: $promptCacheHitTokens, promptCacheMissTokens: $promptCacheMissTokens, completionTokensDetails: $completionTokensDetails)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseUsageCopyWith<$Res> {
+  factory $ChatCompletionResponseUsageCopyWith(
+          ChatCompletionResponseUsage value,
+          $Res Function(ChatCompletionResponseUsage) _then) =
+      _$ChatCompletionResponseUsageCopyWithImpl;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'completion_tokens') int completionTokens,
+      @JsonKey(name: 'prompt_tokens') int promptTokens,
+      @JsonKey(name: 'total_tokens') int totalTokens,
+      @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+      @JsonKey(name: 'prompt_cache_miss_tokens') int? promptCacheMissTokens,
+      @JsonKey(name: 'completion_tokens_details')
+      ChatCompletionResponseUsageCompletionTokensDetails?
+          completionTokensDetails});
+
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails;
+}
+
+/// @nodoc
+class _$ChatCompletionResponseUsageCopyWithImpl<$Res>
+    implements $ChatCompletionResponseUsageCopyWith<$Res> {
+  _$ChatCompletionResponseUsageCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponseUsage _self;
+  final $Res Function(ChatCompletionResponseUsage) _then;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? completionTokens = null,
+    Object? promptTokens = null,
+    Object? totalTokens = null,
+    Object? promptCacheHitTokens = freezed,
+    Object? promptCacheMissTokens = freezed,
+    Object? completionTokensDetails = freezed,
+  }) {
+    return _then(_self.copyWith(
+      completionTokens: null == completionTokens
+          ? _self.completionTokens
+          : completionTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptTokens: null == promptTokens
+          ? _self.promptTokens
+          : promptTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalTokens: null == totalTokens
+          ? _self.totalTokens
+          : totalTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptCacheHitTokens: freezed == promptCacheHitTokens
+          ? _self.promptCacheHitTokens
+          : promptCacheHitTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      promptCacheMissTokens: freezed == promptCacheMissTokens
+          ? _self.promptCacheMissTokens
+          : promptCacheMissTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      completionTokensDetails: freezed == completionTokensDetails
+          ? _self.completionTokensDetails
+          : completionTokensDetails // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsageCompletionTokensDetails?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails {
+    if (_self.completionTokensDetails == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>(
+        _self.completionTokensDetails!, (value) {
+      return _then(_self.copyWith(completionTokensDetails: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseUsage].
+extension ChatCompletionResponseUsagePatterns on ChatCompletionResponseUsage {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsage value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsage value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponseUsage value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: 'completion_tokens') int completionTokens,
+            @JsonKey(name: 'prompt_tokens') int promptTokens,
+            @JsonKey(name: 'total_tokens') int totalTokens,
+            @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+            @JsonKey(name: 'prompt_cache_miss_tokens')
+            int? promptCacheMissTokens,
+            @JsonKey(name: 'completion_tokens_details')
+            ChatCompletionResponseUsageCompletionTokensDetails?
+                completionTokensDetails)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(
+            _that.completionTokens,
+            _that.promptTokens,
+            _that.totalTokens,
+            _that.promptCacheHitTokens,
+            _that.promptCacheMissTokens,
+            _that.completionTokensDetails);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: 'completion_tokens') int completionTokens,
+            @JsonKey(name: 'prompt_tokens') int promptTokens,
+            @JsonKey(name: 'total_tokens') int totalTokens,
+            @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+            @JsonKey(name: 'prompt_cache_miss_tokens')
+            int? promptCacheMissTokens,
+            @JsonKey(name: 'completion_tokens_details')
+            ChatCompletionResponseUsageCompletionTokensDetails?
+                completionTokensDetails)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage():
+        return $default(
+            _that.completionTokens,
+            _that.promptTokens,
+            _that.totalTokens,
+            _that.promptCacheHitTokens,
+            _that.promptCacheMissTokens,
+            _that.completionTokensDetails);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @JsonKey(name: 'completion_tokens') int completionTokens,
+            @JsonKey(name: 'prompt_tokens') int promptTokens,
+            @JsonKey(name: 'total_tokens') int totalTokens,
+            @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+            @JsonKey(name: 'prompt_cache_miss_tokens')
+            int? promptCacheMissTokens,
+            @JsonKey(name: 'completion_tokens_details')
+            ChatCompletionResponseUsageCompletionTokensDetails?
+                completionTokensDetails)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(
+            _that.completionTokens,
+            _that.promptTokens,
+            _that.totalTokens,
+            _that.promptCacheHitTokens,
+            _that.promptCacheMissTokens,
+            _that.completionTokensDetails);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseUsage extends ChatCompletionResponseUsage {
+  _ChatCompletionResponseUsage(
+      {@JsonKey(name: 'completion_tokens') required this.completionTokens,
+      @JsonKey(name: 'prompt_tokens') required this.promptTokens,
+      @JsonKey(name: 'total_tokens') required this.totalTokens,
+      @JsonKey(name: 'prompt_cache_hit_tokens') this.promptCacheHitTokens,
+      @JsonKey(name: 'prompt_cache_miss_tokens') this.promptCacheMissTokens,
+      @JsonKey(name: 'completion_tokens_details') this.completionTokensDetails})
+      : super._();
+  factory _ChatCompletionResponseUsage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseUsageFromJson(json);
+
+  @override
+  @JsonKey(name: 'completion_tokens')
+  final int completionTokens;
+  @override
+  @JsonKey(name: 'prompt_tokens')
+  final int promptTokens;
+  @override
+  @JsonKey(name: 'total_tokens')
+  final int totalTokens;
+  @override
+  @JsonKey(name: 'prompt_cache_hit_tokens')
+  final int? promptCacheHitTokens;
+  @override
+  @JsonKey(name: 'prompt_cache_miss_tokens')
+  final int? promptCacheMissTokens;
+  @override
+  @JsonKey(name: 'completion_tokens_details')
+  final ChatCompletionResponseUsageCompletionTokensDetails?
+      completionTokensDetails;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseUsageCopyWith<_ChatCompletionResponseUsage>
+      get copyWith => __$ChatCompletionResponseUsageCopyWithImpl<
+          _ChatCompletionResponseUsage>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseUsageToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseUsage &&
+            (identical(other.completionTokens, completionTokens) ||
+                other.completionTokens == completionTokens) &&
+            (identical(other.promptTokens, promptTokens) ||
+                other.promptTokens == promptTokens) &&
+            (identical(other.totalTokens, totalTokens) ||
+                other.totalTokens == totalTokens) &&
+            (identical(other.promptCacheHitTokens, promptCacheHitTokens) ||
+                other.promptCacheHitTokens == promptCacheHitTokens) &&
+            (identical(other.promptCacheMissTokens, promptCacheMissTokens) ||
+                other.promptCacheMissTokens == promptCacheMissTokens) &&
+            (identical(
+                    other.completionTokensDetails, completionTokensDetails) ||
+                other.completionTokensDetails == completionTokensDetails));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      completionTokens,
+      promptTokens,
+      totalTokens,
+      promptCacheHitTokens,
+      promptCacheMissTokens,
+      completionTokensDetails);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsage(completionTokens: $completionTokens, promptTokens: $promptTokens, totalTokens: $totalTokens, promptCacheHitTokens: $promptCacheHitTokens, promptCacheMissTokens: $promptCacheMissTokens, completionTokensDetails: $completionTokensDetails)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseUsageCopyWith<$Res>
+    implements $ChatCompletionResponseUsageCopyWith<$Res> {
+  factory _$ChatCompletionResponseUsageCopyWith(
+          _ChatCompletionResponseUsage value,
+          $Res Function(_ChatCompletionResponseUsage) _then) =
+      __$ChatCompletionResponseUsageCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'completion_tokens') int completionTokens,
+      @JsonKey(name: 'prompt_tokens') int promptTokens,
+      @JsonKey(name: 'total_tokens') int totalTokens,
+      @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+      @JsonKey(name: 'prompt_cache_miss_tokens') int? promptCacheMissTokens,
+      @JsonKey(name: 'completion_tokens_details')
+      ChatCompletionResponseUsageCompletionTokensDetails?
+          completionTokensDetails});
+
+  @override
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails;
+}
+
+/// @nodoc
+class __$ChatCompletionResponseUsageCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseUsageCopyWith<$Res> {
+  __$ChatCompletionResponseUsageCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponseUsage _self;
+  final $Res Function(_ChatCompletionResponseUsage) _then;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? completionTokens = null,
+    Object? promptTokens = null,
+    Object? totalTokens = null,
+    Object? promptCacheHitTokens = freezed,
+    Object? promptCacheMissTokens = freezed,
+    Object? completionTokensDetails = freezed,
+  }) {
+    return _then(_ChatCompletionResponseUsage(
+      completionTokens: null == completionTokens
+          ? _self.completionTokens
+          : completionTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptTokens: null == promptTokens
+          ? _self.promptTokens
+          : promptTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalTokens: null == totalTokens
+          ? _self.totalTokens
+          : totalTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptCacheHitTokens: freezed == promptCacheHitTokens
+          ? _self.promptCacheHitTokens
+          : promptCacheHitTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      promptCacheMissTokens: freezed == promptCacheMissTokens
+          ? _self.promptCacheMissTokens
+          : promptCacheMissTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      completionTokensDetails: freezed == completionTokensDetails
+          ? _self.completionTokensDetails
+          : completionTokensDetails // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsageCompletionTokensDetails?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails {
+    if (_self.completionTokensDetails == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>(
+        _self.completionTokensDetails!, (value) {
+      return _then(_self.copyWith(completionTokensDetails: value));
+    });
+  }
+}
+
+/// @nodoc
+mixin _$ChatCompletionResponseUsageCompletionTokensDetails {
+  @JsonKey(name: 'reasoning_tokens')
+  int get reasoningTokens;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+          ChatCompletionResponseUsageCompletionTokensDetails>
+      get copyWith =>
+          _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<
+                  ChatCompletionResponseUsageCompletionTokensDetails>(
+              this as ChatCompletionResponseUsageCompletionTokensDetails,
+              _$identity);
+
+  /// Serializes this ChatCompletionResponseUsageCompletionTokensDetails to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseUsageCompletionTokensDetails &&
+            (identical(other.reasoningTokens, reasoningTokens) ||
+                other.reasoningTokens == reasoningTokens));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, reasoningTokens);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsageCompletionTokensDetails(reasoningTokens: $reasoningTokens)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+    $Res> {
+  factory $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith(
+          ChatCompletionResponseUsageCompletionTokensDetails value,
+          $Res Function(ChatCompletionResponseUsageCompletionTokensDetails)
+              _then) =
+      _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl;
+  @useResult
+  $Res call({@JsonKey(name: 'reasoning_tokens') int reasoningTokens});
+}
+
+/// @nodoc
+class _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<$Res>
+    implements
+        $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res> {
+  _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl(
+      this._self, this._then);
+
+  final ChatCompletionResponseUsageCompletionTokensDetails _self;
+  final $Res Function(ChatCompletionResponseUsageCompletionTokensDetails) _then;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? reasoningTokens = null,
+  }) {
+    return _then(_self.copyWith(
+      reasoningTokens: null == reasoningTokens
+          ? _self.reasoningTokens
+          : reasoningTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseUsageCompletionTokensDetails].
+extension ChatCompletionResponseUsageCompletionTokensDetailsPatterns
+    on ChatCompletionResponseUsageCompletionTokensDetails {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsageCompletionTokensDetails value)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsageCompletionTokensDetails value)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(
+            _ChatCompletionResponseUsageCompletionTokensDetails value)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@JsonKey(name: 'reasoning_tokens') int reasoningTokens)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that.reasoningTokens);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@JsonKey(name: 'reasoning_tokens') int reasoningTokens)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails():
+        return $default(_that.reasoningTokens);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@JsonKey(name: 'reasoning_tokens') int reasoningTokens)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that.reasoningTokens);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseUsageCompletionTokensDetails
+    extends ChatCompletionResponseUsageCompletionTokensDetails {
+  _ChatCompletionResponseUsageCompletionTokensDetails(
+      {@JsonKey(name: 'reasoning_tokens') required this.reasoningTokens})
+      : super._();
+  factory _ChatCompletionResponseUsageCompletionTokensDetails.fromJson(
+          Map<String, dynamic> json) =>
+      _$ChatCompletionResponseUsageCompletionTokensDetailsFromJson(json);
+
+  @override
+  @JsonKey(name: 'reasoning_tokens')
+  final int reasoningTokens;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+          _ChatCompletionResponseUsageCompletionTokensDetails>
+      get copyWith =>
+          __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<
+                  _ChatCompletionResponseUsageCompletionTokensDetails>(
+              this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseUsageCompletionTokensDetailsToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseUsageCompletionTokensDetails &&
+            (identical(other.reasoningTokens, reasoningTokens) ||
+                other.reasoningTokens == reasoningTokens));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, reasoningTokens);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsageCompletionTokensDetails(reasoningTokens: $reasoningTokens)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+        $Res>
+    implements
+        $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res> {
+  factory _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith(
+          _ChatCompletionResponseUsageCompletionTokensDetails value,
+          $Res Function(_ChatCompletionResponseUsageCompletionTokensDetails)
+              _then) =
+      __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl;
+  @override
+  @useResult
+  $Res call({@JsonKey(name: 'reasoning_tokens') int reasoningTokens});
+}
+
+/// @nodoc
+class __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<$Res>
+    implements
+        _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res> {
+  __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl(
+      this._self, this._then);
+
+  final _ChatCompletionResponseUsageCompletionTokensDetails _self;
+  final $Res Function(_ChatCompletionResponseUsageCompletionTokensDetails)
+      _then;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? reasoningTokens = null,
+  }) {
+    return _then(_ChatCompletionResponseUsageCompletionTokensDetails(
+      reasoningTokens: null == reasoningTokens
+          ? _self.reasoningTokens
+          : reasoningTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.g.dart
+++ b/pkgs/qwen_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response_usage.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponseUsage _$ChatCompletionResponseUsageFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponseUsage(
+      completionTokens: (json['completion_tokens'] as num).toInt(),
+      promptTokens: (json['prompt_tokens'] as num).toInt(),
+      totalTokens: (json['total_tokens'] as num).toInt(),
+      promptCacheHitTokens: (json['prompt_cache_hit_tokens'] as num?)?.toInt(),
+      promptCacheMissTokens:
+          (json['prompt_cache_miss_tokens'] as num?)?.toInt(),
+      completionTokensDetails: json['completion_tokens_details'] == null
+          ? null
+          : ChatCompletionResponseUsageCompletionTokensDetails.fromJson(
+              json['completion_tokens_details'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseUsageToJson(
+        _ChatCompletionResponseUsage instance) =>
+    <String, dynamic>{
+      'completion_tokens': instance.completionTokens,
+      'prompt_tokens': instance.promptTokens,
+      'total_tokens': instance.totalTokens,
+      'prompt_cache_hit_tokens': instance.promptCacheHitTokens,
+      'prompt_cache_miss_tokens': instance.promptCacheMissTokens,
+      'completion_tokens_details': instance.completionTokensDetails,
+    };
+
+_ChatCompletionResponseUsageCompletionTokensDetails
+    _$ChatCompletionResponseUsageCompletionTokensDetailsFromJson(
+            Map<String, dynamic> json) =>
+        _ChatCompletionResponseUsageCompletionTokensDetails(
+          reasoningTokens: (json['reasoning_tokens'] as num).toInt(),
+        );
+
+Map<String, dynamic> _$ChatCompletionResponseUsageCompletionTokensDetailsToJson(
+        _ChatCompletionResponseUsageCompletionTokensDetails instance) =>
+    <String, dynamic>{
+      'reasoning_tokens': instance.reasoningTokens,
+    };

--- a/pkgs/qwen_box/lib/src/freezed/model/model/model.dart
+++ b/pkgs/qwen_box/lib/src/freezed/model/model/model.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'model.freezed.dart';
+part 'model.g.dart';
+
+@freezed
+abstract class Model with _$Model {
+  factory Model({
+    required String id,
+    required String object,
+    @JsonKey(name: 'owned_by') required String ownedBy,
+  }) = _Model;
+
+  factory Model.fromJson(Map<String, dynamic> json) => _$ModelFromJson(json);
+  const Model._();
+}

--- a/pkgs/qwen_box/lib/src/freezed/model/model/model.freezed.dart
+++ b/pkgs/qwen_box/lib/src/freezed/model/model/model.freezed.dart
@@ -1,0 +1,353 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Model {
+  String get id;
+  String get object;
+  @JsonKey(name: 'owned_by')
+  String get ownedBy;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ModelCopyWith<Model> get copyWith =>
+      _$ModelCopyWithImpl<Model>(this as Model, _$identity);
+
+  /// Serializes this Model to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Model &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.ownedBy, ownedBy) || other.ownedBy == ownedBy));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, object, ownedBy);
+
+  @override
+  String toString() {
+    return 'Model(id: $id, object: $object, ownedBy: $ownedBy)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ModelCopyWith<$Res> {
+  factory $ModelCopyWith(Model value, $Res Function(Model) _then) =
+      _$ModelCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id, String object, @JsonKey(name: 'owned_by') String ownedBy});
+}
+
+/// @nodoc
+class _$ModelCopyWithImpl<$Res> implements $ModelCopyWith<$Res> {
+  _$ModelCopyWithImpl(this._self, this._then);
+
+  final Model _self;
+  final $Res Function(Model) _then;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? object = null,
+    Object? ownedBy = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      ownedBy: null == ownedBy
+          ? _self.ownedBy
+          : ownedBy // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Model].
+extension ModelPatterns on Model {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Model value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Model value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Model value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String id, String object,
+            @JsonKey(name: 'owned_by') String ownedBy)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that.id, _that.object, _that.ownedBy);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id, String object, @JsonKey(name: 'owned_by') String ownedBy)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model():
+        return $default(_that.id, _that.object, _that.ownedBy);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String id, String object,
+            @JsonKey(name: 'owned_by') String ownedBy)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that.id, _that.object, _that.ownedBy);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _Model extends Model {
+  _Model(
+      {required this.id,
+      required this.object,
+      @JsonKey(name: 'owned_by') required this.ownedBy})
+      : super._();
+  factory _Model.fromJson(Map<String, dynamic> json) => _$ModelFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String object;
+  @override
+  @JsonKey(name: 'owned_by')
+  final String ownedBy;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ModelCopyWith<_Model> get copyWith =>
+      __$ModelCopyWithImpl<_Model>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ModelToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Model &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.ownedBy, ownedBy) || other.ownedBy == ownedBy));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, object, ownedBy);
+
+  @override
+  String toString() {
+    return 'Model(id: $id, object: $object, ownedBy: $ownedBy)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ModelCopyWith<$Res> implements $ModelCopyWith<$Res> {
+  factory _$ModelCopyWith(_Model value, $Res Function(_Model) _then) =
+      __$ModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id, String object, @JsonKey(name: 'owned_by') String ownedBy});
+}
+
+/// @nodoc
+class __$ModelCopyWithImpl<$Res> implements _$ModelCopyWith<$Res> {
+  __$ModelCopyWithImpl(this._self, this._then);
+
+  final _Model _self;
+  final $Res Function(_Model) _then;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? object = null,
+    Object? ownedBy = null,
+  }) {
+    return _then(_Model(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      ownedBy: null == ownedBy
+          ? _self.ownedBy
+          : ownedBy // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/qwen_box/lib/src/freezed/model/model/model.g.dart
+++ b/pkgs/qwen_box/lib/src/freezed/model/model/model.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_Model _$ModelFromJson(Map<String, dynamic> json) => _Model(
+      id: json['id'] as String,
+      object: json['object'] as String,
+      ownedBy: json['owned_by'] as String,
+    );
+
+Map<String, dynamic> _$ModelToJson(_Model instance) => <String, dynamic>{
+      'id': instance.id,
+      'object': instance.object,
+      'owned_by': instance.ownedBy,
+    };

--- a/pkgs/qwen_box/lib/src/freezed/model/model_list/model_list.dart
+++ b/pkgs/qwen_box/lib/src/freezed/model/model_list/model_list.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:qwen_box/src/freezed/model/model/model.dart';
+
+part 'model_list.freezed.dart';
+part 'model_list.g.dart';
+
+@freezed
+abstract class ModelList with _$ModelList {
+  factory ModelList({required String object, required List<Model> data}) =
+      _ModelList;
+
+  factory ModelList.fromJson(Map<String, dynamic> json) =>
+      _$ModelListFromJson(json);
+  const ModelList._();
+}

--- a/pkgs/qwen_box/lib/src/freezed/model/model_list/model_list.freezed.dart
+++ b/pkgs/qwen_box/lib/src/freezed/model/model_list/model_list.freezed.dart
@@ -1,0 +1,336 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'model_list.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ModelList {
+  String get object;
+  List<Model> get data;
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ModelListCopyWith<ModelList> get copyWith =>
+      _$ModelListCopyWithImpl<ModelList>(this as ModelList, _$identity);
+
+  /// Serializes this ModelList to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ModelList &&
+            (identical(other.object, object) || other.object == object) &&
+            const DeepCollectionEquality().equals(other.data, data));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, object, const DeepCollectionEquality().hash(data));
+
+  @override
+  String toString() {
+    return 'ModelList(object: $object, data: $data)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ModelListCopyWith<$Res> {
+  factory $ModelListCopyWith(ModelList value, $Res Function(ModelList) _then) =
+      _$ModelListCopyWithImpl;
+  @useResult
+  $Res call({String object, List<Model> data});
+}
+
+/// @nodoc
+class _$ModelListCopyWithImpl<$Res> implements $ModelListCopyWith<$Res> {
+  _$ModelListCopyWithImpl(this._self, this._then);
+
+  final ModelList _self;
+  final $Res Function(ModelList) _then;
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? object = null,
+    Object? data = null,
+  }) {
+    return _then(_self.copyWith(
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      data: null == data
+          ? _self.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as List<Model>,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ModelList].
+extension ModelListPatterns on ModelList {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ModelList value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ModelList value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ModelList value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String object, List<Model> data)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that.object, _that.data);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String object, List<Model> data) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList():
+        return $default(_that.object, _that.data);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String object, List<Model> data)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that.object, _that.data);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ModelList extends ModelList {
+  _ModelList({required this.object, required final List<Model> data})
+      : _data = data,
+        super._();
+  factory _ModelList.fromJson(Map<String, dynamic> json) =>
+      _$ModelListFromJson(json);
+
+  @override
+  final String object;
+  final List<Model> _data;
+  @override
+  List<Model> get data {
+    if (_data is EqualUnmodifiableListView) return _data;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_data);
+  }
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ModelListCopyWith<_ModelList> get copyWith =>
+      __$ModelListCopyWithImpl<_ModelList>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ModelListToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ModelList &&
+            (identical(other.object, object) || other.object == object) &&
+            const DeepCollectionEquality().equals(other._data, _data));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, object, const DeepCollectionEquality().hash(_data));
+
+  @override
+  String toString() {
+    return 'ModelList(object: $object, data: $data)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ModelListCopyWith<$Res>
+    implements $ModelListCopyWith<$Res> {
+  factory _$ModelListCopyWith(
+          _ModelList value, $Res Function(_ModelList) _then) =
+      __$ModelListCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String object, List<Model> data});
+}
+
+/// @nodoc
+class __$ModelListCopyWithImpl<$Res> implements _$ModelListCopyWith<$Res> {
+  __$ModelListCopyWithImpl(this._self, this._then);
+
+  final _ModelList _self;
+  final $Res Function(_ModelList) _then;
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? object = null,
+    Object? data = null,
+  }) {
+    return _then(_ModelList(
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      data: null == data
+          ? _self._data
+          : data // ignore: cast_nullable_to_non_nullable
+              as List<Model>,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/qwen_box/lib/src/freezed/model/model_list/model_list.g.dart
+++ b/pkgs/qwen_box/lib/src/freezed/model/model_list/model_list.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'model_list.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ModelList _$ModelListFromJson(Map<String, dynamic> json) => _ModelList(
+      object: json['object'] as String,
+      data: (json['data'] as List<dynamic>)
+          .map((e) => Model.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$ModelListToJson(_ModelList instance) =>
+    <String, dynamic>{
+      'object': instance.object,
+      'data': instance.data,
+    };

--- a/pkgs/qwen_box/lib/src/openai_compat.dart
+++ b/pkgs/qwen_box/lib/src/openai_compat.dart
@@ -1,0 +1,338 @@
+// OpenAI 互換 Chat Completions API のリクエスト構築・レスポンス解析ヘルパー。
+//
+// 画像・音声・ファイル・ツール呼び出し・構造化出力を raw JSON として
+// 組み立てる（freezed のコード生成に依存しない）。
+//
+// このファイルは src/ 配下のパッケージ内部実装であり、公開 API には含めない。
+import 'dart:convert';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:api_http/api_http.dart';
+
+/// [LLMCompletionRequest] を OpenAI 互換のリクエストボディに変換する。
+Map<String, dynamic> buildOpenAiBody(
+  LLMCompletionRequest request, {
+  required String maxTokensKey,
+}) {
+  final body = <String, dynamic>{
+    'model': request.model,
+    'messages': _toOpenAiMessages(request.messages),
+  };
+  if (request.maxTokens != null) body[maxTokensKey] = request.maxTokens;
+  if (request.temperature != null) body['temperature'] = request.temperature;
+  if (request.topP != null) body['top_p'] = request.topP;
+  if (request.stop != null) body['stop'] = request.stop;
+  if (request.seed != null) body['seed'] = request.seed;
+  if (request.frequencyPenalty != null) {
+    body['frequency_penalty'] = request.frequencyPenalty;
+  }
+  if (request.presencePenalty != null) {
+    body['presence_penalty'] = request.presencePenalty;
+  }
+  final rf = _toOpenAiResponseFormat(request.responseFormat);
+  if (rf != null) body['response_format'] = rf;
+  final tools = request.tools;
+  if (tools != null && tools.isNotEmpty) {
+    body['tools'] = [
+      for (final t in tools)
+        {
+          'type': 'function',
+          'function': {
+            'name': t.name,
+            'description': t.description,
+            'parameters': t.parameters,
+          },
+        },
+    ];
+    final tc = _toOpenAiToolChoice(request.toolChoice);
+    if (tc != null) body['tool_choice'] = tc;
+  }
+  return body;
+}
+
+List<Map<String, dynamic>> _toOpenAiMessages(List<LLMContent> messages) {
+  final out = <Map<String, dynamic>>[];
+  for (final m in messages) {
+    final role = switch (m.role) {
+      LLMRole.model => 'assistant',
+      LLMRole.system => 'system',
+      LLMRole.user => 'user',
+    };
+
+    // ツール実行結果は role: 'tool' の独立メッセージとして送る。
+    final toolResults = m.parts.whereType<LLMToolResultPart>().toList();
+    if (toolResults.isNotEmpty) {
+      for (final tr in toolResults) {
+        out.add({
+          'role': 'tool',
+          'tool_call_id': tr.toolCallId,
+          'content': tr.content,
+        });
+      }
+      continue;
+    }
+
+    // assistant のツール呼び出しエコー。
+    final toolCalls = m.parts.whereType<LLMToolCallPart>().toList();
+    if (toolCalls.isNotEmpty) {
+      out.add({
+        'role': 'assistant',
+        if (m.text.isNotEmpty) 'content': m.text,
+        'tool_calls': [
+          for (final tc in toolCalls)
+            {
+              'id': tc.id,
+              'type': 'function',
+              'function': {
+                'name': tc.name,
+                'arguments': jsonEncode(tc.arguments),
+              },
+            },
+        ],
+      });
+      continue;
+    }
+
+    final hasMedia = m.parts.any(
+      (p) => p is LLMImagePart || p is LLMAudioPart || p is LLMFilePart,
+    );
+    if (!hasMedia) {
+      out.add({'role': role, 'content': m.text});
+      continue;
+    }
+
+    out.add({'role': role, 'content': _toOpenAiContentArray(m.parts)});
+  }
+  return out;
+}
+
+List<Map<String, dynamic>> _toOpenAiContentArray(List<LLMContentPart> parts) {
+  final arr = <Map<String, dynamic>>[];
+  for (final p in parts) {
+    if (p is LLMTextPart) {
+      arr.add({'type': 'text', 'text': p.text});
+    } else if (p is LLMImagePart) {
+      arr.add({
+        'type': 'image_url',
+        'image_url': {'url': p.asUrlOrDataUri},
+      });
+    } else if (p is LLMAudioPart) {
+      arr.add({
+        'type': 'input_audio',
+        'input_audio': {
+          'data': p.base64Data ?? '',
+          'format': _audioFormat(p.mimeType),
+        },
+      });
+    } else if (p is LLMFilePart) {
+      arr.add({
+        'type': 'file',
+        'file': {
+          if (p.filename != null) 'filename': p.filename,
+          'file_data': _fileDataField(p),
+        },
+      });
+    }
+  }
+  return arr;
+}
+
+String _fileDataField(LLMFilePart f) {
+  if (f.hasBytes) {
+    final mime = f.mimeType ?? 'application/octet-stream';
+    return 'data:$mime;base64,${f.base64Data}';
+  }
+  return f.url ?? '';
+}
+
+String _audioFormat(String? mimeType) {
+  if (mimeType == null) return 'wav';
+  if (mimeType.contains('mp3') || mimeType.contains('mpeg')) return 'mp3';
+  if (mimeType.contains('wav')) return 'wav';
+  return mimeType.split('/').last;
+}
+
+Map<String, dynamic>? _toOpenAiResponseFormat(LLMResponseFormat? f) {
+  if (f == null) return null;
+  switch (f.type) {
+    case LLMResponseFormatType.text:
+      return {'type': 'text'};
+    case LLMResponseFormatType.jsonObject:
+      return {'type': 'json_object'};
+    case LLMResponseFormatType.jsonSchema:
+      return {
+        'type': 'json_schema',
+        'json_schema': {
+          'name': f.schemaName,
+          'schema': f.schema,
+          'strict': f.strict,
+        },
+      };
+  }
+}
+
+dynamic _toOpenAiToolChoice(LLMToolChoice? tc) {
+  if (tc == null) return null;
+  final toolName = tc.toolName;
+  if (toolName != null) {
+    return {
+      'type': 'function',
+      'function': {'name': toolName},
+    };
+  }
+  switch (tc.mode) {
+    case LLMToolChoiceMode.auto:
+      return 'auto';
+    case LLMToolChoiceMode.none:
+      return 'none';
+    case LLMToolChoiceMode.any:
+      return 'required';
+  }
+}
+
+/// OpenAI 互換のレスポンスボディを [LLMCompletionResponse] に変換する。
+LLMCompletionResponse parseOpenAiResponse(Map<String, dynamic> data) {
+  final choices = (data['choices'] as List?) ?? const [];
+  final choice = choices.isNotEmpty
+      ? choices.first as Map<String, dynamic>
+      : const <String, dynamic>{};
+  final message =
+      (choice['message'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  final parts = <LLMContentPart>[];
+
+  final reasoning = message['reasoning_content'];
+  if (reasoning is String && reasoning.isNotEmpty) {
+    parts.add(LLMReasoningPart(reasoning));
+  }
+
+  final rawContent = message['content'];
+  if (rawContent is String && rawContent.isNotEmpty) {
+    parts.add(LLMTextPart(rawContent));
+  } else if (rawContent is List) {
+    _appendOpenAiContentParts(rawContent, parts);
+  }
+
+  final toolCalls = message['tool_calls'];
+  if (toolCalls is List) {
+    for (final tc in toolCalls) {
+      if (tc is Map<String, dynamic>) {
+        final fn = tc['function'];
+        final fnMap =
+            fn is Map<String, dynamic> ? fn : const <String, dynamic>{};
+        parts.add(
+          LLMToolCallPart(
+            id: (tc['id'] ?? '').toString(),
+            name: (fnMap['name'] ?? '').toString(),
+            arguments: _decodeArgs(fnMap['arguments']),
+          ),
+        );
+      }
+    }
+  }
+
+  final audio = message['audio'];
+  if (audio is Map<String, dynamic>) {
+    final adata = audio['data'];
+    if (adata is String && adata.isNotEmpty) {
+      parts.add(
+        LLMAudioPart.base64(adata, transcript: audio['transcript'] as String?),
+      );
+    }
+  }
+
+  final usage =
+      (data['usage'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  return LLMCompletionResponse(
+    content: LLMContent(role: LLMRole.model, parts: parts),
+    usage: _parseOpenAiUsage(usage),
+    finishReason: LLMFinishReason.parse(choice['finish_reason'] as String?),
+    model: data['model'] as String?,
+    id: data['id'] as String?,
+  );
+}
+
+void _appendOpenAiContentParts(List<dynamic> items, List<LLMContentPart> out) {
+  for (final item in items) {
+    if (item is! Map<String, dynamic>) continue;
+    final type = item['type'];
+    if (type == 'text' && item['text'] is String) {
+      out.add(LLMTextPart(item['text'] as String));
+    } else if (type == 'image_url') {
+      final url = (item['image_url'] as Map<String, dynamic>?)?['url'];
+      if (url is String) out.add(LLMImagePart.dataUri(url));
+    }
+  }
+}
+
+Map<String, dynamic> _decodeArgs(Object? argsRaw) {
+  if (argsRaw is Map<String, dynamic>) return argsRaw;
+  if (argsRaw is String && argsRaw.isNotEmpty) {
+    try {
+      final decoded = jsonDecode(argsRaw);
+      if (decoded is Map<String, dynamic>) return decoded;
+    } on FormatException {
+      return <String, dynamic>{};
+    }
+  }
+  return <String, dynamic>{};
+}
+
+LLMUsage _parseOpenAiUsage(Map<String, dynamic> usage) {
+  final promptDetails = usage['prompt_tokens_details'] as Map<String, dynamic>?;
+  final completionDetails =
+      usage['completion_tokens_details'] as Map<String, dynamic>?;
+  return LLMUsage(
+    inputTokens: (usage['prompt_tokens'] as num?)?.toInt() ?? 0,
+    outputTokens: (usage['completion_tokens'] as num?)?.toInt() ?? 0,
+    cachedInputTokens: (promptDetails?['cached_tokens'] as num?)?.toInt(),
+    reasoningTokens: (completionDetails?['reasoning_tokens'] as num?)?.toInt(),
+  );
+}
+
+/// OpenAI 互換 API に POST し、JSON ボディを返す。失敗時は [LLMException]。
+Future<Map<String, dynamic>> postOpenAiJson({
+  required String url,
+  required String apiKey,
+  required String provider,
+  required Map<String, dynamic> body,
+}) async {
+  try {
+    final response = await Api.post(
+      requestAcc: PostRequestAcc(
+        url: url,
+        headers: RestHeaders({
+          'Authorization': 'Bearer $apiKey',
+          'Content-Type': 'application/json',
+        }),
+        body: JsonRequestBody(body),
+      ),
+    );
+    final statusCode = int.tryParse(response.statusCode) ?? 0;
+    final respBody = response.body;
+    Map<String, dynamic>? mapData;
+    if (respBody is MapJsonResponseBody) {
+      mapData = respBody.data;
+    }
+    if (statusCode < 200 || statusCode >= 300) {
+      throw LLMException.fromHttp(
+        statusCode,
+        provider: provider,
+        body: mapData ?? respBody,
+      );
+    }
+    if (mapData != null) return mapData;
+    throw LLMUnknownException(
+      'Unexpected response body from $provider',
+      provider: provider,
+      raw: respBody,
+    );
+  } on LLMException {
+    rethrow;
+  } catch (e) {
+    throw LLMNetworkException(
+      'Network request failed',
+      provider: provider,
+      raw: e,
+    );
+  }
+}

--- a/pkgs/qwen_box/lib/src/qwen.dart
+++ b/pkgs/qwen_box/lib/src/qwen.dart
@@ -1,0 +1,41 @@
+import 'package:ai_box/ai_box.dart';
+import 'package:qwen_box/qwen_box.dart';
+import 'package:qwen_box/src/openai_compat.dart';
+
+class Qwen extends LLMAIBase {
+  Qwen({required super.apiKey});
+
+  static const _baseUrl =
+      'https://dashscope-intl.aliyuncs.com/compatible-mode/v1';
+  static const _provider = 'qwen';
+
+  @override
+  Future<LLMCompletionResponse> completions(
+    LLMCompletionRequest request,
+  ) async {
+    final body = buildOpenAiBody(request, maxTokensKey: 'max_tokens');
+    final data = await postOpenAiJson(
+      url: '$_baseUrl/chat/completions',
+      apiKey: apiKey,
+      provider: _provider,
+      body: body,
+    );
+    return parseOpenAiResponse(data);
+  }
+
+  @override
+  Future<List<AIModel>> getModels() async {
+    final modelList = await QwenCore.listModels(apiKey: apiKey);
+    return modelList.data.map((e) => AIModel(id: e.id)).toList();
+  }
+
+  @override
+  Future<bool> validateKey() async {
+    try {
+      await QwenCore.listModels(apiKey: apiKey);
+      return true;
+    } on Exception catch (_) {
+      return false;
+    }
+  }
+}

--- a/pkgs/qwen_box/pubspec.yaml
+++ b/pkgs/qwen_box/pubspec.yaml
@@ -1,0 +1,24 @@
+---
+dependencies:
+  ai_box: ^0.0.1
+  api_http: ^0.0.1
+  freezed_annotation: ^3.0.0
+  json_annotation: ^4.9.0
+description: '''A Qwen AI provider based on ai_box. '''
+dev_dependencies:
+  auto_exporter: any
+  build_runner: ^2.5.4
+  freezed: ^3.0.6
+  json_serializable: ^6.9.5
+  test: ^1.26.0
+  very_good_analysis: any
+environment:
+  sdk: ^3.2.0
+homepage: https://github.com/normidar/ai_box
+name: qwen_box
+topics:
+  - ai
+  - qwen
+  - ai-box
+  - llm
+version: 0.0.1

--- a/pkgs/qwen_box/pubspec_overrides.yaml
+++ b/pkgs/qwen_box/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: ai_box
+dependency_overrides:
+  ai_box:
+    path: ../ai_box

--- a/pkgs/qwen_box/test/qwen_box_test.dart
+++ b/pkgs/qwen_box/test/qwen_box_test.dart
@@ -1,0 +1,194 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:qwen_box/qwen_box.dart';
+import 'package:qwen_box/src/openai_compat.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Qwen client', () {
+    test('exposes apiKey and is an LLMAIBase', () {
+      final ai = Qwen(apiKey: 'test-key');
+      expect(ai.apiKey, 'test-key');
+      expect(ai, isA<LLMAIBase>());
+    });
+  });
+
+  group('ChatCompletion freezed models', () {
+    test('request serializes to OpenAI-shaped JSON', () {
+      final req = ChatCompletionRequest(
+        model: 'qwen-plus',
+        messages: [
+          ChatCompletionMessage(role: ChatCompletionRole.user, content: 'hi'),
+        ],
+        maxTokens: 16,
+      );
+      // toJson() keeps nested objects; the wire payload is produced when the
+      // map is encoded (as JsonRequestBody does), so round-trip through JSON.
+      final json = jsonDecode(jsonEncode(req.toJson())) as Map<String, dynamic>;
+      expect(json['model'], 'qwen-plus');
+      expect(json['max_tokens'], 16);
+      final msg = (json['messages'] as List).first as Map<String, dynamic>;
+      expect(msg['role'], 'user');
+      expect(msg['content'], 'hi');
+    });
+
+    test('response parses choices + usage', () {
+      final res = ChatCompletionResponse.fromJson({
+        'id': 'x',
+        'object': 'chat.completion',
+        'created': 1,
+        'model': 'qwen-plus',
+        'choices': [
+          {
+            'index': 0,
+            'finish_reason': 'stop',
+            'message': {'role': 'assistant', 'content': 'hello'},
+          },
+        ],
+        'usage': {
+          'prompt_tokens': 3,
+          'completion_tokens': 5,
+          'total_tokens': 8,
+        },
+      });
+      expect(res.choices.single.message.content, 'hello');
+      expect(res.choices.single.finishReason, 'stop');
+      expect(res.usage?.totalTokens, 8);
+    });
+
+    test('ModelList parses model entries', () {
+      final list = ModelList.fromJson({
+        'object': 'list',
+        'data': [
+          {'id': 'qwen-max', 'object': 'model', 'owned_by': 'm'},
+        ],
+      });
+      expect(list.data.single.id, 'qwen-max');
+    });
+  });
+
+  group('buildOpenAiBody', () {
+    test('text message maps to role + content with sampling params', () {
+      final body = buildOpenAiBody(
+        LLMCompletionRequest(
+          model: 'm',
+          messages: [LLMContent.user('hi')],
+          maxTokens: 10,
+          temperature: 0.5,
+        ),
+        maxTokensKey: 'max_tokens',
+      );
+      expect(body['model'], 'm');
+      expect(body['max_tokens'], 10);
+      expect(body['temperature'], 0.5);
+      final msg = (body['messages'] as List).single as Map<String, dynamic>;
+      expect(msg['role'], 'user');
+      expect(msg['content'], 'hi');
+    });
+
+    test('image attachment becomes a content array with image_url', () {
+      final bytes = Uint8List.fromList(utf8.encode('img'));
+      final body = buildOpenAiBody(
+        LLMCompletionRequest(
+          model: 'm',
+          messages: [
+            LLMContent.user('see', attachments: [LLMImagePart.bytes(bytes)]),
+          ],
+        ),
+        maxTokensKey: 'max_tokens',
+      );
+      final msg = (body['messages'] as List).single as Map<String, dynamic>;
+      final content = msg['content'] as List;
+      expect((content[0] as Map<String, dynamic>)['type'], 'text');
+      expect((content[1] as Map<String, dynamic>)['type'], 'image_url');
+    });
+
+    test('tools are mapped to function definitions', () {
+      final body = buildOpenAiBody(
+        LLMCompletionRequest(
+          model: 'm',
+          messages: [LLMContent.user('x')],
+          tools: const [
+            LLMTool(
+              name: 'get_weather',
+              description: 'weather',
+              parameters: {'type': 'object'},
+            ),
+          ],
+          toolChoice: LLMToolChoice.auto,
+        ),
+        maxTokensKey: 'max_tokens',
+      );
+      final tool = (body['tools'] as List).single as Map<String, dynamic>;
+      expect(tool['type'], 'function');
+      expect((tool['function'] as Map<String, dynamic>)['name'], 'get_weather');
+      expect(body['tool_choice'], 'auto');
+    });
+  });
+
+  group('parseOpenAiResponse', () {
+    test('text, usage, finish reason, model and id', () {
+      final res = parseOpenAiResponse({
+        'id': 'r',
+        'model': 'm',
+        'choices': [
+          {
+            'finish_reason': 'stop',
+            'message': {'role': 'assistant', 'content': 'hello'},
+          },
+        ],
+        'usage': {'prompt_tokens': 2, 'completion_tokens': 3},
+      });
+      expect(res.text, 'hello');
+      expect(res.finishReason, LLMFinishReason.stop);
+      expect(res.usage.inputTokens, 2);
+      expect(res.usage.outputTokens, 3);
+      expect(res.model, 'm');
+      expect(res.id, 'r');
+    });
+
+    test('tool calls are parsed into LLMToolCallPart', () {
+      final res = parseOpenAiResponse({
+        'choices': [
+          {
+            'finish_reason': 'tool_calls',
+            'message': {
+              'role': 'assistant',
+              'content': null,
+              'tool_calls': [
+                {
+                  'id': 'c1',
+                  'type': 'function',
+                  'function': {'name': 'f', 'arguments': '{"a":1}'},
+                },
+              ],
+            },
+          },
+        ],
+      });
+      final call = res.content.parts.whereType<LLMToolCallPart>().single;
+      expect(call.id, 'c1');
+      expect(call.name, 'f');
+      expect(call.arguments, {'a': 1});
+      expect(res.finishReason, LLMFinishReason.toolCalls);
+    });
+
+    test('reasoning_content becomes an LLMReasoningPart', () {
+      final res = parseOpenAiResponse({
+        'choices': [
+          {
+            'message': {
+              'role': 'assistant',
+              'reasoning_content': 'think',
+              'content': 'ans',
+            },
+          },
+        ],
+      });
+      expect(res.content.reasoning, 'think');
+      expect(res.text, 'ans');
+    });
+  });
+}

--- a/pkgs/wavespeed_box/.gitignore
+++ b/pkgs/wavespeed_box/.gitignore
@@ -1,0 +1,31 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/

--- a/pkgs/wavespeed_box/CHANGELOG.md
+++ b/pkgs/wavespeed_box/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+- Initial release.

--- a/pkgs/wavespeed_box/README.md
+++ b/pkgs/wavespeed_box/README.md
@@ -1,0 +1,6 @@
+# wavespeed_box
+
+A WaveSpeedAI provider based on [ai_box](https://github.com/normidar/ai_box).
+
+Uses the WaveSpeed OpenAI-compatible LLM endpoint
+(`https://llm.wavespeed.ai/v1`).

--- a/pkgs/wavespeed_box/analysis_options.yaml
+++ b/pkgs/wavespeed_box/analysis_options.yaml
@@ -1,0 +1,11 @@
+include: package:very_good_analysis/analysis_options.yaml
+analyzer:
+  exclude: [build/**, lib/**.freezed.dart, lib/**.g.dart]
+  errors:
+    sort_constructors_first: ignore
+    public_member_api_docs: ignore
+    one_member_abstracts: ignore
+    invalid_annotation_target: ignore
+    avoid_positional_boolean_parameters: ignore
+    use_setters_to_change_properties: ignore
+    prefer_asserts_with_message: ignore

--- a/pkgs/wavespeed_box/build.yaml
+++ b/pkgs/wavespeed_box/build.yaml
@@ -1,0 +1,7 @@
+targets:
+  $default:
+    builders:
+      auto_exporter:
+        options:
+          default_export_all: true
+          project_name: wavespeed_box

--- a/pkgs/wavespeed_box/lib/src/core/wavespeed_core.dart
+++ b/pkgs/wavespeed_box/lib/src/core/wavespeed_core.dart
@@ -1,0 +1,47 @@
+import 'package:api_http/api_http.dart';
+import 'package:wavespeed_box/wavespeed_box.dart';
+
+class WaveSpeedCore {
+  static const _baseUrl = 'https://llm.wavespeed.ai/v1';
+
+  static Future<ChatCompletionResponse> chatCompletion({
+    required String apiKey,
+    required ChatCompletionRequest request,
+  }) async {
+    final response = await Api.post(
+      requestAcc: PostRequestAcc(
+        url: '$_baseUrl/chat/completions',
+        headers: _getHeaders(apiKey: apiKey),
+        body: JsonRequestBody(request.toJson()),
+      ),
+    );
+    switch (response.body) {
+      case MapJsonResponseBody(:final data):
+        return ChatCompletionResponse.fromJson(data);
+      case _:
+        throw Exception('Failed to chat completion: ${response.body}');
+    }
+  }
+
+  static Future<ModelList> listModels({required String apiKey}) async {
+    final response = await Api.get(
+      requestAcc: GetRequestAcc(
+        url: '$_baseUrl/models',
+        headers: _getHeaders(apiKey: apiKey),
+      ),
+    );
+    switch (response.body) {
+      case MapJsonResponseBody(:final data):
+        return ModelList.fromJson(data);
+      case _:
+        throw Exception('Failed to list models: ${response.body}');
+    }
+  }
+
+  static RestHeaders _getHeaders({required String apiKey}) {
+    return RestHeaders({
+      'Authorization': 'Bearer $apiKey',
+      'Content-Type': 'application/json',
+    });
+  }
+}

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'chat_completion_message.freezed.dart';
+part 'chat_completion_message.g.dart';
+
+@freezed
+abstract class ChatCompletionMessage with _$ChatCompletionMessage {
+  factory ChatCompletionMessage({
+    required ChatCompletionRole role,
+    required String content,
+    String? name,
+    @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls,
+  }) = _ChatCompletionMessage;
+
+  factory ChatCompletionMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionMessageFromJson(json);
+  const ChatCompletionMessage._();
+}
+
+enum ChatCompletionRole { system, user, assistant, tool }

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.freezed.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.freezed.dart
@@ -1,0 +1,394 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_message.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionMessage {
+  ChatCompletionRole get role;
+  String get content;
+  String? get name;
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls;
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionMessageCopyWith<ChatCompletionMessage> get copyWith =>
+      _$ChatCompletionMessageCopyWithImpl<ChatCompletionMessage>(
+          this as ChatCompletionMessage, _$identity);
+
+  /// Serializes this ChatCompletionMessage to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.name, name) || other.name == name) &&
+            const DeepCollectionEquality().equals(other.toolCalls, toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, name,
+      const DeepCollectionEquality().hash(toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionMessage(role: $role, content: $content, name: $name, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionMessageCopyWith<$Res> {
+  factory $ChatCompletionMessageCopyWith(ChatCompletionMessage value,
+          $Res Function(ChatCompletionMessage) _then) =
+      _$ChatCompletionMessageCopyWithImpl;
+  @useResult
+  $Res call(
+      {ChatCompletionRole role,
+      String content,
+      String? name,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class _$ChatCompletionMessageCopyWithImpl<$Res>
+    implements $ChatCompletionMessageCopyWith<$Res> {
+  _$ChatCompletionMessageCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionMessage _self;
+  final $Res Function(ChatCompletionMessage) _then;
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? role = null,
+    Object? content = null,
+    Object? name = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_self.copyWith(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionRole,
+      content: null == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: freezed == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self.toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionMessage].
+extension ChatCompletionMessagePatterns on ChatCompletionMessage {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionMessage value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionMessage value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionMessage value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(ChatCompletionRole role, String content, String? name,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.name, _that.toolCalls);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(ChatCompletionRole role, String content, String? name,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage():
+        return $default(_that.role, _that.content, _that.name, _that.toolCalls);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(ChatCompletionRole role, String content, String? name,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.name, _that.toolCalls);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionMessage extends ChatCompletionMessage {
+  _ChatCompletionMessage(
+      {required this.role,
+      required this.content,
+      this.name,
+      @JsonKey(name: 'tool_calls') final List<Map<String, dynamic>>? toolCalls})
+      : _toolCalls = toolCalls,
+        super._();
+  factory _ChatCompletionMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionMessageFromJson(json);
+
+  @override
+  final ChatCompletionRole role;
+  @override
+  final String content;
+  @override
+  final String? name;
+  final List<Map<String, dynamic>>? _toolCalls;
+  @override
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls {
+    final value = _toolCalls;
+    if (value == null) return null;
+    if (_toolCalls is EqualUnmodifiableListView) return _toolCalls;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionMessageCopyWith<_ChatCompletionMessage> get copyWith =>
+      __$ChatCompletionMessageCopyWithImpl<_ChatCompletionMessage>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionMessageToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.name, name) || other.name == name) &&
+            const DeepCollectionEquality()
+                .equals(other._toolCalls, _toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, name,
+      const DeepCollectionEquality().hash(_toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionMessage(role: $role, content: $content, name: $name, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionMessageCopyWith<$Res>
+    implements $ChatCompletionMessageCopyWith<$Res> {
+  factory _$ChatCompletionMessageCopyWith(_ChatCompletionMessage value,
+          $Res Function(_ChatCompletionMessage) _then) =
+      __$ChatCompletionMessageCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {ChatCompletionRole role,
+      String content,
+      String? name,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class __$ChatCompletionMessageCopyWithImpl<$Res>
+    implements _$ChatCompletionMessageCopyWith<$Res> {
+  __$ChatCompletionMessageCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionMessage _self;
+  final $Res Function(_ChatCompletionMessage) _then;
+
+  /// Create a copy of ChatCompletionMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? role = null,
+    Object? content = null,
+    Object? name = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_ChatCompletionMessage(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionRole,
+      content: null == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: freezed == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self._toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.g.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.g.dart
@@ -1,0 +1,34 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_message.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionMessage _$ChatCompletionMessageFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionMessage(
+      role: $enumDecode(_$ChatCompletionRoleEnumMap, json['role']),
+      content: json['content'] as String,
+      name: json['name'] as String?,
+      toolCalls: (json['tool_calls'] as List<dynamic>?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+    );
+
+Map<String, dynamic> _$ChatCompletionMessageToJson(
+        _ChatCompletionMessage instance) =>
+    <String, dynamic>{
+      'role': _$ChatCompletionRoleEnumMap[instance.role]!,
+      'content': instance.content,
+      'name': instance.name,
+      'tool_calls': instance.toolCalls,
+    };
+
+const _$ChatCompletionRoleEnumMap = {
+  ChatCompletionRole.system: 'system',
+  ChatCompletionRole.user: 'user',
+  ChatCompletionRole.assistant: 'assistant',
+  ChatCompletionRole.tool: 'tool',
+};

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:wavespeed_box/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart';
+
+part 'chat_completion_request.freezed.dart';
+part 'chat_completion_request.g.dart';
+
+/// https://wavespeed.ai/docs
+@freezed
+abstract class ChatCompletionRequest with _$ChatCompletionRequest {
+  factory ChatCompletionRequest({
+    required List<ChatCompletionMessage> messages,
+    required String model,
+    @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+    @JsonKey(name: 'max_tokens') int? maxTokens,
+    @JsonKey(name: 'presence_penalty') double? presencePenalty,
+    @JsonKey(name: 'response_format') Map<String, dynamic>? responseFormat,
+    int? seed,
+    List<String>? stop,
+    bool? stream,
+    double? temperature,
+    @JsonKey(name: 'top_p') double? topP,
+    List<Map<String, dynamic>>? tools,
+    @JsonKey(name: 'tool_choice') dynamic toolChoice,
+    bool? logprobs,
+    @JsonKey(name: 'top_logprobs') int? topLogprobs,
+  }) = _ChatCompletionRequest;
+
+  factory ChatCompletionRequest.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionRequestFromJson(json);
+  const ChatCompletionRequest._();
+}

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.freezed.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.freezed.dart
@@ -1,0 +1,766 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_request.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionRequest {
+  List<ChatCompletionMessage> get messages;
+  String get model;
+  @JsonKey(name: 'frequency_penalty')
+  double? get frequencyPenalty;
+  @JsonKey(name: 'max_tokens')
+  int? get maxTokens;
+  @JsonKey(name: 'presence_penalty')
+  double? get presencePenalty;
+  @JsonKey(name: 'response_format')
+  Map<String, dynamic>? get responseFormat;
+  int? get seed;
+  List<String>? get stop;
+  bool? get stream;
+  double? get temperature;
+  @JsonKey(name: 'top_p')
+  double? get topP;
+  List<Map<String, dynamic>>? get tools;
+  @JsonKey(name: 'tool_choice')
+  dynamic get toolChoice;
+  bool? get logprobs;
+  @JsonKey(name: 'top_logprobs')
+  int? get topLogprobs;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionRequestCopyWith<ChatCompletionRequest> get copyWith =>
+      _$ChatCompletionRequestCopyWithImpl<ChatCompletionRequest>(
+          this as ChatCompletionRequest, _$identity);
+
+  /// Serializes this ChatCompletionRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionRequest &&
+            const DeepCollectionEquality().equals(other.messages, messages) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.frequencyPenalty, frequencyPenalty) ||
+                other.frequencyPenalty == frequencyPenalty) &&
+            (identical(other.maxTokens, maxTokens) ||
+                other.maxTokens == maxTokens) &&
+            (identical(other.presencePenalty, presencePenalty) ||
+                other.presencePenalty == presencePenalty) &&
+            const DeepCollectionEquality()
+                .equals(other.responseFormat, responseFormat) &&
+            (identical(other.seed, seed) || other.seed == seed) &&
+            const DeepCollectionEquality().equals(other.stop, stop) &&
+            (identical(other.stream, stream) || other.stream == stream) &&
+            (identical(other.temperature, temperature) ||
+                other.temperature == temperature) &&
+            (identical(other.topP, topP) || other.topP == topP) &&
+            const DeepCollectionEquality().equals(other.tools, tools) &&
+            const DeepCollectionEquality()
+                .equals(other.toolChoice, toolChoice) &&
+            (identical(other.logprobs, logprobs) ||
+                other.logprobs == logprobs) &&
+            (identical(other.topLogprobs, topLogprobs) ||
+                other.topLogprobs == topLogprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(messages),
+      model,
+      frequencyPenalty,
+      maxTokens,
+      presencePenalty,
+      const DeepCollectionEquality().hash(responseFormat),
+      seed,
+      const DeepCollectionEquality().hash(stop),
+      stream,
+      temperature,
+      topP,
+      const DeepCollectionEquality().hash(tools),
+      const DeepCollectionEquality().hash(toolChoice),
+      logprobs,
+      topLogprobs);
+
+  @override
+  String toString() {
+    return 'ChatCompletionRequest(messages: $messages, model: $model, frequencyPenalty: $frequencyPenalty, maxTokens: $maxTokens, presencePenalty: $presencePenalty, responseFormat: $responseFormat, seed: $seed, stop: $stop, stream: $stream, temperature: $temperature, topP: $topP, tools: $tools, toolChoice: $toolChoice, logprobs: $logprobs, topLogprobs: $topLogprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionRequestCopyWith<$Res> {
+  factory $ChatCompletionRequestCopyWith(ChatCompletionRequest value,
+          $Res Function(ChatCompletionRequest) _then) =
+      _$ChatCompletionRequestCopyWithImpl;
+  @useResult
+  $Res call(
+      {List<ChatCompletionMessage> messages,
+      String model,
+      @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+      @JsonKey(name: 'max_tokens') int? maxTokens,
+      @JsonKey(name: 'presence_penalty') double? presencePenalty,
+      @JsonKey(name: 'response_format') Map<String, dynamic>? responseFormat,
+      int? seed,
+      List<String>? stop,
+      bool? stream,
+      double? temperature,
+      @JsonKey(name: 'top_p') double? topP,
+      List<Map<String, dynamic>>? tools,
+      @JsonKey(name: 'tool_choice') dynamic toolChoice,
+      bool? logprobs,
+      @JsonKey(name: 'top_logprobs') int? topLogprobs});
+}
+
+/// @nodoc
+class _$ChatCompletionRequestCopyWithImpl<$Res>
+    implements $ChatCompletionRequestCopyWith<$Res> {
+  _$ChatCompletionRequestCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionRequest _self;
+  final $Res Function(ChatCompletionRequest) _then;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? messages = null,
+    Object? model = null,
+    Object? frequencyPenalty = freezed,
+    Object? maxTokens = freezed,
+    Object? presencePenalty = freezed,
+    Object? responseFormat = freezed,
+    Object? seed = freezed,
+    Object? stop = freezed,
+    Object? stream = freezed,
+    Object? temperature = freezed,
+    Object? topP = freezed,
+    Object? tools = freezed,
+    Object? toolChoice = freezed,
+    Object? logprobs = freezed,
+    Object? topLogprobs = freezed,
+  }) {
+    return _then(_self.copyWith(
+      messages: null == messages
+          ? _self.messages
+          : messages // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionMessage>,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      frequencyPenalty: freezed == frequencyPenalty
+          ? _self.frequencyPenalty
+          : frequencyPenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      maxTokens: freezed == maxTokens
+          ? _self.maxTokens
+          : maxTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      presencePenalty: freezed == presencePenalty
+          ? _self.presencePenalty
+          : presencePenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      responseFormat: freezed == responseFormat
+          ? _self.responseFormat
+          : responseFormat // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+      seed: freezed == seed
+          ? _self.seed
+          : seed // ignore: cast_nullable_to_non_nullable
+              as int?,
+      stop: freezed == stop
+          ? _self.stop
+          : stop // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      stream: freezed == stream
+          ? _self.stream
+          : stream // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      temperature: freezed == temperature
+          ? _self.temperature
+          : temperature // ignore: cast_nullable_to_non_nullable
+              as double?,
+      topP: freezed == topP
+          ? _self.topP
+          : topP // ignore: cast_nullable_to_non_nullable
+              as double?,
+      tools: freezed == tools
+          ? _self.tools
+          : tools // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+      toolChoice: freezed == toolChoice
+          ? _self.toolChoice
+          : toolChoice // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      logprobs: freezed == logprobs
+          ? _self.logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      topLogprobs: freezed == topLogprobs
+          ? _self.topLogprobs
+          : topLogprobs // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionRequest].
+extension ChatCompletionRequestPatterns on ChatCompletionRequest {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionRequest value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionRequest value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionRequest value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionMessage> messages,
+            String model,
+            @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+            @JsonKey(name: 'max_tokens') int? maxTokens,
+            @JsonKey(name: 'presence_penalty') double? presencePenalty,
+            @JsonKey(name: 'response_format')
+            Map<String, dynamic>? responseFormat,
+            int? seed,
+            List<String>? stop,
+            bool? stream,
+            double? temperature,
+            @JsonKey(name: 'top_p') double? topP,
+            List<Map<String, dynamic>>? tools,
+            @JsonKey(name: 'tool_choice') dynamic toolChoice,
+            bool? logprobs,
+            @JsonKey(name: 'top_logprobs') int? topLogprobs)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(
+            _that.messages,
+            _that.model,
+            _that.frequencyPenalty,
+            _that.maxTokens,
+            _that.presencePenalty,
+            _that.responseFormat,
+            _that.seed,
+            _that.stop,
+            _that.stream,
+            _that.temperature,
+            _that.topP,
+            _that.tools,
+            _that.toolChoice,
+            _that.logprobs,
+            _that.topLogprobs);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionMessage> messages,
+            String model,
+            @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+            @JsonKey(name: 'max_tokens') int? maxTokens,
+            @JsonKey(name: 'presence_penalty') double? presencePenalty,
+            @JsonKey(name: 'response_format')
+            Map<String, dynamic>? responseFormat,
+            int? seed,
+            List<String>? stop,
+            bool? stream,
+            double? temperature,
+            @JsonKey(name: 'top_p') double? topP,
+            List<Map<String, dynamic>>? tools,
+            @JsonKey(name: 'tool_choice') dynamic toolChoice,
+            bool? logprobs,
+            @JsonKey(name: 'top_logprobs') int? topLogprobs)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest():
+        return $default(
+            _that.messages,
+            _that.model,
+            _that.frequencyPenalty,
+            _that.maxTokens,
+            _that.presencePenalty,
+            _that.responseFormat,
+            _that.seed,
+            _that.stop,
+            _that.stream,
+            _that.temperature,
+            _that.topP,
+            _that.tools,
+            _that.toolChoice,
+            _that.logprobs,
+            _that.topLogprobs);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            List<ChatCompletionMessage> messages,
+            String model,
+            @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+            @JsonKey(name: 'max_tokens') int? maxTokens,
+            @JsonKey(name: 'presence_penalty') double? presencePenalty,
+            @JsonKey(name: 'response_format')
+            Map<String, dynamic>? responseFormat,
+            int? seed,
+            List<String>? stop,
+            bool? stream,
+            double? temperature,
+            @JsonKey(name: 'top_p') double? topP,
+            List<Map<String, dynamic>>? tools,
+            @JsonKey(name: 'tool_choice') dynamic toolChoice,
+            bool? logprobs,
+            @JsonKey(name: 'top_logprobs') int? topLogprobs)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionRequest() when $default != null:
+        return $default(
+            _that.messages,
+            _that.model,
+            _that.frequencyPenalty,
+            _that.maxTokens,
+            _that.presencePenalty,
+            _that.responseFormat,
+            _that.seed,
+            _that.stop,
+            _that.stream,
+            _that.temperature,
+            _that.topP,
+            _that.tools,
+            _that.toolChoice,
+            _that.logprobs,
+            _that.topLogprobs);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionRequest extends ChatCompletionRequest {
+  _ChatCompletionRequest(
+      {required final List<ChatCompletionMessage> messages,
+      required this.model,
+      @JsonKey(name: 'frequency_penalty') this.frequencyPenalty,
+      @JsonKey(name: 'max_tokens') this.maxTokens,
+      @JsonKey(name: 'presence_penalty') this.presencePenalty,
+      @JsonKey(name: 'response_format')
+      final Map<String, dynamic>? responseFormat,
+      this.seed,
+      final List<String>? stop,
+      this.stream,
+      this.temperature,
+      @JsonKey(name: 'top_p') this.topP,
+      final List<Map<String, dynamic>>? tools,
+      @JsonKey(name: 'tool_choice') this.toolChoice,
+      this.logprobs,
+      @JsonKey(name: 'top_logprobs') this.topLogprobs})
+      : _messages = messages,
+        _responseFormat = responseFormat,
+        _stop = stop,
+        _tools = tools,
+        super._();
+  factory _ChatCompletionRequest.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionRequestFromJson(json);
+
+  final List<ChatCompletionMessage> _messages;
+  @override
+  List<ChatCompletionMessage> get messages {
+    if (_messages is EqualUnmodifiableListView) return _messages;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_messages);
+  }
+
+  @override
+  final String model;
+  @override
+  @JsonKey(name: 'frequency_penalty')
+  final double? frequencyPenalty;
+  @override
+  @JsonKey(name: 'max_tokens')
+  final int? maxTokens;
+  @override
+  @JsonKey(name: 'presence_penalty')
+  final double? presencePenalty;
+  final Map<String, dynamic>? _responseFormat;
+  @override
+  @JsonKey(name: 'response_format')
+  Map<String, dynamic>? get responseFormat {
+    final value = _responseFormat;
+    if (value == null) return null;
+    if (_responseFormat is EqualUnmodifiableMapView) return _responseFormat;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(value);
+  }
+
+  @override
+  final int? seed;
+  final List<String>? _stop;
+  @override
+  List<String>? get stop {
+    final value = _stop;
+    if (value == null) return null;
+    if (_stop is EqualUnmodifiableListView) return _stop;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  final bool? stream;
+  @override
+  final double? temperature;
+  @override
+  @JsonKey(name: 'top_p')
+  final double? topP;
+  final List<Map<String, dynamic>>? _tools;
+  @override
+  List<Map<String, dynamic>>? get tools {
+    final value = _tools;
+    if (value == null) return null;
+    if (_tools is EqualUnmodifiableListView) return _tools;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  @JsonKey(name: 'tool_choice')
+  final dynamic toolChoice;
+  @override
+  final bool? logprobs;
+  @override
+  @JsonKey(name: 'top_logprobs')
+  final int? topLogprobs;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionRequestCopyWith<_ChatCompletionRequest> get copyWith =>
+      __$ChatCompletionRequestCopyWithImpl<_ChatCompletionRequest>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionRequestToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionRequest &&
+            const DeepCollectionEquality().equals(other._messages, _messages) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.frequencyPenalty, frequencyPenalty) ||
+                other.frequencyPenalty == frequencyPenalty) &&
+            (identical(other.maxTokens, maxTokens) ||
+                other.maxTokens == maxTokens) &&
+            (identical(other.presencePenalty, presencePenalty) ||
+                other.presencePenalty == presencePenalty) &&
+            const DeepCollectionEquality()
+                .equals(other._responseFormat, _responseFormat) &&
+            (identical(other.seed, seed) || other.seed == seed) &&
+            const DeepCollectionEquality().equals(other._stop, _stop) &&
+            (identical(other.stream, stream) || other.stream == stream) &&
+            (identical(other.temperature, temperature) ||
+                other.temperature == temperature) &&
+            (identical(other.topP, topP) || other.topP == topP) &&
+            const DeepCollectionEquality().equals(other._tools, _tools) &&
+            const DeepCollectionEquality()
+                .equals(other.toolChoice, toolChoice) &&
+            (identical(other.logprobs, logprobs) ||
+                other.logprobs == logprobs) &&
+            (identical(other.topLogprobs, topLogprobs) ||
+                other.topLogprobs == topLogprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_messages),
+      model,
+      frequencyPenalty,
+      maxTokens,
+      presencePenalty,
+      const DeepCollectionEquality().hash(_responseFormat),
+      seed,
+      const DeepCollectionEquality().hash(_stop),
+      stream,
+      temperature,
+      topP,
+      const DeepCollectionEquality().hash(_tools),
+      const DeepCollectionEquality().hash(toolChoice),
+      logprobs,
+      topLogprobs);
+
+  @override
+  String toString() {
+    return 'ChatCompletionRequest(messages: $messages, model: $model, frequencyPenalty: $frequencyPenalty, maxTokens: $maxTokens, presencePenalty: $presencePenalty, responseFormat: $responseFormat, seed: $seed, stop: $stop, stream: $stream, temperature: $temperature, topP: $topP, tools: $tools, toolChoice: $toolChoice, logprobs: $logprobs, topLogprobs: $topLogprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionRequestCopyWith<$Res>
+    implements $ChatCompletionRequestCopyWith<$Res> {
+  factory _$ChatCompletionRequestCopyWith(_ChatCompletionRequest value,
+          $Res Function(_ChatCompletionRequest) _then) =
+      __$ChatCompletionRequestCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {List<ChatCompletionMessage> messages,
+      String model,
+      @JsonKey(name: 'frequency_penalty') double? frequencyPenalty,
+      @JsonKey(name: 'max_tokens') int? maxTokens,
+      @JsonKey(name: 'presence_penalty') double? presencePenalty,
+      @JsonKey(name: 'response_format') Map<String, dynamic>? responseFormat,
+      int? seed,
+      List<String>? stop,
+      bool? stream,
+      double? temperature,
+      @JsonKey(name: 'top_p') double? topP,
+      List<Map<String, dynamic>>? tools,
+      @JsonKey(name: 'tool_choice') dynamic toolChoice,
+      bool? logprobs,
+      @JsonKey(name: 'top_logprobs') int? topLogprobs});
+}
+
+/// @nodoc
+class __$ChatCompletionRequestCopyWithImpl<$Res>
+    implements _$ChatCompletionRequestCopyWith<$Res> {
+  __$ChatCompletionRequestCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionRequest _self;
+  final $Res Function(_ChatCompletionRequest) _then;
+
+  /// Create a copy of ChatCompletionRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? messages = null,
+    Object? model = null,
+    Object? frequencyPenalty = freezed,
+    Object? maxTokens = freezed,
+    Object? presencePenalty = freezed,
+    Object? responseFormat = freezed,
+    Object? seed = freezed,
+    Object? stop = freezed,
+    Object? stream = freezed,
+    Object? temperature = freezed,
+    Object? topP = freezed,
+    Object? tools = freezed,
+    Object? toolChoice = freezed,
+    Object? logprobs = freezed,
+    Object? topLogprobs = freezed,
+  }) {
+    return _then(_ChatCompletionRequest(
+      messages: null == messages
+          ? _self._messages
+          : messages // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionMessage>,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      frequencyPenalty: freezed == frequencyPenalty
+          ? _self.frequencyPenalty
+          : frequencyPenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      maxTokens: freezed == maxTokens
+          ? _self.maxTokens
+          : maxTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      presencePenalty: freezed == presencePenalty
+          ? _self.presencePenalty
+          : presencePenalty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      responseFormat: freezed == responseFormat
+          ? _self._responseFormat
+          : responseFormat // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+      seed: freezed == seed
+          ? _self.seed
+          : seed // ignore: cast_nullable_to_non_nullable
+              as int?,
+      stop: freezed == stop
+          ? _self._stop
+          : stop // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      stream: freezed == stream
+          ? _self.stream
+          : stream // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      temperature: freezed == temperature
+          ? _self.temperature
+          : temperature // ignore: cast_nullable_to_non_nullable
+              as double?,
+      topP: freezed == topP
+          ? _self.topP
+          : topP // ignore: cast_nullable_to_non_nullable
+              as double?,
+      tools: freezed == tools
+          ? _self._tools
+          : tools // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+      toolChoice: freezed == toolChoice
+          ? _self.toolChoice
+          : toolChoice // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      logprobs: freezed == logprobs
+          ? _self.logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      topLogprobs: freezed == topLogprobs
+          ? _self.topLogprobs
+          : topLogprobs // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.g.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.g.dart
@@ -1,0 +1,51 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionRequest _$ChatCompletionRequestFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionRequest(
+      messages: (json['messages'] as List<dynamic>)
+          .map((e) => ChatCompletionMessage.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      model: json['model'] as String,
+      frequencyPenalty: (json['frequency_penalty'] as num?)?.toDouble(),
+      maxTokens: (json['max_tokens'] as num?)?.toInt(),
+      presencePenalty: (json['presence_penalty'] as num?)?.toDouble(),
+      responseFormat: json['response_format'] as Map<String, dynamic>?,
+      seed: (json['seed'] as num?)?.toInt(),
+      stop: (json['stop'] as List<dynamic>?)?.map((e) => e as String).toList(),
+      stream: json['stream'] as bool?,
+      temperature: (json['temperature'] as num?)?.toDouble(),
+      topP: (json['top_p'] as num?)?.toDouble(),
+      tools: (json['tools'] as List<dynamic>?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+      toolChoice: json['tool_choice'],
+      logprobs: json['logprobs'] as bool?,
+      topLogprobs: (json['top_logprobs'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$ChatCompletionRequestToJson(
+        _ChatCompletionRequest instance) =>
+    <String, dynamic>{
+      'messages': instance.messages,
+      'model': instance.model,
+      'frequency_penalty': instance.frequencyPenalty,
+      'max_tokens': instance.maxTokens,
+      'presence_penalty': instance.presencePenalty,
+      'response_format': instance.responseFormat,
+      'seed': instance.seed,
+      'stop': instance.stop,
+      'stream': instance.stream,
+      'temperature': instance.temperature,
+      'top_p': instance.topP,
+      'tools': instance.tools,
+      'tool_choice': instance.toolChoice,
+      'logprobs': instance.logprobs,
+      'top_logprobs': instance.topLogprobs,
+    };

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:wavespeed_box/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart';
+import 'package:wavespeed_box/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart';
+
+part 'chat_completion_response.freezed.dart';
+part 'chat_completion_response.g.dart';
+
+/// https://wavespeed.ai/docs
+@freezed
+abstract class ChatCompletionResponse with _$ChatCompletionResponse {
+  factory ChatCompletionResponse({
+    required List<ChatCompletionResponseChoice> choices,
+    required int created,
+    required String id,
+    required String model,
+    required String object,
+    @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+    ChatCompletionResponseUsage? usage,
+  }) = _ChatCompletionResponse;
+
+  factory ChatCompletionResponse.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseFromJson(json);
+  const ChatCompletionResponse._();
+}

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.freezed.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.freezed.dart
@@ -1,0 +1,516 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponse {
+  List<ChatCompletionResponseChoice> get choices;
+  int get created;
+  String get id;
+  String get model;
+  String get object;
+  @JsonKey(name: 'system_fingerprint')
+  String? get systemFingerprint;
+  ChatCompletionResponseUsage? get usage;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseCopyWith<ChatCompletionResponse> get copyWith =>
+      _$ChatCompletionResponseCopyWithImpl<ChatCompletionResponse>(
+          this as ChatCompletionResponse, _$identity);
+
+  /// Serializes this ChatCompletionResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponse &&
+            const DeepCollectionEquality().equals(other.choices, choices) &&
+            (identical(other.created, created) || other.created == created) &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.systemFingerprint, systemFingerprint) ||
+                other.systemFingerprint == systemFingerprint) &&
+            (identical(other.usage, usage) || other.usage == usage));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(choices),
+      created,
+      id,
+      model,
+      object,
+      systemFingerprint,
+      usage);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponse(choices: $choices, created: $created, id: $id, model: $model, object: $object, systemFingerprint: $systemFingerprint, usage: $usage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseCopyWith<$Res> {
+  factory $ChatCompletionResponseCopyWith(ChatCompletionResponse value,
+          $Res Function(ChatCompletionResponse) _then) =
+      _$ChatCompletionResponseCopyWithImpl;
+  @useResult
+  $Res call(
+      {List<ChatCompletionResponseChoice> choices,
+      int created,
+      String id,
+      String model,
+      String object,
+      @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+      ChatCompletionResponseUsage? usage});
+
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage;
+}
+
+/// @nodoc
+class _$ChatCompletionResponseCopyWithImpl<$Res>
+    implements $ChatCompletionResponseCopyWith<$Res> {
+  _$ChatCompletionResponseCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponse _self;
+  final $Res Function(ChatCompletionResponse) _then;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? choices = null,
+    Object? created = null,
+    Object? id = null,
+    Object? model = null,
+    Object? object = null,
+    Object? systemFingerprint = freezed,
+    Object? usage = freezed,
+  }) {
+    return _then(_self.copyWith(
+      choices: null == choices
+          ? _self.choices
+          : choices // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionResponseChoice>,
+      created: null == created
+          ? _self.created
+          : created // ignore: cast_nullable_to_non_nullable
+              as int,
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      systemFingerprint: freezed == systemFingerprint
+          ? _self.systemFingerprint
+          : systemFingerprint // ignore: cast_nullable_to_non_nullable
+              as String?,
+      usage: freezed == usage
+          ? _self.usage
+          : usage // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsage?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage {
+    if (_self.usage == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCopyWith<$Res>(_self.usage!, (value) {
+      return _then(_self.copyWith(usage: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponse].
+extension ChatCompletionResponsePatterns on ChatCompletionResponse {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponse value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponse value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponse value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionResponseChoice> choices,
+            int created,
+            String id,
+            String model,
+            String object,
+            @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+            ChatCompletionResponseUsage? usage)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that.choices, _that.created, _that.id, _that.model,
+            _that.object, _that.systemFingerprint, _that.usage);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            List<ChatCompletionResponseChoice> choices,
+            int created,
+            String id,
+            String model,
+            String object,
+            @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+            ChatCompletionResponseUsage? usage)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse():
+        return $default(_that.choices, _that.created, _that.id, _that.model,
+            _that.object, _that.systemFingerprint, _that.usage);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            List<ChatCompletionResponseChoice> choices,
+            int created,
+            String id,
+            String model,
+            String object,
+            @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+            ChatCompletionResponseUsage? usage)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponse() when $default != null:
+        return $default(_that.choices, _that.created, _that.id, _that.model,
+            _that.object, _that.systemFingerprint, _that.usage);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponse extends ChatCompletionResponse {
+  _ChatCompletionResponse(
+      {required final List<ChatCompletionResponseChoice> choices,
+      required this.created,
+      required this.id,
+      required this.model,
+      required this.object,
+      @JsonKey(name: 'system_fingerprint') this.systemFingerprint,
+      this.usage})
+      : _choices = choices,
+        super._();
+  factory _ChatCompletionResponse.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseFromJson(json);
+
+  final List<ChatCompletionResponseChoice> _choices;
+  @override
+  List<ChatCompletionResponseChoice> get choices {
+    if (_choices is EqualUnmodifiableListView) return _choices;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_choices);
+  }
+
+  @override
+  final int created;
+  @override
+  final String id;
+  @override
+  final String model;
+  @override
+  final String object;
+  @override
+  @JsonKey(name: 'system_fingerprint')
+  final String? systemFingerprint;
+  @override
+  final ChatCompletionResponseUsage? usage;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseCopyWith<_ChatCompletionResponse> get copyWith =>
+      __$ChatCompletionResponseCopyWithImpl<_ChatCompletionResponse>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponse &&
+            const DeepCollectionEquality().equals(other._choices, _choices) &&
+            (identical(other.created, created) || other.created == created) &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.model, model) || other.model == model) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.systemFingerprint, systemFingerprint) ||
+                other.systemFingerprint == systemFingerprint) &&
+            (identical(other.usage, usage) || other.usage == usage));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_choices),
+      created,
+      id,
+      model,
+      object,
+      systemFingerprint,
+      usage);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponse(choices: $choices, created: $created, id: $id, model: $model, object: $object, systemFingerprint: $systemFingerprint, usage: $usage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseCopyWith<$Res>
+    implements $ChatCompletionResponseCopyWith<$Res> {
+  factory _$ChatCompletionResponseCopyWith(_ChatCompletionResponse value,
+          $Res Function(_ChatCompletionResponse) _then) =
+      __$ChatCompletionResponseCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {List<ChatCompletionResponseChoice> choices,
+      int created,
+      String id,
+      String model,
+      String object,
+      @JsonKey(name: 'system_fingerprint') String? systemFingerprint,
+      ChatCompletionResponseUsage? usage});
+
+  @override
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage;
+}
+
+/// @nodoc
+class __$ChatCompletionResponseCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseCopyWith<$Res> {
+  __$ChatCompletionResponseCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponse _self;
+  final $Res Function(_ChatCompletionResponse) _then;
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? choices = null,
+    Object? created = null,
+    Object? id = null,
+    Object? model = null,
+    Object? object = null,
+    Object? systemFingerprint = freezed,
+    Object? usage = freezed,
+  }) {
+    return _then(_ChatCompletionResponse(
+      choices: null == choices
+          ? _self._choices
+          : choices // ignore: cast_nullable_to_non_nullable
+              as List<ChatCompletionResponseChoice>,
+      created: null == created
+          ? _self.created
+          : created // ignore: cast_nullable_to_non_nullable
+              as int,
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      model: null == model
+          ? _self.model
+          : model // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      systemFingerprint: freezed == systemFingerprint
+          ? _self.systemFingerprint
+          : systemFingerprint // ignore: cast_nullable_to_non_nullable
+              as String?,
+      usage: freezed == usage
+          ? _self.usage
+          : usage // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsage?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCopyWith<$Res>? get usage {
+    if (_self.usage == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCopyWith<$Res>(_self.usage!, (value) {
+      return _then(_self.copyWith(usage: value));
+    });
+  }
+}
+
+// dart format on

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.g.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponse _$ChatCompletionResponseFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponse(
+      choices: (json['choices'] as List<dynamic>)
+          .map((e) =>
+              ChatCompletionResponseChoice.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      created: (json['created'] as num).toInt(),
+      id: json['id'] as String,
+      model: json['model'] as String,
+      object: json['object'] as String,
+      systemFingerprint: json['system_fingerprint'] as String?,
+      usage: json['usage'] == null
+          ? null
+          : ChatCompletionResponseUsage.fromJson(
+              json['usage'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseToJson(
+        _ChatCompletionResponse instance) =>
+    <String, dynamic>{
+      'choices': instance.choices,
+      'created': instance.created,
+      'id': instance.id,
+      'model': instance.model,
+      'object': instance.object,
+      'system_fingerprint': instance.systemFingerprint,
+      'usage': instance.usage,
+    };

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:wavespeed_box/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart';
+
+part 'chat_completion_response_choice.freezed.dart';
+part 'chat_completion_response_choice.g.dart';
+
+@freezed
+abstract class ChatCompletionResponseChoice
+    with _$ChatCompletionResponseChoice {
+  factory ChatCompletionResponseChoice({
+    required int index,
+    required ChatCompletionResponseMessage message,
+    @JsonKey(name: 'finish_reason') String? finishReason,
+    Map<String, dynamic>? logprobs,
+  }) = _ChatCompletionResponseChoice;
+
+  factory ChatCompletionResponseChoice.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseChoiceFromJson(json);
+  const ChatCompletionResponseChoice._();
+}

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.freezed.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.freezed.dart
@@ -1,0 +1,435 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response_choice.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponseChoice {
+  int get index;
+  ChatCompletionResponseMessage get message;
+  @JsonKey(name: 'finish_reason')
+  String? get finishReason;
+  Map<String, dynamic>? get logprobs;
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseChoiceCopyWith<ChatCompletionResponseChoice>
+      get copyWith => _$ChatCompletionResponseChoiceCopyWithImpl<
+              ChatCompletionResponseChoice>(
+          this as ChatCompletionResponseChoice, _$identity);
+
+  /// Serializes this ChatCompletionResponseChoice to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseChoice &&
+            (identical(other.index, index) || other.index == index) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.finishReason, finishReason) ||
+                other.finishReason == finishReason) &&
+            const DeepCollectionEquality().equals(other.logprobs, logprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, index, message, finishReason,
+      const DeepCollectionEquality().hash(logprobs));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseChoice(index: $index, message: $message, finishReason: $finishReason, logprobs: $logprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseChoiceCopyWith<$Res> {
+  factory $ChatCompletionResponseChoiceCopyWith(
+          ChatCompletionResponseChoice value,
+          $Res Function(ChatCompletionResponseChoice) _then) =
+      _$ChatCompletionResponseChoiceCopyWithImpl;
+  @useResult
+  $Res call(
+      {int index,
+      ChatCompletionResponseMessage message,
+      @JsonKey(name: 'finish_reason') String? finishReason,
+      Map<String, dynamic>? logprobs});
+
+  $ChatCompletionResponseMessageCopyWith<$Res> get message;
+}
+
+/// @nodoc
+class _$ChatCompletionResponseChoiceCopyWithImpl<$Res>
+    implements $ChatCompletionResponseChoiceCopyWith<$Res> {
+  _$ChatCompletionResponseChoiceCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponseChoice _self;
+  final $Res Function(ChatCompletionResponseChoice) _then;
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? index = null,
+    Object? message = null,
+    Object? finishReason = freezed,
+    Object? logprobs = freezed,
+  }) {
+    return _then(_self.copyWith(
+      index: null == index
+          ? _self.index
+          : index // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseMessage,
+      finishReason: freezed == finishReason
+          ? _self.finishReason
+          : finishReason // ignore: cast_nullable_to_non_nullable
+              as String?,
+      logprobs: freezed == logprobs
+          ? _self.logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseMessageCopyWith<$Res> get message {
+    return $ChatCompletionResponseMessageCopyWith<$Res>(_self.message, (value) {
+      return _then(_self.copyWith(message: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseChoice].
+extension ChatCompletionResponseChoicePatterns on ChatCompletionResponseChoice {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseChoice value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseChoice value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponseChoice value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            int index,
+            ChatCompletionResponseMessage message,
+            @JsonKey(name: 'finish_reason') String? finishReason,
+            Map<String, dynamic>? logprobs)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(
+            _that.index, _that.message, _that.finishReason, _that.logprobs);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            int index,
+            ChatCompletionResponseMessage message,
+            @JsonKey(name: 'finish_reason') String? finishReason,
+            Map<String, dynamic>? logprobs)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice():
+        return $default(
+            _that.index, _that.message, _that.finishReason, _that.logprobs);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            int index,
+            ChatCompletionResponseMessage message,
+            @JsonKey(name: 'finish_reason') String? finishReason,
+            Map<String, dynamic>? logprobs)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseChoice() when $default != null:
+        return $default(
+            _that.index, _that.message, _that.finishReason, _that.logprobs);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseChoice extends ChatCompletionResponseChoice {
+  _ChatCompletionResponseChoice(
+      {required this.index,
+      required this.message,
+      @JsonKey(name: 'finish_reason') this.finishReason,
+      final Map<String, dynamic>? logprobs})
+      : _logprobs = logprobs,
+        super._();
+  factory _ChatCompletionResponseChoice.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseChoiceFromJson(json);
+
+  @override
+  final int index;
+  @override
+  final ChatCompletionResponseMessage message;
+  @override
+  @JsonKey(name: 'finish_reason')
+  final String? finishReason;
+  final Map<String, dynamic>? _logprobs;
+  @override
+  Map<String, dynamic>? get logprobs {
+    final value = _logprobs;
+    if (value == null) return null;
+    if (_logprobs is EqualUnmodifiableMapView) return _logprobs;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(value);
+  }
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseChoiceCopyWith<_ChatCompletionResponseChoice>
+      get copyWith => __$ChatCompletionResponseChoiceCopyWithImpl<
+          _ChatCompletionResponseChoice>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseChoiceToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseChoice &&
+            (identical(other.index, index) || other.index == index) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.finishReason, finishReason) ||
+                other.finishReason == finishReason) &&
+            const DeepCollectionEquality().equals(other._logprobs, _logprobs));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, index, message, finishReason,
+      const DeepCollectionEquality().hash(_logprobs));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseChoice(index: $index, message: $message, finishReason: $finishReason, logprobs: $logprobs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseChoiceCopyWith<$Res>
+    implements $ChatCompletionResponseChoiceCopyWith<$Res> {
+  factory _$ChatCompletionResponseChoiceCopyWith(
+          _ChatCompletionResponseChoice value,
+          $Res Function(_ChatCompletionResponseChoice) _then) =
+      __$ChatCompletionResponseChoiceCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {int index,
+      ChatCompletionResponseMessage message,
+      @JsonKey(name: 'finish_reason') String? finishReason,
+      Map<String, dynamic>? logprobs});
+
+  @override
+  $ChatCompletionResponseMessageCopyWith<$Res> get message;
+}
+
+/// @nodoc
+class __$ChatCompletionResponseChoiceCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseChoiceCopyWith<$Res> {
+  __$ChatCompletionResponseChoiceCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponseChoice _self;
+  final $Res Function(_ChatCompletionResponseChoice) _then;
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? index = null,
+    Object? message = null,
+    Object? finishReason = freezed,
+    Object? logprobs = freezed,
+  }) {
+    return _then(_ChatCompletionResponseChoice(
+      index: null == index
+          ? _self.index
+          : index // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseMessage,
+      finishReason: freezed == finishReason
+          ? _self.finishReason
+          : finishReason // ignore: cast_nullable_to_non_nullable
+              as String?,
+      logprobs: freezed == logprobs
+          ? _self._logprobs
+          : logprobs // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseChoice
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseMessageCopyWith<$Res> get message {
+    return $ChatCompletionResponseMessageCopyWith<$Res>(_self.message, (value) {
+      return _then(_self.copyWith(message: value));
+    });
+  }
+}
+
+// dart format on

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.g.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response_choice.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponseChoice _$ChatCompletionResponseChoiceFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponseChoice(
+      index: (json['index'] as num).toInt(),
+      message: ChatCompletionResponseMessage.fromJson(
+          json['message'] as Map<String, dynamic>),
+      finishReason: json['finish_reason'] as String?,
+      logprobs: json['logprobs'] as Map<String, dynamic>?,
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseChoiceToJson(
+        _ChatCompletionResponseChoice instance) =>
+    <String, dynamic>{
+      'index': instance.index,
+      'message': instance.message,
+      'finish_reason': instance.finishReason,
+      'logprobs': instance.logprobs,
+    };

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'chat_completion_response_message.freezed.dart';
+part 'chat_completion_response_message.g.dart';
+
+@freezed
+abstract class ChatCompletionResponseMessage
+    with _$ChatCompletionResponseMessage {
+  factory ChatCompletionResponseMessage({
+    required String role,
+    String? content,
+    @JsonKey(name: 'reasoning_content') String? reasoningContent,
+    String? refusal,
+    @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls,
+  }) = _ChatCompletionResponseMessage;
+
+  factory ChatCompletionResponseMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseMessageFromJson(json);
+  const ChatCompletionResponseMessage._();
+}

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.freezed.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.freezed.dart
@@ -1,0 +1,435 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response_message.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponseMessage {
+  String get role;
+  String? get content;
+  @JsonKey(name: 'reasoning_content')
+  String? get reasoningContent;
+  String? get refusal;
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls;
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseMessageCopyWith<ChatCompletionResponseMessage>
+      get copyWith => _$ChatCompletionResponseMessageCopyWithImpl<
+              ChatCompletionResponseMessage>(
+          this as ChatCompletionResponseMessage, _$identity);
+
+  /// Serializes this ChatCompletionResponseMessage to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.reasoningContent, reasoningContent) ||
+                other.reasoningContent == reasoningContent) &&
+            (identical(other.refusal, refusal) || other.refusal == refusal) &&
+            const DeepCollectionEquality().equals(other.toolCalls, toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, reasoningContent,
+      refusal, const DeepCollectionEquality().hash(toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseMessage(role: $role, content: $content, reasoningContent: $reasoningContent, refusal: $refusal, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseMessageCopyWith<$Res> {
+  factory $ChatCompletionResponseMessageCopyWith(
+          ChatCompletionResponseMessage value,
+          $Res Function(ChatCompletionResponseMessage) _then) =
+      _$ChatCompletionResponseMessageCopyWithImpl;
+  @useResult
+  $Res call(
+      {String role,
+      String? content,
+      @JsonKey(name: 'reasoning_content') String? reasoningContent,
+      String? refusal,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class _$ChatCompletionResponseMessageCopyWithImpl<$Res>
+    implements $ChatCompletionResponseMessageCopyWith<$Res> {
+  _$ChatCompletionResponseMessageCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponseMessage _self;
+  final $Res Function(ChatCompletionResponseMessage) _then;
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? role = null,
+    Object? content = freezed,
+    Object? reasoningContent = freezed,
+    Object? refusal = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_self.copyWith(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: freezed == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String?,
+      reasoningContent: freezed == reasoningContent
+          ? _self.reasoningContent
+          : reasoningContent // ignore: cast_nullable_to_non_nullable
+              as String?,
+      refusal: freezed == refusal
+          ? _self.refusal
+          : refusal // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self.toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseMessage].
+extension ChatCompletionResponseMessagePatterns
+    on ChatCompletionResponseMessage {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseMessage value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseMessage value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponseMessage value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String role,
+            String? content,
+            @JsonKey(name: 'reasoning_content') String? reasoningContent,
+            String? refusal,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.reasoningContent,
+            _that.refusal, _that.toolCalls);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String role,
+            String? content,
+            @JsonKey(name: 'reasoning_content') String? reasoningContent,
+            String? refusal,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage():
+        return $default(_that.role, _that.content, _that.reasoningContent,
+            _that.refusal, _that.toolCalls);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String role,
+            String? content,
+            @JsonKey(name: 'reasoning_content') String? reasoningContent,
+            String? refusal,
+            @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseMessage() when $default != null:
+        return $default(_that.role, _that.content, _that.reasoningContent,
+            _that.refusal, _that.toolCalls);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseMessage extends ChatCompletionResponseMessage {
+  _ChatCompletionResponseMessage(
+      {required this.role,
+      this.content,
+      @JsonKey(name: 'reasoning_content') this.reasoningContent,
+      this.refusal,
+      @JsonKey(name: 'tool_calls') final List<Map<String, dynamic>>? toolCalls})
+      : _toolCalls = toolCalls,
+        super._();
+  factory _ChatCompletionResponseMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseMessageFromJson(json);
+
+  @override
+  final String role;
+  @override
+  final String? content;
+  @override
+  @JsonKey(name: 'reasoning_content')
+  final String? reasoningContent;
+  @override
+  final String? refusal;
+  final List<Map<String, dynamic>>? _toolCalls;
+  @override
+  @JsonKey(name: 'tool_calls')
+  List<Map<String, dynamic>>? get toolCalls {
+    final value = _toolCalls;
+    if (value == null) return null;
+    if (_toolCalls is EqualUnmodifiableListView) return _toolCalls;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseMessageCopyWith<_ChatCompletionResponseMessage>
+      get copyWith => __$ChatCompletionResponseMessageCopyWithImpl<
+          _ChatCompletionResponseMessage>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseMessageToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseMessage &&
+            (identical(other.role, role) || other.role == role) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.reasoningContent, reasoningContent) ||
+                other.reasoningContent == reasoningContent) &&
+            (identical(other.refusal, refusal) || other.refusal == refusal) &&
+            const DeepCollectionEquality()
+                .equals(other._toolCalls, _toolCalls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content, reasoningContent,
+      refusal, const DeepCollectionEquality().hash(_toolCalls));
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseMessage(role: $role, content: $content, reasoningContent: $reasoningContent, refusal: $refusal, toolCalls: $toolCalls)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseMessageCopyWith<$Res>
+    implements $ChatCompletionResponseMessageCopyWith<$Res> {
+  factory _$ChatCompletionResponseMessageCopyWith(
+          _ChatCompletionResponseMessage value,
+          $Res Function(_ChatCompletionResponseMessage) _then) =
+      __$ChatCompletionResponseMessageCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String role,
+      String? content,
+      @JsonKey(name: 'reasoning_content') String? reasoningContent,
+      String? refusal,
+      @JsonKey(name: 'tool_calls') List<Map<String, dynamic>>? toolCalls});
+}
+
+/// @nodoc
+class __$ChatCompletionResponseMessageCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseMessageCopyWith<$Res> {
+  __$ChatCompletionResponseMessageCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponseMessage _self;
+  final $Res Function(_ChatCompletionResponseMessage) _then;
+
+  /// Create a copy of ChatCompletionResponseMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? role = null,
+    Object? content = freezed,
+    Object? reasoningContent = freezed,
+    Object? refusal = freezed,
+    Object? toolCalls = freezed,
+  }) {
+    return _then(_ChatCompletionResponseMessage(
+      role: null == role
+          ? _self.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: freezed == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String?,
+      reasoningContent: freezed == reasoningContent
+          ? _self.reasoningContent
+          : reasoningContent // ignore: cast_nullable_to_non_nullable
+              as String?,
+      refusal: freezed == refusal
+          ? _self.refusal
+          : refusal // ignore: cast_nullable_to_non_nullable
+              as String?,
+      toolCalls: freezed == toolCalls
+          ? _self._toolCalls
+          : toolCalls // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>?,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.g.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response_message.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponseMessage _$ChatCompletionResponseMessageFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponseMessage(
+      role: json['role'] as String,
+      content: json['content'] as String?,
+      reasoningContent: json['reasoning_content'] as String?,
+      refusal: json['refusal'] as String?,
+      toolCalls: (json['tool_calls'] as List<dynamic>?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseMessageToJson(
+        _ChatCompletionResponseMessage instance) =>
+    <String, dynamic>{
+      'role': instance.role,
+      'content': instance.content,
+      'reasoning_content': instance.reasoningContent,
+      'refusal': instance.refusal,
+      'tool_calls': instance.toolCalls,
+    };

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart
@@ -1,0 +1,35 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'chat_completion_response_usage.freezed.dart';
+part 'chat_completion_response_usage.g.dart';
+
+@freezed
+abstract class ChatCompletionResponseUsage with _$ChatCompletionResponseUsage {
+  factory ChatCompletionResponseUsage({
+    @JsonKey(name: 'completion_tokens') required int completionTokens,
+    @JsonKey(name: 'prompt_tokens') required int promptTokens,
+    @JsonKey(name: 'total_tokens') required int totalTokens,
+    @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+    @JsonKey(name: 'prompt_cache_miss_tokens') int? promptCacheMissTokens,
+    @JsonKey(name: 'completion_tokens_details')
+    ChatCompletionResponseUsageCompletionTokensDetails? completionTokensDetails,
+  }) = _ChatCompletionResponseUsage;
+
+  factory ChatCompletionResponseUsage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseUsageFromJson(json);
+  const ChatCompletionResponseUsage._();
+}
+
+@freezed
+abstract class ChatCompletionResponseUsageCompletionTokensDetails
+    with _$ChatCompletionResponseUsageCompletionTokensDetails {
+  factory ChatCompletionResponseUsageCompletionTokensDetails({
+    @JsonKey(name: 'reasoning_tokens') required int reasoningTokens,
+  }) = _ChatCompletionResponseUsageCompletionTokensDetails;
+
+  factory ChatCompletionResponseUsageCompletionTokensDetails.fromJson(
+    Map<String, dynamic> json,
+  ) =>
+      _$ChatCompletionResponseUsageCompletionTokensDetailsFromJson(json);
+  const ChatCompletionResponseUsageCompletionTokensDetails._();
+}

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.freezed.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.freezed.dart
@@ -1,0 +1,888 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_completion_response_usage.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChatCompletionResponseUsage {
+  @JsonKey(name: 'completion_tokens')
+  int get completionTokens;
+  @JsonKey(name: 'prompt_tokens')
+  int get promptTokens;
+  @JsonKey(name: 'total_tokens')
+  int get totalTokens;
+  @JsonKey(name: 'prompt_cache_hit_tokens')
+  int? get promptCacheHitTokens;
+  @JsonKey(name: 'prompt_cache_miss_tokens')
+  int? get promptCacheMissTokens;
+  @JsonKey(name: 'completion_tokens_details')
+  ChatCompletionResponseUsageCompletionTokensDetails?
+      get completionTokensDetails;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCopyWith<ChatCompletionResponseUsage>
+      get copyWith => _$ChatCompletionResponseUsageCopyWithImpl<
+              ChatCompletionResponseUsage>(
+          this as ChatCompletionResponseUsage, _$identity);
+
+  /// Serializes this ChatCompletionResponseUsage to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseUsage &&
+            (identical(other.completionTokens, completionTokens) ||
+                other.completionTokens == completionTokens) &&
+            (identical(other.promptTokens, promptTokens) ||
+                other.promptTokens == promptTokens) &&
+            (identical(other.totalTokens, totalTokens) ||
+                other.totalTokens == totalTokens) &&
+            (identical(other.promptCacheHitTokens, promptCacheHitTokens) ||
+                other.promptCacheHitTokens == promptCacheHitTokens) &&
+            (identical(other.promptCacheMissTokens, promptCacheMissTokens) ||
+                other.promptCacheMissTokens == promptCacheMissTokens) &&
+            (identical(
+                    other.completionTokensDetails, completionTokensDetails) ||
+                other.completionTokensDetails == completionTokensDetails));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      completionTokens,
+      promptTokens,
+      totalTokens,
+      promptCacheHitTokens,
+      promptCacheMissTokens,
+      completionTokensDetails);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsage(completionTokens: $completionTokens, promptTokens: $promptTokens, totalTokens: $totalTokens, promptCacheHitTokens: $promptCacheHitTokens, promptCacheMissTokens: $promptCacheMissTokens, completionTokensDetails: $completionTokensDetails)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseUsageCopyWith<$Res> {
+  factory $ChatCompletionResponseUsageCopyWith(
+          ChatCompletionResponseUsage value,
+          $Res Function(ChatCompletionResponseUsage) _then) =
+      _$ChatCompletionResponseUsageCopyWithImpl;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'completion_tokens') int completionTokens,
+      @JsonKey(name: 'prompt_tokens') int promptTokens,
+      @JsonKey(name: 'total_tokens') int totalTokens,
+      @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+      @JsonKey(name: 'prompt_cache_miss_tokens') int? promptCacheMissTokens,
+      @JsonKey(name: 'completion_tokens_details')
+      ChatCompletionResponseUsageCompletionTokensDetails?
+          completionTokensDetails});
+
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails;
+}
+
+/// @nodoc
+class _$ChatCompletionResponseUsageCopyWithImpl<$Res>
+    implements $ChatCompletionResponseUsageCopyWith<$Res> {
+  _$ChatCompletionResponseUsageCopyWithImpl(this._self, this._then);
+
+  final ChatCompletionResponseUsage _self;
+  final $Res Function(ChatCompletionResponseUsage) _then;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? completionTokens = null,
+    Object? promptTokens = null,
+    Object? totalTokens = null,
+    Object? promptCacheHitTokens = freezed,
+    Object? promptCacheMissTokens = freezed,
+    Object? completionTokensDetails = freezed,
+  }) {
+    return _then(_self.copyWith(
+      completionTokens: null == completionTokens
+          ? _self.completionTokens
+          : completionTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptTokens: null == promptTokens
+          ? _self.promptTokens
+          : promptTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalTokens: null == totalTokens
+          ? _self.totalTokens
+          : totalTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptCacheHitTokens: freezed == promptCacheHitTokens
+          ? _self.promptCacheHitTokens
+          : promptCacheHitTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      promptCacheMissTokens: freezed == promptCacheMissTokens
+          ? _self.promptCacheMissTokens
+          : promptCacheMissTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      completionTokensDetails: freezed == completionTokensDetails
+          ? _self.completionTokensDetails
+          : completionTokensDetails // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsageCompletionTokensDetails?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails {
+    if (_self.completionTokensDetails == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>(
+        _self.completionTokensDetails!, (value) {
+      return _then(_self.copyWith(completionTokensDetails: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseUsage].
+extension ChatCompletionResponseUsagePatterns on ChatCompletionResponseUsage {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsage value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsage value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ChatCompletionResponseUsage value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: 'completion_tokens') int completionTokens,
+            @JsonKey(name: 'prompt_tokens') int promptTokens,
+            @JsonKey(name: 'total_tokens') int totalTokens,
+            @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+            @JsonKey(name: 'prompt_cache_miss_tokens')
+            int? promptCacheMissTokens,
+            @JsonKey(name: 'completion_tokens_details')
+            ChatCompletionResponseUsageCompletionTokensDetails?
+                completionTokensDetails)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(
+            _that.completionTokens,
+            _that.promptTokens,
+            _that.totalTokens,
+            _that.promptCacheHitTokens,
+            _that.promptCacheMissTokens,
+            _that.completionTokensDetails);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: 'completion_tokens') int completionTokens,
+            @JsonKey(name: 'prompt_tokens') int promptTokens,
+            @JsonKey(name: 'total_tokens') int totalTokens,
+            @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+            @JsonKey(name: 'prompt_cache_miss_tokens')
+            int? promptCacheMissTokens,
+            @JsonKey(name: 'completion_tokens_details')
+            ChatCompletionResponseUsageCompletionTokensDetails?
+                completionTokensDetails)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage():
+        return $default(
+            _that.completionTokens,
+            _that.promptTokens,
+            _that.totalTokens,
+            _that.promptCacheHitTokens,
+            _that.promptCacheMissTokens,
+            _that.completionTokensDetails);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @JsonKey(name: 'completion_tokens') int completionTokens,
+            @JsonKey(name: 'prompt_tokens') int promptTokens,
+            @JsonKey(name: 'total_tokens') int totalTokens,
+            @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+            @JsonKey(name: 'prompt_cache_miss_tokens')
+            int? promptCacheMissTokens,
+            @JsonKey(name: 'completion_tokens_details')
+            ChatCompletionResponseUsageCompletionTokensDetails?
+                completionTokensDetails)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsage() when $default != null:
+        return $default(
+            _that.completionTokens,
+            _that.promptTokens,
+            _that.totalTokens,
+            _that.promptCacheHitTokens,
+            _that.promptCacheMissTokens,
+            _that.completionTokensDetails);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseUsage extends ChatCompletionResponseUsage {
+  _ChatCompletionResponseUsage(
+      {@JsonKey(name: 'completion_tokens') required this.completionTokens,
+      @JsonKey(name: 'prompt_tokens') required this.promptTokens,
+      @JsonKey(name: 'total_tokens') required this.totalTokens,
+      @JsonKey(name: 'prompt_cache_hit_tokens') this.promptCacheHitTokens,
+      @JsonKey(name: 'prompt_cache_miss_tokens') this.promptCacheMissTokens,
+      @JsonKey(name: 'completion_tokens_details') this.completionTokensDetails})
+      : super._();
+  factory _ChatCompletionResponseUsage.fromJson(Map<String, dynamic> json) =>
+      _$ChatCompletionResponseUsageFromJson(json);
+
+  @override
+  @JsonKey(name: 'completion_tokens')
+  final int completionTokens;
+  @override
+  @JsonKey(name: 'prompt_tokens')
+  final int promptTokens;
+  @override
+  @JsonKey(name: 'total_tokens')
+  final int totalTokens;
+  @override
+  @JsonKey(name: 'prompt_cache_hit_tokens')
+  final int? promptCacheHitTokens;
+  @override
+  @JsonKey(name: 'prompt_cache_miss_tokens')
+  final int? promptCacheMissTokens;
+  @override
+  @JsonKey(name: 'completion_tokens_details')
+  final ChatCompletionResponseUsageCompletionTokensDetails?
+      completionTokensDetails;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseUsageCopyWith<_ChatCompletionResponseUsage>
+      get copyWith => __$ChatCompletionResponseUsageCopyWithImpl<
+          _ChatCompletionResponseUsage>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseUsageToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseUsage &&
+            (identical(other.completionTokens, completionTokens) ||
+                other.completionTokens == completionTokens) &&
+            (identical(other.promptTokens, promptTokens) ||
+                other.promptTokens == promptTokens) &&
+            (identical(other.totalTokens, totalTokens) ||
+                other.totalTokens == totalTokens) &&
+            (identical(other.promptCacheHitTokens, promptCacheHitTokens) ||
+                other.promptCacheHitTokens == promptCacheHitTokens) &&
+            (identical(other.promptCacheMissTokens, promptCacheMissTokens) ||
+                other.promptCacheMissTokens == promptCacheMissTokens) &&
+            (identical(
+                    other.completionTokensDetails, completionTokensDetails) ||
+                other.completionTokensDetails == completionTokensDetails));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      completionTokens,
+      promptTokens,
+      totalTokens,
+      promptCacheHitTokens,
+      promptCacheMissTokens,
+      completionTokensDetails);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsage(completionTokens: $completionTokens, promptTokens: $promptTokens, totalTokens: $totalTokens, promptCacheHitTokens: $promptCacheHitTokens, promptCacheMissTokens: $promptCacheMissTokens, completionTokensDetails: $completionTokensDetails)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseUsageCopyWith<$Res>
+    implements $ChatCompletionResponseUsageCopyWith<$Res> {
+  factory _$ChatCompletionResponseUsageCopyWith(
+          _ChatCompletionResponseUsage value,
+          $Res Function(_ChatCompletionResponseUsage) _then) =
+      __$ChatCompletionResponseUsageCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'completion_tokens') int completionTokens,
+      @JsonKey(name: 'prompt_tokens') int promptTokens,
+      @JsonKey(name: 'total_tokens') int totalTokens,
+      @JsonKey(name: 'prompt_cache_hit_tokens') int? promptCacheHitTokens,
+      @JsonKey(name: 'prompt_cache_miss_tokens') int? promptCacheMissTokens,
+      @JsonKey(name: 'completion_tokens_details')
+      ChatCompletionResponseUsageCompletionTokensDetails?
+          completionTokensDetails});
+
+  @override
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails;
+}
+
+/// @nodoc
+class __$ChatCompletionResponseUsageCopyWithImpl<$Res>
+    implements _$ChatCompletionResponseUsageCopyWith<$Res> {
+  __$ChatCompletionResponseUsageCopyWithImpl(this._self, this._then);
+
+  final _ChatCompletionResponseUsage _self;
+  final $Res Function(_ChatCompletionResponseUsage) _then;
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? completionTokens = null,
+    Object? promptTokens = null,
+    Object? totalTokens = null,
+    Object? promptCacheHitTokens = freezed,
+    Object? promptCacheMissTokens = freezed,
+    Object? completionTokensDetails = freezed,
+  }) {
+    return _then(_ChatCompletionResponseUsage(
+      completionTokens: null == completionTokens
+          ? _self.completionTokens
+          : completionTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptTokens: null == promptTokens
+          ? _self.promptTokens
+          : promptTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalTokens: null == totalTokens
+          ? _self.totalTokens
+          : totalTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+      promptCacheHitTokens: freezed == promptCacheHitTokens
+          ? _self.promptCacheHitTokens
+          : promptCacheHitTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      promptCacheMissTokens: freezed == promptCacheMissTokens
+          ? _self.promptCacheMissTokens
+          : promptCacheMissTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
+      completionTokensDetails: freezed == completionTokensDetails
+          ? _self.completionTokensDetails
+          : completionTokensDetails // ignore: cast_nullable_to_non_nullable
+              as ChatCompletionResponseUsageCompletionTokensDetails?,
+    ));
+  }
+
+  /// Create a copy of ChatCompletionResponseUsage
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>?
+      get completionTokensDetails {
+    if (_self.completionTokensDetails == null) {
+      return null;
+    }
+
+    return $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res>(
+        _self.completionTokensDetails!, (value) {
+      return _then(_self.copyWith(completionTokensDetails: value));
+    });
+  }
+}
+
+/// @nodoc
+mixin _$ChatCompletionResponseUsageCompletionTokensDetails {
+  @JsonKey(name: 'reasoning_tokens')
+  int get reasoningTokens;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+          ChatCompletionResponseUsageCompletionTokensDetails>
+      get copyWith =>
+          _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<
+                  ChatCompletionResponseUsageCompletionTokensDetails>(
+              this as ChatCompletionResponseUsageCompletionTokensDetails,
+              _$identity);
+
+  /// Serializes this ChatCompletionResponseUsageCompletionTokensDetails to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ChatCompletionResponseUsageCompletionTokensDetails &&
+            (identical(other.reasoningTokens, reasoningTokens) ||
+                other.reasoningTokens == reasoningTokens));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, reasoningTokens);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsageCompletionTokensDetails(reasoningTokens: $reasoningTokens)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+    $Res> {
+  factory $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith(
+          ChatCompletionResponseUsageCompletionTokensDetails value,
+          $Res Function(ChatCompletionResponseUsageCompletionTokensDetails)
+              _then) =
+      _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl;
+  @useResult
+  $Res call({@JsonKey(name: 'reasoning_tokens') int reasoningTokens});
+}
+
+/// @nodoc
+class _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<$Res>
+    implements
+        $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res> {
+  _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl(
+      this._self, this._then);
+
+  final ChatCompletionResponseUsageCompletionTokensDetails _self;
+  final $Res Function(ChatCompletionResponseUsageCompletionTokensDetails) _then;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? reasoningTokens = null,
+  }) {
+    return _then(_self.copyWith(
+      reasoningTokens: null == reasoningTokens
+          ? _self.reasoningTokens
+          : reasoningTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ChatCompletionResponseUsageCompletionTokensDetails].
+extension ChatCompletionResponseUsageCompletionTokensDetailsPatterns
+    on ChatCompletionResponseUsageCompletionTokensDetails {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsageCompletionTokensDetails value)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ChatCompletionResponseUsageCompletionTokensDetails value)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(
+            _ChatCompletionResponseUsageCompletionTokensDetails value)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@JsonKey(name: 'reasoning_tokens') int reasoningTokens)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that.reasoningTokens);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@JsonKey(name: 'reasoning_tokens') int reasoningTokens)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails():
+        return $default(_that.reasoningTokens);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(@JsonKey(name: 'reasoning_tokens') int reasoningTokens)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ChatCompletionResponseUsageCompletionTokensDetails()
+          when $default != null:
+        return $default(_that.reasoningTokens);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ChatCompletionResponseUsageCompletionTokensDetails
+    extends ChatCompletionResponseUsageCompletionTokensDetails {
+  _ChatCompletionResponseUsageCompletionTokensDetails(
+      {@JsonKey(name: 'reasoning_tokens') required this.reasoningTokens})
+      : super._();
+  factory _ChatCompletionResponseUsageCompletionTokensDetails.fromJson(
+          Map<String, dynamic> json) =>
+      _$ChatCompletionResponseUsageCompletionTokensDetailsFromJson(json);
+
+  @override
+  @JsonKey(name: 'reasoning_tokens')
+  final int reasoningTokens;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+          _ChatCompletionResponseUsageCompletionTokensDetails>
+      get copyWith =>
+          __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<
+                  _ChatCompletionResponseUsageCompletionTokensDetails>(
+              this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ChatCompletionResponseUsageCompletionTokensDetailsToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ChatCompletionResponseUsageCompletionTokensDetails &&
+            (identical(other.reasoningTokens, reasoningTokens) ||
+                other.reasoningTokens == reasoningTokens));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, reasoningTokens);
+
+  @override
+  String toString() {
+    return 'ChatCompletionResponseUsageCompletionTokensDetails(reasoningTokens: $reasoningTokens)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<
+        $Res>
+    implements
+        $ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res> {
+  factory _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith(
+          _ChatCompletionResponseUsageCompletionTokensDetails value,
+          $Res Function(_ChatCompletionResponseUsageCompletionTokensDetails)
+              _then) =
+      __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl;
+  @override
+  @useResult
+  $Res call({@JsonKey(name: 'reasoning_tokens') int reasoningTokens});
+}
+
+/// @nodoc
+class __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl<$Res>
+    implements
+        _$ChatCompletionResponseUsageCompletionTokensDetailsCopyWith<$Res> {
+  __$ChatCompletionResponseUsageCompletionTokensDetailsCopyWithImpl(
+      this._self, this._then);
+
+  final _ChatCompletionResponseUsageCompletionTokensDetails _self;
+  final $Res Function(_ChatCompletionResponseUsageCompletionTokensDetails)
+      _then;
+
+  /// Create a copy of ChatCompletionResponseUsageCompletionTokensDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? reasoningTokens = null,
+  }) {
+    return _then(_ChatCompletionResponseUsageCompletionTokensDetails(
+      reasoningTokens: null == reasoningTokens
+          ? _self.reasoningTokens
+          : reasoningTokens // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.g.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_completion_response_usage.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChatCompletionResponseUsage _$ChatCompletionResponseUsageFromJson(
+        Map<String, dynamic> json) =>
+    _ChatCompletionResponseUsage(
+      completionTokens: (json['completion_tokens'] as num).toInt(),
+      promptTokens: (json['prompt_tokens'] as num).toInt(),
+      totalTokens: (json['total_tokens'] as num).toInt(),
+      promptCacheHitTokens: (json['prompt_cache_hit_tokens'] as num?)?.toInt(),
+      promptCacheMissTokens:
+          (json['prompt_cache_miss_tokens'] as num?)?.toInt(),
+      completionTokensDetails: json['completion_tokens_details'] == null
+          ? null
+          : ChatCompletionResponseUsageCompletionTokensDetails.fromJson(
+              json['completion_tokens_details'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$ChatCompletionResponseUsageToJson(
+        _ChatCompletionResponseUsage instance) =>
+    <String, dynamic>{
+      'completion_tokens': instance.completionTokens,
+      'prompt_tokens': instance.promptTokens,
+      'total_tokens': instance.totalTokens,
+      'prompt_cache_hit_tokens': instance.promptCacheHitTokens,
+      'prompt_cache_miss_tokens': instance.promptCacheMissTokens,
+      'completion_tokens_details': instance.completionTokensDetails,
+    };
+
+_ChatCompletionResponseUsageCompletionTokensDetails
+    _$ChatCompletionResponseUsageCompletionTokensDetailsFromJson(
+            Map<String, dynamic> json) =>
+        _ChatCompletionResponseUsageCompletionTokensDetails(
+          reasoningTokens: (json['reasoning_tokens'] as num).toInt(),
+        );
+
+Map<String, dynamic> _$ChatCompletionResponseUsageCompletionTokensDetailsToJson(
+        _ChatCompletionResponseUsageCompletionTokensDetails instance) =>
+    <String, dynamic>{
+      'reasoning_tokens': instance.reasoningTokens,
+    };

--- a/pkgs/wavespeed_box/lib/src/freezed/model/model/model.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/model/model/model.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'model.freezed.dart';
+part 'model.g.dart';
+
+@freezed
+abstract class Model with _$Model {
+  factory Model({
+    required String id,
+    required String object,
+    @JsonKey(name: 'owned_by') required String ownedBy,
+  }) = _Model;
+
+  factory Model.fromJson(Map<String, dynamic> json) => _$ModelFromJson(json);
+  const Model._();
+}

--- a/pkgs/wavespeed_box/lib/src/freezed/model/model/model.freezed.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/model/model/model.freezed.dart
@@ -1,0 +1,353 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Model {
+  String get id;
+  String get object;
+  @JsonKey(name: 'owned_by')
+  String get ownedBy;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ModelCopyWith<Model> get copyWith =>
+      _$ModelCopyWithImpl<Model>(this as Model, _$identity);
+
+  /// Serializes this Model to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Model &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.ownedBy, ownedBy) || other.ownedBy == ownedBy));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, object, ownedBy);
+
+  @override
+  String toString() {
+    return 'Model(id: $id, object: $object, ownedBy: $ownedBy)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ModelCopyWith<$Res> {
+  factory $ModelCopyWith(Model value, $Res Function(Model) _then) =
+      _$ModelCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id, String object, @JsonKey(name: 'owned_by') String ownedBy});
+}
+
+/// @nodoc
+class _$ModelCopyWithImpl<$Res> implements $ModelCopyWith<$Res> {
+  _$ModelCopyWithImpl(this._self, this._then);
+
+  final Model _self;
+  final $Res Function(Model) _then;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? object = null,
+    Object? ownedBy = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      ownedBy: null == ownedBy
+          ? _self.ownedBy
+          : ownedBy // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Model].
+extension ModelPatterns on Model {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Model value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Model value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Model value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String id, String object,
+            @JsonKey(name: 'owned_by') String ownedBy)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that.id, _that.object, _that.ownedBy);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id, String object, @JsonKey(name: 'owned_by') String ownedBy)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model():
+        return $default(_that.id, _that.object, _that.ownedBy);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String id, String object,
+            @JsonKey(name: 'owned_by') String ownedBy)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Model() when $default != null:
+        return $default(_that.id, _that.object, _that.ownedBy);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _Model extends Model {
+  _Model(
+      {required this.id,
+      required this.object,
+      @JsonKey(name: 'owned_by') required this.ownedBy})
+      : super._();
+  factory _Model.fromJson(Map<String, dynamic> json) => _$ModelFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String object;
+  @override
+  @JsonKey(name: 'owned_by')
+  final String ownedBy;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ModelCopyWith<_Model> get copyWith =>
+      __$ModelCopyWithImpl<_Model>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ModelToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Model &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.object, object) || other.object == object) &&
+            (identical(other.ownedBy, ownedBy) || other.ownedBy == ownedBy));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, object, ownedBy);
+
+  @override
+  String toString() {
+    return 'Model(id: $id, object: $object, ownedBy: $ownedBy)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ModelCopyWith<$Res> implements $ModelCopyWith<$Res> {
+  factory _$ModelCopyWith(_Model value, $Res Function(_Model) _then) =
+      __$ModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id, String object, @JsonKey(name: 'owned_by') String ownedBy});
+}
+
+/// @nodoc
+class __$ModelCopyWithImpl<$Res> implements _$ModelCopyWith<$Res> {
+  __$ModelCopyWithImpl(this._self, this._then);
+
+  final _Model _self;
+  final $Res Function(_Model) _then;
+
+  /// Create a copy of Model
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? object = null,
+    Object? ownedBy = null,
+  }) {
+    return _then(_Model(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      ownedBy: null == ownedBy
+          ? _self.ownedBy
+          : ownedBy // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/wavespeed_box/lib/src/freezed/model/model/model.g.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/model/model/model.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_Model _$ModelFromJson(Map<String, dynamic> json) => _Model(
+      id: json['id'] as String,
+      object: json['object'] as String,
+      ownedBy: json['owned_by'] as String,
+    );
+
+Map<String, dynamic> _$ModelToJson(_Model instance) => <String, dynamic>{
+      'id': instance.id,
+      'object': instance.object,
+      'owned_by': instance.ownedBy,
+    };

--- a/pkgs/wavespeed_box/lib/src/freezed/model/model_list/model_list.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/model/model_list/model_list.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:wavespeed_box/src/freezed/model/model/model.dart';
+
+part 'model_list.freezed.dart';
+part 'model_list.g.dart';
+
+@freezed
+abstract class ModelList with _$ModelList {
+  factory ModelList({required String object, required List<Model> data}) =
+      _ModelList;
+
+  factory ModelList.fromJson(Map<String, dynamic> json) =>
+      _$ModelListFromJson(json);
+  const ModelList._();
+}

--- a/pkgs/wavespeed_box/lib/src/freezed/model/model_list/model_list.freezed.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/model/model_list/model_list.freezed.dart
@@ -1,0 +1,336 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'model_list.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ModelList {
+  String get object;
+  List<Model> get data;
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ModelListCopyWith<ModelList> get copyWith =>
+      _$ModelListCopyWithImpl<ModelList>(this as ModelList, _$identity);
+
+  /// Serializes this ModelList to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ModelList &&
+            (identical(other.object, object) || other.object == object) &&
+            const DeepCollectionEquality().equals(other.data, data));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, object, const DeepCollectionEquality().hash(data));
+
+  @override
+  String toString() {
+    return 'ModelList(object: $object, data: $data)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ModelListCopyWith<$Res> {
+  factory $ModelListCopyWith(ModelList value, $Res Function(ModelList) _then) =
+      _$ModelListCopyWithImpl;
+  @useResult
+  $Res call({String object, List<Model> data});
+}
+
+/// @nodoc
+class _$ModelListCopyWithImpl<$Res> implements $ModelListCopyWith<$Res> {
+  _$ModelListCopyWithImpl(this._self, this._then);
+
+  final ModelList _self;
+  final $Res Function(ModelList) _then;
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? object = null,
+    Object? data = null,
+  }) {
+    return _then(_self.copyWith(
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      data: null == data
+          ? _self.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as List<Model>,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ModelList].
+extension ModelListPatterns on ModelList {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ModelList value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ModelList value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ModelList value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String object, List<Model> data)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that.object, _that.data);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String object, List<Model> data) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList():
+        return $default(_that.object, _that.data);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String object, List<Model> data)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ModelList() when $default != null:
+        return $default(_that.object, _that.data);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ModelList extends ModelList {
+  _ModelList({required this.object, required final List<Model> data})
+      : _data = data,
+        super._();
+  factory _ModelList.fromJson(Map<String, dynamic> json) =>
+      _$ModelListFromJson(json);
+
+  @override
+  final String object;
+  final List<Model> _data;
+  @override
+  List<Model> get data {
+    if (_data is EqualUnmodifiableListView) return _data;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_data);
+  }
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ModelListCopyWith<_ModelList> get copyWith =>
+      __$ModelListCopyWithImpl<_ModelList>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ModelListToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ModelList &&
+            (identical(other.object, object) || other.object == object) &&
+            const DeepCollectionEquality().equals(other._data, _data));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, object, const DeepCollectionEquality().hash(_data));
+
+  @override
+  String toString() {
+    return 'ModelList(object: $object, data: $data)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ModelListCopyWith<$Res>
+    implements $ModelListCopyWith<$Res> {
+  factory _$ModelListCopyWith(
+          _ModelList value, $Res Function(_ModelList) _then) =
+      __$ModelListCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String object, List<Model> data});
+}
+
+/// @nodoc
+class __$ModelListCopyWithImpl<$Res> implements _$ModelListCopyWith<$Res> {
+  __$ModelListCopyWithImpl(this._self, this._then);
+
+  final _ModelList _self;
+  final $Res Function(_ModelList) _then;
+
+  /// Create a copy of ModelList
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? object = null,
+    Object? data = null,
+  }) {
+    return _then(_ModelList(
+      object: null == object
+          ? _self.object
+          : object // ignore: cast_nullable_to_non_nullable
+              as String,
+      data: null == data
+          ? _self._data
+          : data // ignore: cast_nullable_to_non_nullable
+              as List<Model>,
+    ));
+  }
+}
+
+// dart format on

--- a/pkgs/wavespeed_box/lib/src/freezed/model/model_list/model_list.g.dart
+++ b/pkgs/wavespeed_box/lib/src/freezed/model/model_list/model_list.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'model_list.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ModelList _$ModelListFromJson(Map<String, dynamic> json) => _ModelList(
+      object: json['object'] as String,
+      data: (json['data'] as List<dynamic>)
+          .map((e) => Model.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$ModelListToJson(_ModelList instance) =>
+    <String, dynamic>{
+      'object': instance.object,
+      'data': instance.data,
+    };

--- a/pkgs/wavespeed_box/lib/src/openai_compat.dart
+++ b/pkgs/wavespeed_box/lib/src/openai_compat.dart
@@ -1,0 +1,338 @@
+// OpenAI 互換 Chat Completions API のリクエスト構築・レスポンス解析ヘルパー。
+//
+// 画像・音声・ファイル・ツール呼び出し・構造化出力を raw JSON として
+// 組み立てる（freezed のコード生成に依存しない）。
+//
+// このファイルは src/ 配下のパッケージ内部実装であり、公開 API には含めない。
+import 'dart:convert';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:api_http/api_http.dart';
+
+/// [LLMCompletionRequest] を OpenAI 互換のリクエストボディに変換する。
+Map<String, dynamic> buildOpenAiBody(
+  LLMCompletionRequest request, {
+  required String maxTokensKey,
+}) {
+  final body = <String, dynamic>{
+    'model': request.model,
+    'messages': _toOpenAiMessages(request.messages),
+  };
+  if (request.maxTokens != null) body[maxTokensKey] = request.maxTokens;
+  if (request.temperature != null) body['temperature'] = request.temperature;
+  if (request.topP != null) body['top_p'] = request.topP;
+  if (request.stop != null) body['stop'] = request.stop;
+  if (request.seed != null) body['seed'] = request.seed;
+  if (request.frequencyPenalty != null) {
+    body['frequency_penalty'] = request.frequencyPenalty;
+  }
+  if (request.presencePenalty != null) {
+    body['presence_penalty'] = request.presencePenalty;
+  }
+  final rf = _toOpenAiResponseFormat(request.responseFormat);
+  if (rf != null) body['response_format'] = rf;
+  final tools = request.tools;
+  if (tools != null && tools.isNotEmpty) {
+    body['tools'] = [
+      for (final t in tools)
+        {
+          'type': 'function',
+          'function': {
+            'name': t.name,
+            'description': t.description,
+            'parameters': t.parameters,
+          },
+        },
+    ];
+    final tc = _toOpenAiToolChoice(request.toolChoice);
+    if (tc != null) body['tool_choice'] = tc;
+  }
+  return body;
+}
+
+List<Map<String, dynamic>> _toOpenAiMessages(List<LLMContent> messages) {
+  final out = <Map<String, dynamic>>[];
+  for (final m in messages) {
+    final role = switch (m.role) {
+      LLMRole.model => 'assistant',
+      LLMRole.system => 'system',
+      LLMRole.user => 'user',
+    };
+
+    // ツール実行結果は role: 'tool' の独立メッセージとして送る。
+    final toolResults = m.parts.whereType<LLMToolResultPart>().toList();
+    if (toolResults.isNotEmpty) {
+      for (final tr in toolResults) {
+        out.add({
+          'role': 'tool',
+          'tool_call_id': tr.toolCallId,
+          'content': tr.content,
+        });
+      }
+      continue;
+    }
+
+    // assistant のツール呼び出しエコー。
+    final toolCalls = m.parts.whereType<LLMToolCallPart>().toList();
+    if (toolCalls.isNotEmpty) {
+      out.add({
+        'role': 'assistant',
+        if (m.text.isNotEmpty) 'content': m.text,
+        'tool_calls': [
+          for (final tc in toolCalls)
+            {
+              'id': tc.id,
+              'type': 'function',
+              'function': {
+                'name': tc.name,
+                'arguments': jsonEncode(tc.arguments),
+              },
+            },
+        ],
+      });
+      continue;
+    }
+
+    final hasMedia = m.parts.any(
+      (p) => p is LLMImagePart || p is LLMAudioPart || p is LLMFilePart,
+    );
+    if (!hasMedia) {
+      out.add({'role': role, 'content': m.text});
+      continue;
+    }
+
+    out.add({'role': role, 'content': _toOpenAiContentArray(m.parts)});
+  }
+  return out;
+}
+
+List<Map<String, dynamic>> _toOpenAiContentArray(List<LLMContentPart> parts) {
+  final arr = <Map<String, dynamic>>[];
+  for (final p in parts) {
+    if (p is LLMTextPart) {
+      arr.add({'type': 'text', 'text': p.text});
+    } else if (p is LLMImagePart) {
+      arr.add({
+        'type': 'image_url',
+        'image_url': {'url': p.asUrlOrDataUri},
+      });
+    } else if (p is LLMAudioPart) {
+      arr.add({
+        'type': 'input_audio',
+        'input_audio': {
+          'data': p.base64Data ?? '',
+          'format': _audioFormat(p.mimeType),
+        },
+      });
+    } else if (p is LLMFilePart) {
+      arr.add({
+        'type': 'file',
+        'file': {
+          if (p.filename != null) 'filename': p.filename,
+          'file_data': _fileDataField(p),
+        },
+      });
+    }
+  }
+  return arr;
+}
+
+String _fileDataField(LLMFilePart f) {
+  if (f.hasBytes) {
+    final mime = f.mimeType ?? 'application/octet-stream';
+    return 'data:$mime;base64,${f.base64Data}';
+  }
+  return f.url ?? '';
+}
+
+String _audioFormat(String? mimeType) {
+  if (mimeType == null) return 'wav';
+  if (mimeType.contains('mp3') || mimeType.contains('mpeg')) return 'mp3';
+  if (mimeType.contains('wav')) return 'wav';
+  return mimeType.split('/').last;
+}
+
+Map<String, dynamic>? _toOpenAiResponseFormat(LLMResponseFormat? f) {
+  if (f == null) return null;
+  switch (f.type) {
+    case LLMResponseFormatType.text:
+      return {'type': 'text'};
+    case LLMResponseFormatType.jsonObject:
+      return {'type': 'json_object'};
+    case LLMResponseFormatType.jsonSchema:
+      return {
+        'type': 'json_schema',
+        'json_schema': {
+          'name': f.schemaName,
+          'schema': f.schema,
+          'strict': f.strict,
+        },
+      };
+  }
+}
+
+dynamic _toOpenAiToolChoice(LLMToolChoice? tc) {
+  if (tc == null) return null;
+  final toolName = tc.toolName;
+  if (toolName != null) {
+    return {
+      'type': 'function',
+      'function': {'name': toolName},
+    };
+  }
+  switch (tc.mode) {
+    case LLMToolChoiceMode.auto:
+      return 'auto';
+    case LLMToolChoiceMode.none:
+      return 'none';
+    case LLMToolChoiceMode.any:
+      return 'required';
+  }
+}
+
+/// OpenAI 互換のレスポンスボディを [LLMCompletionResponse] に変換する。
+LLMCompletionResponse parseOpenAiResponse(Map<String, dynamic> data) {
+  final choices = (data['choices'] as List?) ?? const [];
+  final choice = choices.isNotEmpty
+      ? choices.first as Map<String, dynamic>
+      : const <String, dynamic>{};
+  final message =
+      (choice['message'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  final parts = <LLMContentPart>[];
+
+  final reasoning = message['reasoning_content'];
+  if (reasoning is String && reasoning.isNotEmpty) {
+    parts.add(LLMReasoningPart(reasoning));
+  }
+
+  final rawContent = message['content'];
+  if (rawContent is String && rawContent.isNotEmpty) {
+    parts.add(LLMTextPart(rawContent));
+  } else if (rawContent is List) {
+    _appendOpenAiContentParts(rawContent, parts);
+  }
+
+  final toolCalls = message['tool_calls'];
+  if (toolCalls is List) {
+    for (final tc in toolCalls) {
+      if (tc is Map<String, dynamic>) {
+        final fn = tc['function'];
+        final fnMap =
+            fn is Map<String, dynamic> ? fn : const <String, dynamic>{};
+        parts.add(
+          LLMToolCallPart(
+            id: (tc['id'] ?? '').toString(),
+            name: (fnMap['name'] ?? '').toString(),
+            arguments: _decodeArgs(fnMap['arguments']),
+          ),
+        );
+      }
+    }
+  }
+
+  final audio = message['audio'];
+  if (audio is Map<String, dynamic>) {
+    final adata = audio['data'];
+    if (adata is String && adata.isNotEmpty) {
+      parts.add(
+        LLMAudioPart.base64(adata, transcript: audio['transcript'] as String?),
+      );
+    }
+  }
+
+  final usage =
+      (data['usage'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+  return LLMCompletionResponse(
+    content: LLMContent(role: LLMRole.model, parts: parts),
+    usage: _parseOpenAiUsage(usage),
+    finishReason: LLMFinishReason.parse(choice['finish_reason'] as String?),
+    model: data['model'] as String?,
+    id: data['id'] as String?,
+  );
+}
+
+void _appendOpenAiContentParts(List<dynamic> items, List<LLMContentPart> out) {
+  for (final item in items) {
+    if (item is! Map<String, dynamic>) continue;
+    final type = item['type'];
+    if (type == 'text' && item['text'] is String) {
+      out.add(LLMTextPart(item['text'] as String));
+    } else if (type == 'image_url') {
+      final url = (item['image_url'] as Map<String, dynamic>?)?['url'];
+      if (url is String) out.add(LLMImagePart.dataUri(url));
+    }
+  }
+}
+
+Map<String, dynamic> _decodeArgs(Object? argsRaw) {
+  if (argsRaw is Map<String, dynamic>) return argsRaw;
+  if (argsRaw is String && argsRaw.isNotEmpty) {
+    try {
+      final decoded = jsonDecode(argsRaw);
+      if (decoded is Map<String, dynamic>) return decoded;
+    } on FormatException {
+      return <String, dynamic>{};
+    }
+  }
+  return <String, dynamic>{};
+}
+
+LLMUsage _parseOpenAiUsage(Map<String, dynamic> usage) {
+  final promptDetails = usage['prompt_tokens_details'] as Map<String, dynamic>?;
+  final completionDetails =
+      usage['completion_tokens_details'] as Map<String, dynamic>?;
+  return LLMUsage(
+    inputTokens: (usage['prompt_tokens'] as num?)?.toInt() ?? 0,
+    outputTokens: (usage['completion_tokens'] as num?)?.toInt() ?? 0,
+    cachedInputTokens: (promptDetails?['cached_tokens'] as num?)?.toInt(),
+    reasoningTokens: (completionDetails?['reasoning_tokens'] as num?)?.toInt(),
+  );
+}
+
+/// OpenAI 互換 API に POST し、JSON ボディを返す。失敗時は [LLMException]。
+Future<Map<String, dynamic>> postOpenAiJson({
+  required String url,
+  required String apiKey,
+  required String provider,
+  required Map<String, dynamic> body,
+}) async {
+  try {
+    final response = await Api.post(
+      requestAcc: PostRequestAcc(
+        url: url,
+        headers: RestHeaders({
+          'Authorization': 'Bearer $apiKey',
+          'Content-Type': 'application/json',
+        }),
+        body: JsonRequestBody(body),
+      ),
+    );
+    final statusCode = int.tryParse(response.statusCode) ?? 0;
+    final respBody = response.body;
+    Map<String, dynamic>? mapData;
+    if (respBody is MapJsonResponseBody) {
+      mapData = respBody.data;
+    }
+    if (statusCode < 200 || statusCode >= 300) {
+      throw LLMException.fromHttp(
+        statusCode,
+        provider: provider,
+        body: mapData ?? respBody,
+      );
+    }
+    if (mapData != null) return mapData;
+    throw LLMUnknownException(
+      'Unexpected response body from $provider',
+      provider: provider,
+      raw: respBody,
+    );
+  } on LLMException {
+    rethrow;
+  } catch (e) {
+    throw LLMNetworkException(
+      'Network request failed',
+      provider: provider,
+      raw: e,
+    );
+  }
+}

--- a/pkgs/wavespeed_box/lib/src/wavespeed.dart
+++ b/pkgs/wavespeed_box/lib/src/wavespeed.dart
@@ -1,0 +1,40 @@
+import 'package:ai_box/ai_box.dart';
+import 'package:wavespeed_box/src/openai_compat.dart';
+import 'package:wavespeed_box/wavespeed_box.dart';
+
+class WaveSpeed extends LLMAIBase {
+  WaveSpeed({required super.apiKey});
+
+  static const _url = 'https://llm.wavespeed.ai/v1/chat/completions';
+  static const _provider = 'wavespeed';
+
+  @override
+  Future<LLMCompletionResponse> completions(
+    LLMCompletionRequest request,
+  ) async {
+    final body = buildOpenAiBody(request, maxTokensKey: 'max_tokens');
+    final data = await postOpenAiJson(
+      url: _url,
+      apiKey: apiKey,
+      provider: _provider,
+      body: body,
+    );
+    return parseOpenAiResponse(data);
+  }
+
+  @override
+  Future<List<AIModel>> getModels() async {
+    final modelList = await WaveSpeedCore.listModels(apiKey: apiKey);
+    return modelList.data.map((e) => AIModel(id: e.id)).toList();
+  }
+
+  @override
+  Future<bool> validateKey() async {
+    try {
+      await WaveSpeedCore.listModels(apiKey: apiKey);
+      return true;
+    } on Exception catch (_) {
+      return false;
+    }
+  }
+}

--- a/pkgs/wavespeed_box/lib/wavespeed_box.dart
+++ b/pkgs/wavespeed_box/lib/wavespeed_box.dart
@@ -1,0 +1,10 @@
+export 'package:wavespeed_box/src/core/wavespeed_core.dart';
+export 'package:wavespeed_box/src/freezed/chat_completion/request/chat_completion_message/chat_completion_message.dart';
+export 'package:wavespeed_box/src/freezed/chat_completion/request/chat_completion_request/chat_completion_request.dart';
+export 'package:wavespeed_box/src/freezed/chat_completion/response/chat_completion_response/chat_completion_response.dart';
+export 'package:wavespeed_box/src/freezed/chat_completion/response/chat_completion_response_choice/chat_completion_response_choice.dart';
+export 'package:wavespeed_box/src/freezed/chat_completion/response/chat_completion_response_message/chat_completion_response_message.dart';
+export 'package:wavespeed_box/src/freezed/chat_completion/response/chat_completion_response_usage/chat_completion_response_usage.dart';
+export 'package:wavespeed_box/src/freezed/model/model/model.dart';
+export 'package:wavespeed_box/src/freezed/model/model_list/model_list.dart';
+export 'package:wavespeed_box/src/wavespeed.dart';

--- a/pkgs/wavespeed_box/pubspec.yaml
+++ b/pkgs/wavespeed_box/pubspec.yaml
@@ -1,0 +1,24 @@
+---
+dependencies:
+  ai_box: ^0.0.1
+  api_http: ^0.0.1
+  freezed_annotation: ^3.0.0
+  json_annotation: ^4.9.0
+description: '''A WaveSpeedAI provider based on ai_box. '''
+dev_dependencies:
+  auto_exporter: any
+  build_runner: ^2.5.4
+  freezed: ^3.0.6
+  json_serializable: ^6.9.5
+  test: ^1.26.0
+  very_good_analysis: any
+environment:
+  sdk: ^3.2.0
+homepage: https://github.com/normidar/ai_box
+name: wavespeed_box
+topics:
+  - ai
+  - wavespeed
+  - ai-box
+  - llm
+version: 0.0.1

--- a/pkgs/wavespeed_box/pubspec_overrides.yaml
+++ b/pkgs/wavespeed_box/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: ai_box
+dependency_overrides:
+  ai_box:
+    path: ../ai_box

--- a/pkgs/wavespeed_box/test/wavespeed_box_test.dart
+++ b/pkgs/wavespeed_box/test/wavespeed_box_test.dart
@@ -1,0 +1,194 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:test/test.dart';
+import 'package:wavespeed_box/src/openai_compat.dart';
+import 'package:wavespeed_box/wavespeed_box.dart';
+
+void main() {
+  group('WaveSpeed client', () {
+    test('exposes apiKey and is an LLMAIBase', () {
+      final ai = WaveSpeed(apiKey: 'test-key');
+      expect(ai.apiKey, 'test-key');
+      expect(ai, isA<LLMAIBase>());
+    });
+  });
+
+  group('ChatCompletion freezed models', () {
+    test('request serializes to OpenAI-shaped JSON', () {
+      final req = ChatCompletionRequest(
+        model: 'gpt-4o-mini',
+        messages: [
+          ChatCompletionMessage(role: ChatCompletionRole.user, content: 'hi'),
+        ],
+        maxTokens: 16,
+      );
+      // toJson() keeps nested objects; the wire payload is produced when the
+      // map is encoded (as JsonRequestBody does), so round-trip through JSON.
+      final json = jsonDecode(jsonEncode(req.toJson())) as Map<String, dynamic>;
+      expect(json['model'], 'gpt-4o-mini');
+      expect(json['max_tokens'], 16);
+      final msg = (json['messages'] as List).first as Map<String, dynamic>;
+      expect(msg['role'], 'user');
+      expect(msg['content'], 'hi');
+    });
+
+    test('response parses choices + usage', () {
+      final res = ChatCompletionResponse.fromJson({
+        'id': 'x',
+        'object': 'chat.completion',
+        'created': 1,
+        'model': 'gpt-4o-mini',
+        'choices': [
+          {
+            'index': 0,
+            'finish_reason': 'stop',
+            'message': {'role': 'assistant', 'content': 'hello'},
+          },
+        ],
+        'usage': {
+          'prompt_tokens': 3,
+          'completion_tokens': 5,
+          'total_tokens': 8,
+        },
+      });
+      expect(res.choices.single.message.content, 'hello');
+      expect(res.choices.single.finishReason, 'stop');
+      expect(res.usage?.totalTokens, 8);
+    });
+
+    test('ModelList parses model entries', () {
+      final list = ModelList.fromJson({
+        'object': 'list',
+        'data': [
+          {'id': 'gpt-4o', 'object': 'model', 'owned_by': 'm'},
+        ],
+      });
+      expect(list.data.single.id, 'gpt-4o');
+    });
+  });
+
+  group('buildOpenAiBody', () {
+    test('text message maps to role + content with sampling params', () {
+      final body = buildOpenAiBody(
+        LLMCompletionRequest(
+          model: 'm',
+          messages: [LLMContent.user('hi')],
+          maxTokens: 10,
+          temperature: 0.5,
+        ),
+        maxTokensKey: 'max_tokens',
+      );
+      expect(body['model'], 'm');
+      expect(body['max_tokens'], 10);
+      expect(body['temperature'], 0.5);
+      final msg = (body['messages'] as List).single as Map<String, dynamic>;
+      expect(msg['role'], 'user');
+      expect(msg['content'], 'hi');
+    });
+
+    test('image attachment becomes a content array with image_url', () {
+      final bytes = Uint8List.fromList(utf8.encode('img'));
+      final body = buildOpenAiBody(
+        LLMCompletionRequest(
+          model: 'm',
+          messages: [
+            LLMContent.user('see', attachments: [LLMImagePart.bytes(bytes)]),
+          ],
+        ),
+        maxTokensKey: 'max_tokens',
+      );
+      final msg = (body['messages'] as List).single as Map<String, dynamic>;
+      final content = msg['content'] as List;
+      expect((content[0] as Map<String, dynamic>)['type'], 'text');
+      expect((content[1] as Map<String, dynamic>)['type'], 'image_url');
+    });
+
+    test('tools are mapped to function definitions', () {
+      final body = buildOpenAiBody(
+        LLMCompletionRequest(
+          model: 'm',
+          messages: [LLMContent.user('x')],
+          tools: const [
+            LLMTool(
+              name: 'get_weather',
+              description: 'weather',
+              parameters: {'type': 'object'},
+            ),
+          ],
+          toolChoice: LLMToolChoice.auto,
+        ),
+        maxTokensKey: 'max_tokens',
+      );
+      final tool = (body['tools'] as List).single as Map<String, dynamic>;
+      expect(tool['type'], 'function');
+      expect((tool['function'] as Map<String, dynamic>)['name'], 'get_weather');
+      expect(body['tool_choice'], 'auto');
+    });
+  });
+
+  group('parseOpenAiResponse', () {
+    test('text, usage, finish reason, model and id', () {
+      final res = parseOpenAiResponse({
+        'id': 'r',
+        'model': 'm',
+        'choices': [
+          {
+            'finish_reason': 'stop',
+            'message': {'role': 'assistant', 'content': 'hello'},
+          },
+        ],
+        'usage': {'prompt_tokens': 2, 'completion_tokens': 3},
+      });
+      expect(res.text, 'hello');
+      expect(res.finishReason, LLMFinishReason.stop);
+      expect(res.usage.inputTokens, 2);
+      expect(res.usage.outputTokens, 3);
+      expect(res.model, 'm');
+      expect(res.id, 'r');
+    });
+
+    test('tool calls are parsed into LLMToolCallPart', () {
+      final res = parseOpenAiResponse({
+        'choices': [
+          {
+            'finish_reason': 'tool_calls',
+            'message': {
+              'role': 'assistant',
+              'content': null,
+              'tool_calls': [
+                {
+                  'id': 'c1',
+                  'type': 'function',
+                  'function': {'name': 'f', 'arguments': '{"a":1}'},
+                },
+              ],
+            },
+          },
+        ],
+      });
+      final call = res.content.parts.whereType<LLMToolCallPart>().single;
+      expect(call.id, 'c1');
+      expect(call.name, 'f');
+      expect(call.arguments, {'a': 1});
+      expect(res.finishReason, LLMFinishReason.toolCalls);
+    });
+
+    test('reasoning_content becomes an LLMReasoningPart', () {
+      final res = parseOpenAiResponse({
+        'choices': [
+          {
+            'message': {
+              'role': 'assistant',
+              'reasoning_content': 'think',
+              'content': 'ans',
+            },
+          },
+        ],
+      });
+      expect(res.content.reasoning, 'think');
+      expect(res.text, 'ans');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds four new AI provider packages, built on `ai_box`'s `LLMAIBase` and mirroring the existing `deepseek_box` / `minimax_box` structure (core client, `openai_compat` request/response helpers, and freezed request/response models).

| Package | Endpoint | Notes |
| --- | --- | --- |
| `mistral_box` | `https://api.mistral.ai/v1` | OpenAI-compatible chat + `/models` |
| `qwen_box` | `https://dashscope-intl.aliyuncs.com/compatible-mode/v1` | Alibaba Cloud Model Studio (DashScope) compatible mode |
| `wavespeed_box` | `https://llm.wavespeed.ai/v1` | WaveSpeed OpenAI-compatible LLM endpoint |
| `perplexity_box` | `https://api.perplexity.ai` | Perplexity Sonar models |

Each package exposes `<Provider>` (e.g. `Mistral`, `Qwen`, `WaveSpeed`, `Perplexity`) extending `LLMAIBase`, plus a `<Provider>Core` low-level client, following the same conventions as the other `*_box` packages. `melos.yaml` already globs `pkgs/**`, so no manifest change is needed.

## Provider-specific handling

- **Perplexity** does not expose a `/models` listing endpoint, so `getModels()` returns the documented Sonar model family (`sonar`, `sonar-pro`, `sonar-reasoning`, `sonar-reasoning-pro`, `sonar-deep-research`) and `validateKey()` probes with a minimal completion, treating `401/403` (`LLMAuthException`) as an invalid key and other failures as "key valid".

## Verification

Ran the same checks as CI against each new package with the Dart SDK:

- `dart pub get` — resolves
- `dart analyze` — **No issues found!**
- `dart format --set-exit-if-changed` — **0 changed** (format clean)
- Runtime smoke test of `Perplexity.getModels()` / `getModelIds()` — returns the 5 Sonar models

The freezed `*.freezed.dart` / `*.g.dart` files are byte-identical to the `deepseek_box` template (only `part of` relative references), so they remain consistent with what `build_runner` would generate.

## Notes

- API call paths (`completions`, live `getModels`/`validateKey` for Mistral/Qwen/WaveSpeed) require real API keys and were not exercised against the live services.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JAgdMXgUbbx6523dkrsMiG)_