### PR TITLE
feat: 全プロバイダーに真の SSE ストリーミングを実装

### DIFF
--- a/pkgs/ai_box/CHANGELOG.md
+++ b/pkgs/ai_box/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.3.0
+
+- Add true SSE streaming support:
+  - `package:ai_box/provider_http.dart`: `postSseData()` (streaming POST
+    with the same `LLMException` error normalization as `requestJson()`)
+    and `decodeSseJson()`.
+  - `package:ai_box/openai_compat.dart`: `streamOpenAiCompletions()` /
+    `openAiChunksFromEvents()` — incremental text / reasoning deltas and
+    cross-chunk tool-call assembly for OpenAI-compatible providers.
+- Add `LLMStreamChunk.reasoningDelta` for incremental thinking output.
+  The final chunk now carries the complete parts of the response.
+- Add `LLMAIBase.chatStream()`, the streaming counterpart of `chat()`.
+- Add `http` as a dependency.
+
 ## 0.2.0
 
 - Add `package:ai_box/openai_compat.dart`: the OpenAI-compatible request

--- a/pkgs/ai_box/README.md
+++ b/pkgs/ai_box/README.md
@@ -14,12 +14,13 @@ An abstract class that all AI providers (such as ChatGPT, Claude, Gemini, etc.) 
 
 ### Required Methods
 
-- `chat()`: Chat functionality
-- `getModelIds()`: Get a list of available model IDs
+- `completions()`: Chat completion
+- `getModels()`: Get a list of available models
 - `validateKey()`: Validate the API key
 
 ### Provided Utility Methods
 
+- `chat()` / `chatStream()`: Chat with structured messages
 - `chatWithStrings()`: Chat with an array of strings
 - `generateText()`: Simple text generation
 - `generateTextStream()`: Stream text output
@@ -162,89 +163,39 @@ final res = await ai.chat(
 
 ## Streaming
 
+Every provider implements true token-by-token SSE streaming:
+
 ```dart
 await for (final text in ai.generateTextStream(model: '...', message: 'Hi')) {
   stdout.write(text);
 }
 ```
 
-> Note: the base `completionsStream()` currently emits the full response as a
-> single chunk (a non-incremental fallback). Providers can override it with
-> true token-by-token SSE streaming.
-
-## Common Tests
-
-By using the `runLLMAIBaseCommonTests()` function, you can ensure that all `LLMAIBase` implementation classes are tested to the same standard.
-
-### Usage Example
+For full control (reasoning deltas, tool calls, usage), use `chatStream()` /
+`completionsStream()`:
 
 ```dart
-import 'package:test/test.dart';
-import 'package:your_ai_package/your_ai_package.dart';
-
-// Import the test utilities from ai_box
-import '../ai_box/test/test_utils.dart';
-
-void main() {
-  // Run the common tests
-  runLLMAIBaseCommonTests(
-    createInstance: () => YourAIClass(apiKey: 'your-api-key'),
-    instanceName: 'YourAI',
-    testModel: 'your-model-name',
-    skipApiTests: false, // Set to false to perform actual API calls
-  );
-
-  // Add any additional specific tests here
-  group('YourAI Specific Tests', () {
-    // ...
-  });
+await for (final chunk in ai.chatStream(
+  model: '...',
+  messages: [LLMContent.user('Hi')],
+)) {
+  stdout.write(chunk.delta);          // incremental text
+  logThinking(chunk.reasoningDelta);  // incremental thinking (if any)
+  if (chunk.isDone) {
+    // The final chunk carries the complete parts, finish reason and usage.
+    print(chunk.finishReason);
+    print(chunk.usage);
+  }
 }
 ```
-
-### Parameters
-
-- `createInstance`: A function that creates an instance of the LLMAIBase to be tested.
-- `instanceName`: The name of the class being tested (for display purposes in tests).
-- `testModel`: The name of the model to be used for testing.
-- `skipApiTests`: Whether to skip tests that involve API calls (default: false).
-
-### Test Contents
-
-The common tests include the following:
-
-#### Basic Tests
-
-- The instance is created correctly.
-- The API key is set.
-
-#### API Functionality Tests (if skipApiTests=false)
-
-- The API key can be validated.
-- Available model IDs can be retrieved.
-- The chat functionality works.
-- The chat functionality with strings works.
-- The text generation functionality works.
-- The `maxTokens` parameter is applied.
-
-#### Class Tests
-
-- `LLMContent` is created correctly.
-- The values of `LLMRole` are correct.
-
-#### Error Handling Tests
-
-- An error occurs with an empty message list.
-- An error occurs with an invalid model name.
 
 ## Adding a New AI Provider
 
 1. Create a class that inherits from `LLMAIBase`.
-2. Implement the required methods.
-3. Import `../ai_box/test/test_utils.dart` in the test file.
-4. Call `runLLMAIBaseCommonTests()`.
-5. Add specific tests as needed.
-
-This ensures that all AI providers maintain consistent quality.
+2. Implement `completions()`, `getModels()` and `validateKey()`.
+3. Optionally override `completionsStream()` with the provider's SSE
+   streaming (the shared helpers below already cover OpenAI-compatible
+   APIs).
 
 ### Shared helpers for provider implementations
 
@@ -254,14 +205,10 @@ Two opt-in libraries keep provider packages free of copy-pasted plumbing
 - `package:ai_box/provider_http.dart` — `requestJson()` runs an HTTP call and
   normalizes failures into the sealed `LLMException` hierarchy
   (`LLMNetworkException` on connectivity errors, `LLMException.fromHttp` on
-  non-2xx responses).
+  non-2xx responses). `postSseData()` / `decodeSseJson()` do the same for
+  SSE streaming endpoints.
 - `package:ai_box/openai_compat.dart` — `buildOpenAiBody()` /
-  `parseOpenAiResponse()` / `postOpenAiJson()` implement the OpenAI-compatible
-  Chat Completions wire format (multimodal content, tools, structured output),
-  shared by chatgpt_box, deepseek_box, grok_box, minimax_box and
-  openrouter_box.
-
-### Notes
-
-- The test utilities are located in the `test` folder and are not included in the main `lib` folder.
-- This prevents the `test` package dependency from being included in the production code.
+  `parseOpenAiResponse()` / `postOpenAiJson()` / `streamOpenAiCompletions()`
+  implement the OpenAI-compatible Chat Completions wire format (multimodal
+  content, tools, structured output, SSE streaming), shared by chatgpt_box,
+  deepseek_box, grok_box, minimax_box and openrouter_box.

--- a/pkgs/ai_box/lib/openai_compat.dart
+++ b/pkgs/ai_box/lib/openai_compat.dart
@@ -155,7 +155,8 @@ String _audioFormat(String? mimeType) {
   if (mimeType == null) return 'wav';
   if (mimeType.contains('mp3') || mimeType.contains('mpeg')) return 'mp3';
   if (mimeType.contains('wav')) return 'wav';
-  return mimeType.split('/').last;
+  // `audio/ogg;codecs=opus` のようなパラメータ付き MIME にも対応する。
+  return mimeType.split(';').first.split('/').last.trim();
 }
 
 Map<String, dynamic>? _toOpenAiResponseFormat(LLMResponseFormat? f) {
@@ -220,16 +221,7 @@ LLMCompletionResponse parseOpenAiResponse(Map<String, dynamic> data) {
 
   // 生成画像（OpenRouter は message.images で返す）。
   final images = message['images'];
-  if (images is List) {
-    for (final im in images) {
-      if (im is! Map<String, dynamic>) continue;
-      final imageUrl = im['image_url'];
-      final url = imageUrl is Map<String, dynamic> ? imageUrl['url'] : null;
-      if (url is String && url.isNotEmpty) {
-        parts.add(LLMImagePart.dataUri(url));
-      }
-    }
-  }
+  if (images is List) _appendOpenAiImages(images, parts);
 
   final toolCalls = message['tool_calls'];
   if (toolCalls is List) {
@@ -268,6 +260,17 @@ LLMCompletionResponse parseOpenAiResponse(Map<String, dynamic> data) {
     model: data['model'] as String?,
     id: data['id'] as String?,
   );
+}
+
+void _appendOpenAiImages(List<dynamic> images, List<LLMContentPart> out) {
+  for (final im in images) {
+    if (im is! Map<String, dynamic>) continue;
+    final imageUrl = im['image_url'];
+    final url = imageUrl is Map<String, dynamic> ? imageUrl['url'] : null;
+    if (url is String && url.isNotEmpty) {
+      out.add(LLMImagePart.dataUri(url));
+    }
+  }
 }
 
 void _appendOpenAiContentParts(List<dynamic> items, List<LLMContentPart> out) {
@@ -332,5 +335,158 @@ Future<Map<String, dynamic>> postOpenAiJson({
         body: JsonRequestBody(body),
       ),
     ),
+  );
+}
+
+/// OpenAI 互換 API へ `stream: true` で POST し、[LLMStreamChunk] を流す。
+///
+/// テキストは届いた増分ごとに `delta`、推論テキスト
+/// （DeepSeek の `reasoning_content` / OpenRouter の `reasoning`）は
+/// `reasoningDelta` として流れる。ツール呼び出しはチャンクをまたいで
+/// 組み立てられ、最終チャンクの `parts` に完全な応答として入る。
+///
+/// [includeUsage] を有効にすると `stream_options.include_usage` を送り、
+/// 最終チャンクでトークン使用量を受け取る（対応プロバイダーのみ）。
+Stream<LLMStreamChunk> streamOpenAiCompletions({
+  required String url,
+  required String apiKey,
+  required String provider,
+  required LLMCompletionRequest request,
+  required String maxTokensKey,
+  bool includeUsage = false,
+  Map<String, String> extraHeaders = const {},
+}) {
+  final body = buildOpenAiBody(request, maxTokensKey: maxTokensKey);
+  body['stream'] = true;
+  if (includeUsage) {
+    body['stream_options'] = {'include_usage': true};
+  }
+  final data = postSseData(
+    url: url,
+    provider: provider,
+    headers: {'Authorization': 'Bearer $apiKey', ...extraHeaders},
+    body: body,
+  );
+  return openAiChunksFromEvents(decodeSseJson(data), provider: provider);
+}
+
+/// OpenAI 互換のストリーミングイベント（`chat.completion.chunk`）列を
+/// [LLMStreamChunk] 列へ変換する。
+///
+/// ストリーム中の `error` イベントは [LLMException] に正規化して投げる。
+Stream<LLMStreamChunk> openAiChunksFromEvents(
+  Stream<Map<String, dynamic>> events, {
+  String? provider,
+}) async* {
+  final text = StringBuffer();
+  final reasoning = StringBuffer();
+  final toolCalls = <int, _StreamToolCall>{};
+  final images = <LLMContentPart>[];
+  LLMFinishReason? finishReason;
+  LLMUsage? usage;
+
+  await for (final event in events) {
+    final error = event['error'];
+    if (error is Map<String, dynamic>) {
+      throw _streamErrorToException(error, provider: provider, raw: event);
+    }
+    final rawUsage = event['usage'];
+    if (rawUsage is Map<String, dynamic>) {
+      usage = _parseOpenAiUsage(rawUsage);
+    }
+    final choices = event['choices'];
+    if (choices is! List || choices.isEmpty) continue;
+    final choice = choices.first;
+    if (choice is! Map<String, dynamic>) continue;
+
+    final rawFinish = choice['finish_reason'];
+    if (rawFinish is String && rawFinish.isNotEmpty) {
+      finishReason = LLMFinishReason.parse(rawFinish);
+    }
+    final delta = choice['delta'];
+    if (delta is! Map<String, dynamic>) continue;
+
+    final reasoningDelta = delta['reasoning_content'] ?? delta['reasoning'];
+    if (reasoningDelta is String && reasoningDelta.isNotEmpty) {
+      reasoning.write(reasoningDelta);
+      yield LLMStreamChunk(reasoningDelta: reasoningDelta);
+    }
+    final contentDelta = delta['content'];
+    if (contentDelta is String && contentDelta.isNotEmpty) {
+      text.write(contentDelta);
+      yield LLMStreamChunk(delta: contentDelta);
+    }
+    final imageDeltas = delta['images'];
+    if (imageDeltas is List) _appendOpenAiImages(imageDeltas, images);
+    final toolCallDeltas = delta['tool_calls'];
+    if (toolCallDeltas is List) {
+      _mergeToolCallDeltas(toolCallDeltas, toolCalls);
+    }
+  }
+
+  yield LLMStreamChunk(
+    parts: [
+      if (reasoning.isNotEmpty) LLMReasoningPart(reasoning.toString()),
+      if (text.isNotEmpty) LLMTextPart(text.toString()),
+      ...images,
+      for (final index in toolCalls.keys.toList()..sort())
+        toolCalls[index]!.toPart(),
+    ],
+    finishReason: finishReason ?? LLMFinishReason.other,
+    usage: usage,
+  );
+}
+
+/// チャンクをまたいで組み立て中のツール呼び出し。
+class _StreamToolCall {
+  String id = '';
+  String name = '';
+  final StringBuffer arguments = StringBuffer();
+
+  LLMToolCallPart toPart() => LLMToolCallPart(
+        id: id,
+        name: name,
+        arguments: _decodeArgs(arguments.toString()),
+      );
+}
+
+void _mergeToolCallDeltas(
+  List<dynamic> deltas,
+  Map<int, _StreamToolCall> toolCalls,
+) {
+  for (var i = 0; i < deltas.length; i++) {
+    final tc = deltas[i];
+    if (tc is! Map<String, dynamic>) continue;
+    final index = (tc['index'] as num?)?.toInt() ?? i;
+    final acc = toolCalls.putIfAbsent(index, _StreamToolCall.new);
+    final id = tc['id'];
+    if (id is String && id.isNotEmpty) acc.id = id;
+    final fn = tc['function'];
+    if (fn is Map<String, dynamic>) {
+      final name = fn['name'];
+      // name は最初のチャンクに完全な形で 1 度だけ届く。
+      if (name is String && name.isNotEmpty && acc.name.isEmpty) {
+        acc.name = name;
+      }
+      final args = fn['arguments'];
+      if (args is String) acc.arguments.write(args);
+    }
+  }
+}
+
+LLMException _streamErrorToException(
+  Map<String, dynamic> error, {
+  String? provider,
+  Object? raw,
+}) {
+  final code = error['code'];
+  if (code is num) {
+    return LLMException.fromHttp(code.toInt(), provider: provider, body: raw);
+  }
+  return LLMUnknownException(
+    (error['message'] ?? 'Stream error').toString(),
+    provider: provider,
+    code: (error['type'] ?? error['code'])?.toString(),
+    raw: raw,
   );
 }

--- a/pkgs/ai_box/lib/provider_http.dart
+++ b/pkgs/ai_box/lib/provider_http.dart
@@ -5,8 +5,11 @@
 /// （chatgpt_box / claude_box など）の内部実装向け。
 library;
 
+import 'dart:convert';
+
 import 'package:ai_box/ai_box.dart';
 import 'package:api_http/api_http.dart';
+import 'package:http/http.dart' as http;
 
 /// HTTP リクエストを実行し、JSON マップを取り出す。
 ///
@@ -42,4 +45,124 @@ Future<Map<String, dynamic>> requestJson({
     provider: provider,
     raw: body,
   );
+}
+
+/// JSON ボディを POST し、SSE（Server-Sent Events）の `data` ペイロードを
+/// イベント単位で流す。
+///
+/// SSE の仕様に従い、複数行の `data:` は改行で連結し、空行でイベントを
+/// 区切る。コメント行（`:` 始まり）や `event:` / `id:` などのフィールドは
+/// 無視する（各プロバイダーの data JSON はイベント種別を自身に含むため）。
+///
+/// エラーは [requestJson] と同じ階層に正規化する:
+/// 通信失敗・切断は [LLMNetworkException]、非 2xx は [LLMException.fromHttp]。
+Stream<String> postSseData({
+  required String url,
+  required String provider,
+  required Map<String, String> headers,
+  required Map<String, dynamic> body,
+  Map<String, String>? queryParameters,
+}) async* {
+  var uri = Uri.parse(url);
+  if (queryParameters != null && queryParameters.isNotEmpty) {
+    uri = uri.replace(
+      queryParameters: {...uri.queryParameters, ...queryParameters},
+    );
+  }
+  final request = http.Request('POST', uri)
+    ..headers.addAll({
+      'Content-Type': 'application/json',
+      'Accept': 'text/event-stream',
+      ...headers,
+    })
+    ..body = jsonEncode(body);
+
+  final client = http.Client();
+  try {
+    http.StreamedResponse response;
+    try {
+      response = await client.send(request);
+    } catch (e) {
+      throw LLMNetworkException(
+        'Network request failed',
+        provider: provider,
+        raw: e,
+      );
+    }
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw LLMException.fromHttp(
+        response.statusCode,
+        provider: provider,
+        body: await _readErrorBody(response),
+      );
+    }
+    final lines =
+        response.stream.transform(utf8.decoder).transform(const LineSplitter());
+    final dataBuffer = StringBuffer();
+    var hasData = false;
+    try {
+      await for (final line in lines) {
+        if (line.isEmpty) {
+          // 空行 = イベントの区切り。
+          if (hasData) {
+            yield dataBuffer.toString();
+            dataBuffer.clear();
+            hasData = false;
+          }
+          continue;
+        }
+        if (line.startsWith(':')) continue; // コメント行。
+        if (line.startsWith('data:')) {
+          var value = line.substring(5);
+          if (value.startsWith(' ')) value = value.substring(1);
+          if (hasData) dataBuffer.write('\n');
+          dataBuffer.write(value);
+          hasData = true;
+        }
+      }
+    } on LLMException {
+      rethrow;
+    } catch (e) {
+      throw LLMNetworkException(
+        'Connection lost during streaming',
+        provider: provider,
+        raw: e,
+      );
+    }
+    if (hasData) yield dataBuffer.toString();
+  } finally {
+    client.close();
+  }
+}
+
+/// SSE の `data` ペイロード列を JSON マップ列にデコードする。
+///
+/// `[DONE]`（OpenAI 互換 API の終端マーカー）・JSON でないもの・
+/// マップでないものは読み飛ばす。
+Stream<Map<String, dynamic>> decodeSseJson(Stream<String> data) async* {
+  await for (final payload in data) {
+    final trimmed = payload.trim();
+    if (trimmed.isEmpty || trimmed == '[DONE]') continue;
+    Object? decoded;
+    try {
+      decoded = jsonDecode(trimmed);
+    } on FormatException {
+      continue;
+    }
+    if (decoded is Map<String, dynamic>) yield decoded;
+  }
+}
+
+Future<Object?> _readErrorBody(http.StreamedResponse response) async {
+  String text;
+  try {
+    text = await response.stream.bytesToString();
+  } on Exception {
+    return null;
+  }
+  try {
+    return jsonDecode(text);
+  } on FormatException {
+    return text;
+  }
 }

--- a/pkgs/ai_box/lib/src/llm_ai_base.dart
+++ b/pkgs/ai_box/lib/src/llm_ai_base.dart
@@ -19,8 +19,8 @@ abstract class LLMAIBase extends AIBase implements LLMAIInterface {
   /// ストリーミング応答。
   ///
   /// 既定実装は [completions] を呼び、結果を 1 チャンクとして流す
-  /// （非インクリメンタルなフォールバック）。プロバイダーは真の SSE
-  /// ストリーミングでオーバーライドできる。
+  /// （非インクリメンタルなフォールバック）。各プロバイダーパッケージは
+  /// 真の SSE ストリーミングでオーバーライドしている。
   @override
   Stream<LLMStreamChunk> completionsStream(
     LLMCompletionRequest request,
@@ -28,6 +28,7 @@ abstract class LLMAIBase extends AIBase implements LLMAIInterface {
     final res = await completions(request);
     yield LLMStreamChunk(
       delta: res.content.text,
+      reasoningDelta: res.content.reasoning,
       parts: res.content.parts,
       finishReason: res.finishReason,
       usage: res.usage,
@@ -44,6 +45,27 @@ abstract class LLMAIBase extends AIBase implements LLMAIInterface {
     LLMResponseFormat? responseFormat,
   }) {
     return completions(
+      LLMCompletionRequest(
+        model: model,
+        messages: messages,
+        maxTokens: maxTokens,
+        tools: tools,
+        toolChoice: toolChoice,
+        responseFormat: responseFormat,
+      ),
+    );
+  }
+
+  /// [completionsStream] の簡易ラッパー（[chat] のストリーミング版）。
+  Stream<LLMStreamChunk> chatStream({
+    required String model,
+    required List<LLMContent> messages,
+    int? maxTokens,
+    List<LLMTool>? tools,
+    LLMToolChoice? toolChoice,
+    LLMResponseFormat? responseFormat,
+  }) {
+    return completionsStream(
       LLMCompletionRequest(
         model: model,
         messages: messages,

--- a/pkgs/ai_box/lib/src/stream.dart
+++ b/pkgs/ai_box/lib/src/stream.dart
@@ -2,9 +2,14 @@ import 'package:ai_box/src/content.dart';
 import 'package:ai_box/src/response.dart';
 
 /// ストリーミング応答の 1 チャンク。
+///
+/// 途中のチャンクは [delta]（本文テキストの増分）や [reasoningDelta]
+/// （thinking テキストの増分）を運び、最終チャンクは [finishReason] と
+/// [parts]（確定した全パーツ）・[usage] を運ぶ。
 class LLMStreamChunk {
   const LLMStreamChunk({
     this.delta = '',
+    this.reasoningDelta = '',
     this.parts,
     this.finishReason,
     this.usage,
@@ -13,7 +18,13 @@ class LLMStreamChunk {
   /// 直前からの増分テキスト。
   final String delta;
 
+  /// 直前からの推論（thinking / reasoning）テキストの増分。
+  final String reasoningDelta;
+
   /// 確定したパーツ（完了時などに付与される）。
+  ///
+  /// 最終チャンクには応答全体のパーツ（推論・全文テキスト・ツール呼び出し
+  /// など）が入るため、最終チャンクだけで完全な応答を復元できる。
   final List<LLMContentPart>? parts;
 
   /// 完了理由（最終チャンクのみ）。

--- a/pkgs/ai_box/pubspec.yaml
+++ b/pkgs/ai_box/pubspec.yaml
@@ -1,6 +1,7 @@
 ---
 dependencies:
   api_http: ^0.0.1
+  http: ^1.0.0
 description: A base class for all AI providers.
 dev_dependencies:
   auto_exporter: ^4.0.0
@@ -17,4 +18,4 @@ topics:
   - grok
   - gemini
   - claude
-version: 0.2.0
+version: 0.3.0

--- a/pkgs/ai_box/test/openai_stream_test.dart
+++ b/pkgs/ai_box/test/openai_stream_test.dart
@@ -1,0 +1,211 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:ai_box/openai_compat.dart';
+import 'package:test/test.dart';
+
+/// OpenAI 互換ストリーミング（openai_compat.dart の
+/// openAiChunksFromEvents / streamOpenAiCompletions）の検証。
+void main() {
+  Map<String, dynamic> deltaEvent(
+    Map<String, dynamic> delta, {
+    String? finishReason,
+  }) =>
+      {
+        'choices': [
+          {'index': 0, 'delta': delta, 'finish_reason': finishReason},
+        ],
+      };
+
+  group('openAiChunksFromEvents', () {
+    test('streams text deltas and assembles the final chunk', () async {
+      final chunks = await openAiChunksFromEvents(
+        Stream.fromIterable([
+          deltaEvent({'role': 'assistant', 'content': ''}),
+          deltaEvent({'content': 'Hel'}),
+          deltaEvent({'content': 'lo'}),
+          deltaEvent({}, finishReason: 'stop'),
+        ]),
+      ).toList();
+
+      expect(chunks.map((c) => c.delta).join(), 'Hello');
+      final last = chunks.last;
+      expect(last.isDone, isTrue);
+      expect(last.finishReason, LLMFinishReason.stop);
+      expect(last.parts, hasLength(1));
+      expect((last.parts!.single as LLMTextPart).text, 'Hello');
+      // 最終チャンク以外は isDone にならない。
+      expect(chunks.sublist(0, chunks.length - 1).any((c) => c.isDone), false);
+    });
+
+    test('streams reasoning deltas separately from text', () async {
+      final chunks = await openAiChunksFromEvents(
+        Stream.fromIterable([
+          deltaEvent({'reasoning_content': 'think'}),
+          deltaEvent({'reasoning': 'ing'}),
+          deltaEvent({'content': 'answer'}),
+          deltaEvent({}, finishReason: 'stop'),
+        ]),
+      ).toList();
+
+      expect(chunks.map((c) => c.reasoningDelta).join(), 'thinking');
+      expect(chunks.map((c) => c.delta).join(), 'answer');
+      final parts = chunks.last.parts!;
+      expect((parts[0] as LLMReasoningPart).text, 'thinking');
+      expect((parts[1] as LLMTextPart).text, 'answer');
+    });
+
+    test('assembles tool calls across chunks', () async {
+      final chunks = await openAiChunksFromEvents(
+        Stream.fromIterable([
+          deltaEvent({
+            'tool_calls': [
+              {
+                'index': 0,
+                'id': 'call_1',
+                'type': 'function',
+                'function': {'name': 'get_weather', 'arguments': ''},
+              },
+            ],
+          }),
+          deltaEvent({
+            'tool_calls': [
+              {
+                'index': 0,
+                'function': {'arguments': '{"city":'},
+              },
+            ],
+          }),
+          deltaEvent({
+            'tool_calls': [
+              {
+                'index': 0,
+                'function': {'arguments': '"Tokyo"}'},
+              },
+            ],
+          }),
+          deltaEvent({}, finishReason: 'tool_calls'),
+        ]),
+      ).toList();
+
+      final last = chunks.last;
+      expect(last.finishReason, LLMFinishReason.toolCalls);
+      final call = last.parts!.whereType<LLMToolCallPart>().single;
+      expect(call.id, 'call_1');
+      expect(call.name, 'get_weather');
+      expect(call.arguments, {'city': 'Tokyo'});
+    });
+
+    test('captures usage from a trailing usage-only chunk', () async {
+      final chunks = await openAiChunksFromEvents(
+        Stream.fromIterable([
+          deltaEvent({'content': 'hi'}, finishReason: 'stop'),
+          {
+            'choices': <dynamic>[],
+            'usage': {
+              'prompt_tokens': 3,
+              'completion_tokens': 5,
+              'prompt_tokens_details': {'cached_tokens': 2},
+            },
+          },
+        ]),
+      ).toList();
+
+      final usage = chunks.last.usage;
+      expect(usage, isNotNull);
+      expect(usage!.inputTokens, 3);
+      expect(usage.outputTokens, 5);
+      expect(usage.cachedInputTokens, 2);
+    });
+
+    test('throws a typed exception on an error event with an HTTP code',
+        () async {
+      await expectLater(
+        openAiChunksFromEvents(
+          Stream.fromIterable([
+            {
+              'error': {'code': 429, 'message': 'slow down'},
+            },
+          ]),
+          provider: 'openrouter',
+        ).toList(),
+        throwsA(isA<LLMRateLimitException>()),
+      );
+    });
+
+    test('throws LLMUnknownException on an error event without a code',
+        () async {
+      await expectLater(
+        openAiChunksFromEvents(
+          Stream.fromIterable([
+            {
+              'error': {'message': 'boom', 'type': 'server_error'},
+            },
+          ]),
+        ).toList(),
+        throwsA(
+          isA<LLMUnknownException>()
+              .having((e) => e.message, 'message', 'boom')
+              .having((e) => e.code, 'code', 'server_error'),
+        ),
+      );
+    });
+
+    test('falls back to other when no finish_reason arrives', () async {
+      final chunks = await openAiChunksFromEvents(
+        Stream.fromIterable([
+          deltaEvent({'content': 'x'}),
+        ]),
+      ).toList();
+      expect(chunks.last.finishReason, LLMFinishReason.other);
+    });
+  });
+
+  group('streamOpenAiCompletions', () {
+    test('posts stream:true and parses the SSE response end-to-end', () async {
+      late Map<String, dynamic> receivedBody;
+      String? receivedAuth;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        receivedAuth = request.headers.value('authorization');
+        receivedBody = jsonDecode(await utf8.decoder.bind(request).join())
+            as Map<String, dynamic>;
+        request.response.headers.contentType =
+            ContentType('text', 'event-stream');
+        Map<String, dynamic> ev(Map<String, dynamic> delta, [String? fin]) => {
+              'choices': [
+                {'index': 0, 'delta': delta, 'finish_reason': fin},
+              ],
+            };
+        request.response.write(
+          'data: ${jsonEncode(ev({'content': 'Hi'}))}\n\n'
+          'data: ${jsonEncode(ev({}, 'stop'))}\n\n'
+          'data: [DONE]\n\n',
+        );
+        await request.response.close();
+      });
+
+      final chunks = await streamOpenAiCompletions(
+        url: 'http://127.0.0.1:${server.port}/v1/chat/completions',
+        apiKey: 'sk-test',
+        provider: 'openai',
+        request: LLMCompletionRequest(
+          model: 'gpt-4o',
+          messages: [LLMContent.user('hello')],
+          maxTokens: 10,
+        ),
+        maxTokensKey: 'max_completion_tokens',
+        includeUsage: true,
+      ).toList();
+
+      expect(receivedAuth, 'Bearer sk-test');
+      expect(receivedBody['stream'], true);
+      expect(receivedBody['stream_options'], {'include_usage': true});
+      expect(receivedBody['max_completion_tokens'], 10);
+      expect(chunks.map((c) => c.delta).join(), 'Hi');
+      expect(chunks.last.finishReason, LLMFinishReason.stop);
+    });
+  });
+}

--- a/pkgs/ai_box/test/sse_test.dart
+++ b/pkgs/ai_box/test/sse_test.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:ai_box/ai_box.dart';
+import 'package:ai_box/provider_http.dart';
+import 'package:test/test.dart';
+
+/// SSE トランスポート（provider_http.dart の postSseData / decodeSseJson）の
+/// 検証。ローカル HTTP サーバーに対して実際にストリーミングする。
+void main() {
+  group('postSseData', () {
+    late HttpServer server;
+
+    tearDown(() async {
+      await server.close(force: true);
+    });
+
+    Future<String> serve(
+      Future<void> Function(HttpRequest request) handler,
+    ) async {
+      server = (await HttpServer.bind(InternetAddress.loopbackIPv4, 0))
+        ..listen((request) async {
+          await handler(request);
+          await request.response.close();
+        });
+      return 'http://127.0.0.1:${server.port}/v1/test';
+    }
+
+    void writeSse(HttpRequest request, String raw) {
+      request.response.headers.contentType =
+          ContentType('text', 'event-stream');
+      request.response.write(raw);
+    }
+
+    test('yields one payload per event and joins multi-line data', () async {
+      final url = await serve((request) async {
+        writeSse(
+          request,
+          ': comment line\n'
+          'event: message\n'
+          'data: {"a":\n'
+          'data: 1}\n'
+          '\n'
+          'data: second\n'
+          '\n',
+        );
+      });
+      final events = await postSseData(
+        url: url,
+        provider: 'test',
+        headers: const {},
+        body: const {'x': 1},
+      ).toList();
+      expect(events, ['{"a":\n1}', 'second']);
+    });
+
+    test('handles CRLF lines and a final event without a trailing blank line',
+        () async {
+      final url = await serve((request) async {
+        writeSse(request, 'data: one\r\n\r\ndata: two');
+      });
+      final events = await postSseData(
+        url: url,
+        provider: 'test',
+        headers: const {},
+        body: const {},
+      ).toList();
+      expect(events, ['one', 'two']);
+    });
+
+    test('sends JSON body, custom headers and query parameters', () async {
+      late Map<String, dynamic> receivedBody;
+      String? receivedHeader;
+      String? receivedQuery;
+      final url = await serve((request) async {
+        receivedQuery = request.uri.queryParameters['alt'];
+        receivedHeader = request.headers.value('x-api-key');
+        receivedBody = jsonDecode(await utf8.decoder.bind(request).join())
+            as Map<String, dynamic>;
+        writeSse(request, 'data: ok\n\n');
+      });
+      final events = await postSseData(
+        url: url,
+        provider: 'test',
+        headers: const {'x-api-key': 'k'},
+        body: const {'stream': true},
+        queryParameters: const {'alt': 'sse'},
+      ).toList();
+      expect(events, ['ok']);
+      expect(receivedBody, {'stream': true});
+      expect(receivedHeader, 'k');
+      expect(receivedQuery, 'sse');
+    });
+
+    test('normalizes non-2xx into typed LLMExceptions', () async {
+      final url = await serve((request) async {
+        request.response.statusCode = 401;
+        request.response.write(
+          jsonEncode({
+            'error': {'message': 'bad key', 'type': 'auth_error'},
+          }),
+        );
+      });
+      await expectLater(
+        postSseData(
+          url: url,
+          provider: 'test',
+          headers: const {},
+          body: const {},
+        ).toList(),
+        throwsA(
+          isA<LLMAuthException>()
+              .having((e) => e.message, 'message', 'bad key')
+              .having((e) => e.statusCode, 'statusCode', 401)
+              .having((e) => e.provider, 'provider', 'test'),
+        ),
+      );
+    });
+
+    test('throws LLMNetworkException when the connection fails', () async {
+      // 接続を確実に失敗させるため、閉じたポートへ接続する。
+      final probe = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final port = probe.port;
+      await probe.close(force: true);
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      await expectLater(
+        postSseData(
+          url: 'http://127.0.0.1:$port/',
+          provider: 'test',
+          headers: const {},
+          body: const {},
+        ).toList(),
+        throwsA(isA<LLMNetworkException>()),
+      );
+    });
+  });
+
+  group('decodeSseJson', () {
+    test('decodes JSON maps and skips [DONE] / non-JSON / non-map', () async {
+      final events = await decodeSseJson(
+        Stream.fromIterable([
+          '{"a":1}',
+          '[DONE]',
+          'not json',
+          '[1,2]',
+          '{"b":2}',
+        ]),
+      ).toList();
+      expect(events, [
+        {'a': 1},
+        {'b': 2},
+      ]);
+    });
+  });
+}

--- a/pkgs/chatgpt_box/CHANGELOG.md
+++ b/pkgs/chatgpt_box/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.5
+
+- `completionsStream()` now uses real SSE streaming (incremental text /
+  reasoning deltas, cross-chunk tool-call assembly, usage via
+  `stream_options.include_usage`) instead of the single-chunk fallback.
+
 ## 0.0.4
 
 - Use the OpenAI-compat layer and HTTP error normalization shared via

--- a/pkgs/chatgpt_box/lib/src/chatgpt.dart
+++ b/pkgs/chatgpt_box/lib/src/chatgpt.dart
@@ -26,6 +26,20 @@ class ChatGPT extends LLMAIBase {
     return parseOpenAiResponse(data);
   }
 
+  /// 真の SSE ストリーミング。テキストは増分で流れ、最終チャンクに
+  /// 完全なパーツ・完了理由・トークン使用量が入る。
+  @override
+  Stream<LLMStreamChunk> completionsStream(LLMCompletionRequest request) {
+    return streamOpenAiCompletions(
+      url: _url,
+      apiKey: apiKey,
+      provider: _provider,
+      request: request,
+      maxTokensKey: 'max_completion_tokens',
+      includeUsage: true,
+    );
+  }
+
   @override
   Future<List<AIModel>> getModels() async {
     final models = await ModelsCore.listModels(apiKey: apiKey);

--- a/pkgs/chatgpt_box/pubspec.yaml
+++ b/pkgs/chatgpt_box/pubspec.yaml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  ai_box: ^0.2.0
+  ai_box: ^0.3.0
   api_http: ^0.0.1
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
@@ -22,4 +22,4 @@ topics:
   - ai-box
   - llm
   - openai
-version: 0.0.4
+version: 0.0.5

--- a/pkgs/claude_box/CHANGELOG.md
+++ b/pkgs/claude_box/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.3
+
+- `completionsStream()` now uses real SSE streaming of the Messages API
+  (incremental text / thinking deltas, cross-event `input_json_delta`
+  tool-call assembly, usage from `message_start` / `message_delta`,
+  normalized `error` events) instead of the single-chunk fallback.
+
 ## 0.1.2
 
 - Use the HTTP error normalization shared via `ai_box`

--- a/pkgs/claude_box/lib/claude_box.dart
+++ b/pkgs/claude_box/lib/claude_box.dart
@@ -1,5 +1,6 @@
 export 'package:claude_box/src/claude.dart';
 export 'package:claude_box/src/claude_core.dart';
+export 'package:claude_box/src/claude_stream.dart';
 export 'package:claude_box/src/freezed/message/request/message_request/message_request.dart';
 export 'package:claude_box/src/freezed/message/response/message_response.dart';
 export 'package:claude_box/src/freezed/models/list_models_query_parameters/list_models_query_parameters.dart';

--- a/pkgs/claude_box/lib/src/claude.dart
+++ b/pkgs/claude_box/lib/src/claude.dart
@@ -1,6 +1,8 @@
 import 'package:ai_box/ai_box.dart';
+import 'package:ai_box/provider_http.dart';
 import 'package:api_http/api_http.dart';
 import 'package:claude_box/src/claude_core.dart';
+import 'package:claude_box/src/claude_stream.dart';
 import 'package:claude_box/src/freezed/message/request/message_request/message_request.dart';
 import 'package:claude_box/src/freezed/message/response/message_response.dart';
 import 'package:claude_box/src/freezed/models/list_models_response/list_models_response.dart';
@@ -27,44 +29,27 @@ class Claude extends LLMAIBase {
   Future<LLMCompletionResponse> completions(
     LLMCompletionRequest request,
   ) async {
-    // Claude では system ロールのメッセージを system フィールドに分離する。
-    final system = request.messages
-        .where((e) => e.role == LLMRole.system)
-        .map((e) => e.text)
-        .where((t) => t.isNotEmpty)
-        .join('\n');
-    final convo =
-        request.messages.where((e) => e.role != LLMRole.system).toList();
-
-    final body = <String, dynamic>{
-      'model': request.model,
-      'messages': _toClaudeMessages(convo),
-      'max_tokens': request.maxTokens ?? defaultMaxTokens,
-      if (system.isNotEmpty) 'system': system,
-      if (request.temperature != null) 'temperature': request.temperature,
-      if (request.topP != null) 'top_p': request.topP,
-      if (request.stop != null) 'stop_sequences': request.stop,
-    };
-    final tools = request.tools;
-    if (tools != null && tools.isNotEmpty) {
-      body['tools'] = [
-        for (final t in tools)
-          {
-            'name': t.name,
-            'description': t.description,
-            'input_schema': t.parameters,
-          },
-      ];
-      final tc = _toClaudeToolChoice(request.toolChoice);
-      if (tc != null) body['tool_choice'] = tc;
-    }
-
     final data = await _postClaude(
       apiKey: apiKey,
       version: _version,
-      body: body,
+      body: _buildClaudeBody(request),
     );
     return _parseClaudeResponse(data);
+  }
+
+  /// 真の SSE ストリーミング。テキストは増分で流れ、最終チャンクに
+  /// 完全なパーツ・完了理由・トークン使用量が入る。
+  @override
+  Stream<LLMStreamChunk> completionsStream(LLMCompletionRequest request) {
+    final body = _buildClaudeBody(request);
+    body['stream'] = true;
+    final data = postSseData(
+      url: _messagesUrl,
+      provider: ClaudeCore.provider,
+      headers: {'x-api-key': apiKey, 'anthropic-version': _version},
+      body: body,
+    );
+    return claudeChunksFromEvents(decodeSseJson(data));
   }
 
   Future<MessageResponse> createMessage({
@@ -122,6 +107,43 @@ class Claude extends LLMAIBase {
       return false;
     }
   }
+}
+
+const _messagesUrl = 'https://api.anthropic.com/v1/messages';
+
+Map<String, dynamic> _buildClaudeBody(LLMCompletionRequest request) {
+  // Claude では system ロールのメッセージを system フィールドに分離する。
+  final system = request.messages
+      .where((e) => e.role == LLMRole.system)
+      .map((e) => e.text)
+      .where((t) => t.isNotEmpty)
+      .join('\n');
+  final convo =
+      request.messages.where((e) => e.role != LLMRole.system).toList();
+
+  final body = <String, dynamic>{
+    'model': request.model,
+    'messages': _toClaudeMessages(convo),
+    'max_tokens': request.maxTokens ?? Claude.defaultMaxTokens,
+    if (system.isNotEmpty) 'system': system,
+    if (request.temperature != null) 'temperature': request.temperature,
+    if (request.topP != null) 'top_p': request.topP,
+    if (request.stop != null) 'stop_sequences': request.stop,
+  };
+  final tools = request.tools;
+  if (tools != null && tools.isNotEmpty) {
+    body['tools'] = [
+      for (final t in tools)
+        {
+          'name': t.name,
+          'description': t.description,
+          'input_schema': t.parameters,
+        },
+    ];
+    final tc = _toClaudeToolChoice(request.toolChoice);
+    if (tc != null) body['tool_choice'] = tc;
+  }
+  return body;
 }
 
 List<Map<String, dynamic>> _toClaudeMessages(List<LLMContent> messages) {
@@ -256,7 +278,7 @@ Future<Map<String, dynamic>> _postClaude({
   return ClaudeCore.requestJson(
     () => Api.post(
       requestAcc: PostRequestAcc(
-        url: 'https://api.anthropic.com/v1/messages',
+        url: _messagesUrl,
         headers: RestHeaders({
           'x-api-key': apiKey,
           'anthropic-version': version,

--- a/pkgs/claude_box/lib/src/claude_stream.dart
+++ b/pkgs/claude_box/lib/src/claude_stream.dart
@@ -1,0 +1,187 @@
+/// Claude（Anthropic Messages API）の SSE ストリーミングイベント解析。
+///
+/// 各プロバイダーパッケージの内部実装向けで、アプリから直接使う想定ではない。
+library;
+
+import 'dart:convert';
+
+import 'package:ai_box/ai_box.dart';
+
+/// Claude のストリーミングイベント（`message_start` /
+/// `content_block_delta` / `message_delta` など）列を [LLMStreamChunk] 列へ
+/// 変換する。
+///
+/// テキストは `delta`、thinking は `reasoningDelta` として増分で流れ、
+/// ツール呼び出し（`input_json_delta`）はイベントをまたいで組み立てられて
+/// 最終チャンクの `parts` に入る。`error` イベントは [LLMException] に
+/// 正規化して投げる。
+Stream<LLMStreamChunk> claudeChunksFromEvents(
+  Stream<Map<String, dynamic>> events,
+) async* {
+  final blocks = <int, _StreamBlock>{};
+  LLMFinishReason? finishReason;
+  int? inputTokens;
+  int? outputTokens;
+  int? cachedInputTokens;
+
+  await for (final event in events) {
+    switch (event['type']) {
+      case 'message_start':
+        final message = event['message'];
+        final usage = message is Map<String, dynamic> ? message['usage'] : null;
+        if (usage is Map<String, dynamic>) {
+          inputTokens = (usage['input_tokens'] as num?)?.toInt();
+          outputTokens = (usage['output_tokens'] as num?)?.toInt();
+          cachedInputTokens =
+              (usage['cache_read_input_tokens'] as num?)?.toInt();
+        }
+      case 'content_block_start':
+        final index = (event['index'] as num?)?.toInt() ?? 0;
+        final block = _StreamBlock.start(event['content_block']);
+        blocks[index] = block;
+        if (block.text.isNotEmpty) {
+          yield LLMStreamChunk(delta: block.text.toString());
+        }
+      case 'content_block_delta':
+        final index = (event['index'] as num?)?.toInt() ?? 0;
+        final block = blocks.putIfAbsent(index, _StreamBlock.new);
+        final delta = event['delta'];
+        if (delta is! Map<String, dynamic>) continue;
+        switch (delta['type']) {
+          case 'text_delta':
+            final text = delta['text'];
+            if (text is String && text.isNotEmpty) {
+              block.text.write(text);
+              yield LLMStreamChunk(delta: text);
+            }
+          case 'thinking_delta':
+            final thinking = delta['thinking'];
+            if (thinking is String && thinking.isNotEmpty) {
+              block.thinking.write(thinking);
+              yield LLMStreamChunk(reasoningDelta: thinking);
+            }
+          case 'input_json_delta':
+            final partial = delta['partial_json'];
+            if (partial is String) block.inputJson.write(partial);
+          case 'signature_delta':
+            final signature = delta['signature'];
+            if (signature is String) block.signature = signature;
+        }
+      case 'message_delta':
+        final delta = event['delta'];
+        if (delta is Map<String, dynamic>) {
+          final stopReason = delta['stop_reason'];
+          if (stopReason is String && stopReason.isNotEmpty) {
+            finishReason = LLMFinishReason.parse(stopReason);
+          }
+        }
+        final usage = event['usage'];
+        if (usage is Map<String, dynamic>) {
+          outputTokens =
+              (usage['output_tokens'] as num?)?.toInt() ?? outputTokens;
+        }
+      case 'error':
+        throw claudeStreamErrorToException(event['error'], raw: event);
+    }
+  }
+
+  yield LLMStreamChunk(
+    parts: [
+      for (final index in blocks.keys.toList()..sort())
+        ...blocks[index]!.toParts(),
+    ],
+    finishReason: finishReason ?? LLMFinishReason.other,
+    usage: LLMUsage(
+      inputTokens: inputTokens ?? 0,
+      outputTokens: outputTokens ?? 0,
+      cachedInputTokens: cachedInputTokens,
+    ),
+  );
+}
+
+/// Claude の `error` イベントを [LLMException] 階層へ正規化する。
+LLMException claudeStreamErrorToException(Object? error, {Object? raw}) {
+  final map = error is Map<String, dynamic> ? error : const <String, dynamic>{};
+  final type = (map['type'] ?? '').toString();
+  final message = (map['message'] ?? 'Stream error').toString();
+  const provider = 'claude';
+  return switch (type) {
+    'authentication_error' ||
+    'permission_error' =>
+      LLMAuthException(message, provider: provider, code: type, raw: raw),
+    'rate_limit_error' =>
+      LLMRateLimitException(message, provider: provider, code: type, raw: raw),
+    'invalid_request_error' ||
+    'not_found_error' ||
+    'request_too_large' =>
+      LLMInvalidRequestException(
+        message,
+        provider: provider,
+        code: type,
+        raw: raw,
+      ),
+    'api_error' ||
+    'overloaded_error' =>
+      LLMServerException(message, provider: provider, code: type, raw: raw),
+    _ => LLMUnknownException(message, provider: provider, code: type, raw: raw),
+  };
+}
+
+/// ストリーミング中に組み立てる 1 コンテントブロック。
+class _StreamBlock {
+  _StreamBlock() : type = 'text';
+
+  _StreamBlock.start(Object? contentBlock)
+      : type = contentBlock is Map<String, dynamic>
+            ? (contentBlock['type'] ?? 'text').toString()
+            : 'text' {
+    if (contentBlock is! Map<String, dynamic>) return;
+    final initialText = contentBlock['text'];
+    if (initialText is String) text.write(initialText);
+    final initialThinking = contentBlock['thinking'];
+    if (initialThinking is String) thinking.write(initialThinking);
+    toolUseId = (contentBlock['id'] ?? '').toString();
+    toolName = (contentBlock['name'] ?? '').toString();
+  }
+
+  final String type;
+  final StringBuffer text = StringBuffer();
+  final StringBuffer thinking = StringBuffer();
+  final StringBuffer inputJson = StringBuffer();
+  String toolUseId = '';
+  String toolName = '';
+  String? signature;
+
+  List<LLMContentPart> toParts() {
+    switch (type) {
+      case 'tool_use':
+        return [
+          LLMToolCallPart(
+            id: toolUseId,
+            name: toolName,
+            arguments: _decodeJsonMap(inputJson.toString()),
+          ),
+        ];
+      case 'thinking':
+        return [
+          if (thinking.isNotEmpty)
+            LLMReasoningPart(thinking.toString(), signature: signature),
+        ];
+      case 'text':
+        return [if (text.isNotEmpty) LLMTextPart(text.toString())];
+      default:
+        return const [];
+    }
+  }
+}
+
+Map<String, dynamic> _decodeJsonMap(String source) {
+  if (source.isEmpty) return <String, dynamic>{};
+  try {
+    final decoded = jsonDecode(source);
+    if (decoded is Map<String, dynamic>) return decoded;
+  } on FormatException {
+    // 不完全な JSON は空マップとして扱う。
+  }
+  return <String, dynamic>{};
+}

--- a/pkgs/claude_box/pubspec.yaml
+++ b/pkgs/claude_box/pubspec.yaml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  ai_box: ^0.2.0
+  ai_box: ^0.3.0
   api_http: ^0.0.1
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
@@ -22,4 +22,4 @@ topics:
   - ai-box
   - llm
   - anthropic
-version: 0.1.2
+version: 0.1.3

--- a/pkgs/claude_box/test/claude_stream_test.dart
+++ b/pkgs/claude_box/test/claude_stream_test.dart
@@ -1,0 +1,149 @@
+import 'package:ai_box/ai_box.dart';
+import 'package:claude_box/claude_box.dart';
+import 'package:test/test.dart';
+
+/// Claude の SSE ストリーミングイベント解析（claude_stream.dart）の検証。
+void main() {
+  group('claudeChunksFromEvents', () {
+    test('streams text deltas and assembles the final chunk with usage',
+        () async {
+      final chunks = await claudeChunksFromEvents(
+        Stream.fromIterable([
+          {
+            'type': 'message_start',
+            'message': {
+              'id': 'msg_1',
+              'usage': {
+                'input_tokens': 10,
+                'output_tokens': 1,
+                'cache_read_input_tokens': 4,
+              },
+            },
+          },
+          {
+            'type': 'content_block_start',
+            'index': 0,
+            'content_block': {'type': 'text', 'text': ''},
+          },
+          {
+            'type': 'content_block_delta',
+            'index': 0,
+            'delta': {'type': 'text_delta', 'text': 'Hel'},
+          },
+          {
+            'type': 'content_block_delta',
+            'index': 0,
+            'delta': {'type': 'text_delta', 'text': 'lo'},
+          },
+          {'type': 'content_block_stop', 'index': 0},
+          {
+            'type': 'message_delta',
+            'delta': {'stop_reason': 'end_turn', 'stop_sequence': null},
+            'usage': {'output_tokens': 12},
+          },
+          {'type': 'message_stop'},
+        ]),
+      ).toList();
+
+      expect(chunks.map((c) => c.delta).join(), 'Hello');
+      final last = chunks.last;
+      expect(last.isDone, isTrue);
+      expect(last.finishReason, LLMFinishReason.stop);
+      expect((last.parts!.single as LLMTextPart).text, 'Hello');
+      expect(last.usage!.inputTokens, 10);
+      expect(last.usage!.outputTokens, 12);
+      expect(last.usage!.cachedInputTokens, 4);
+    });
+
+    test('assembles thinking and tool_use blocks across events', () async {
+      final chunks = await claudeChunksFromEvents(
+        Stream.fromIterable([
+          {
+            'type': 'content_block_start',
+            'index': 0,
+            'content_block': {'type': 'thinking', 'thinking': ''},
+          },
+          {
+            'type': 'content_block_delta',
+            'index': 0,
+            'delta': {'type': 'thinking_delta', 'thinking': 'hmm'},
+          },
+          {
+            'type': 'content_block_delta',
+            'index': 0,
+            'delta': {'type': 'signature_delta', 'signature': 'sig'},
+          },
+          {
+            'type': 'content_block_start',
+            'index': 1,
+            'content_block': {
+              'type': 'tool_use',
+              'id': 'toolu_1',
+              'name': 'get_weather',
+              'input': <String, dynamic>{},
+            },
+          },
+          {
+            'type': 'content_block_delta',
+            'index': 1,
+            'delta': {'type': 'input_json_delta', 'partial_json': '{"city"'},
+          },
+          {
+            'type': 'content_block_delta',
+            'index': 1,
+            'delta': {'type': 'input_json_delta', 'partial_json': ':"Osaka"}'},
+          },
+          {
+            'type': 'message_delta',
+            'delta': {'stop_reason': 'tool_use'},
+            'usage': {'output_tokens': 7},
+          },
+        ]),
+      ).toList();
+
+      expect(chunks.map((c) => c.reasoningDelta).join(), 'hmm');
+      final last = chunks.last;
+      expect(last.finishReason, LLMFinishReason.toolCalls);
+      final reasoningPart = last.parts![0] as LLMReasoningPart;
+      expect(reasoningPart.text, 'hmm');
+      expect(reasoningPart.signature, 'sig');
+      final call = last.parts![1] as LLMToolCallPart;
+      expect(call.id, 'toolu_1');
+      expect(call.name, 'get_weather');
+      expect(call.arguments, {'city': 'Osaka'});
+    });
+
+    test('throws a typed exception on an error event', () async {
+      await expectLater(
+        claudeChunksFromEvents(
+          Stream.fromIterable([
+            {
+              'type': 'error',
+              'error': {'type': 'overloaded_error', 'message': 'Overloaded'},
+            },
+          ]),
+        ).toList(),
+        throwsA(
+          isA<LLMServerException>()
+              .having((e) => e.message, 'message', 'Overloaded')
+              .having((e) => e.code, 'code', 'overloaded_error'),
+        ),
+      );
+    });
+  });
+
+  group('claudeStreamErrorToException', () {
+    test('maps Anthropic error types to the LLMException hierarchy', () {
+      LLMException map(String type) =>
+          claudeStreamErrorToException({'type': type, 'message': 'm'});
+      expect(map('authentication_error'), isA<LLMAuthException>());
+      expect(map('permission_error'), isA<LLMAuthException>());
+      expect(map('rate_limit_error'), isA<LLMRateLimitException>());
+      expect(map('invalid_request_error'), isA<LLMInvalidRequestException>());
+      expect(map('not_found_error'), isA<LLMInvalidRequestException>());
+      expect(map('api_error'), isA<LLMServerException>());
+      expect(map('overloaded_error'), isA<LLMServerException>());
+      expect(map('mystery'), isA<LLMUnknownException>());
+    });
+  });
+}

--- a/pkgs/deepseek_box/CHANGELOG.md
+++ b/pkgs/deepseek_box/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.4
+
+- `completionsStream()` now uses real SSE streaming (incremental text and
+  `reasoning_content` deltas, cross-chunk tool-call assembly, usage via
+  `stream_options.include_usage`) instead of the single-chunk fallback.
+
 ## 0.0.3
 
 - Use the OpenAI-compat layer and HTTP error normalization shared via

--- a/pkgs/deepseek_box/lib/src/deepseek.dart
+++ b/pkgs/deepseek_box/lib/src/deepseek.dart
@@ -22,6 +22,20 @@ class DeepSeek extends LLMAIBase {
     return parseOpenAiResponse(data);
   }
 
+  /// 真の SSE ストリーミング。テキストは増分で流れ、最終チャンクに
+  /// 完全なパーツ・完了理由・トークン使用量が入る。
+  @override
+  Stream<LLMStreamChunk> completionsStream(LLMCompletionRequest request) {
+    return streamOpenAiCompletions(
+      url: _url,
+      apiKey: apiKey,
+      provider: _provider,
+      request: request,
+      maxTokensKey: 'max_tokens',
+      includeUsage: true,
+    );
+  }
+
   @override
   Future<List<AIModel>> getModels() async {
     final modelList = await DeepSeekCore.listModels(apiKey: apiKey);

--- a/pkgs/deepseek_box/pubspec.yaml
+++ b/pkgs/deepseek_box/pubspec.yaml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  ai_box: ^0.2.0
+  ai_box: ^0.3.0
   api_http: ^0.0.1
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
@@ -21,4 +21,4 @@ topics:
   - deepseek
   - ai-box
   - llm
-version: 0.0.3
+version: 0.0.4

--- a/pkgs/gemini_box/CHANGELOG.md
+++ b/pkgs/gemini_box/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.4
+
+- `completionsStream()` now uses real SSE streaming via
+  `streamGenerateContent` + `alt=sse` (incremental text / thought deltas,
+  function calls and generated media in the final chunk) instead of the
+  single-chunk fallback.
+
 ## 0.0.3
 
 - Use the HTTP error normalization shared via `ai_box`

--- a/pkgs/gemini_box/lib/gemini_box.dart
+++ b/pkgs/gemini_box/lib/gemini_box.dart
@@ -53,6 +53,7 @@ export 'package:gemini_box/src/freezed/tool/tool_config/tool_config/tool_config.
 export 'package:gemini_box/src/gemini_api/gemini.dart';
 export 'package:gemini_box/src/gemini_api/gemini_core.dart';
 export 'package:gemini_box/src/gemini_api/gemini_files_core.dart';
+export 'package:gemini_box/src/gemini_api/gemini_stream.dart';
 export 'package:gemini_box/src/gemini_file/gemini_file.dart';
 export 'package:gemini_box/src/response_schema/model_info.dart';
 export 'package:gemini_box/src/response_schema/schema_type.dart';

--- a/pkgs/gemini_box/lib/src/gemini_api/gemini.dart
+++ b/pkgs/gemini_box/lib/src/gemini_api/gemini.dart
@@ -1,7 +1,7 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:ai_box/ai_box.dart';
+import 'package:ai_box/provider_http.dart';
 import 'package:api_http/api_http.dart' as ac;
 import 'package:gemini_box/gemini_box.dart';
 
@@ -21,6 +21,20 @@ class Gemini extends LLMAIBase {
       body: body,
     );
     return _parseGeminiResponse(data);
+  }
+
+  /// 真の SSE ストリーミング。テキストは増分で流れ、最終チャンクに
+  /// 完全なパーツ・完了理由・トークン使用量が入る。
+  @override
+  Stream<LLMStreamChunk> completionsStream(LLMCompletionRequest request) {
+    final data = postSseData(
+      url: '$_baseUrl/models/${request.model}:streamGenerateContent',
+      provider: GeminiCore.provider,
+      headers: const {},
+      body: _buildGeminiBody(request),
+      queryParameters: {'key': apiKey, 'alt': 'sse'},
+    );
+    return geminiChunksFromEvents(decodeSseJson(data));
   }
 
   /// Generate content (低レベル・型付き API)
@@ -223,7 +237,9 @@ LLMCompletionResponse _parseGeminiResponse(Map<String, dynamic> data) {
     if (p['text'] is String) {
       parts.add(LLMTextPart(p['text'] as String));
     } else if (p['inlineData'] is Map<String, dynamic>) {
-      parts.add(_geminiInlineToPart(p['inlineData'] as Map<String, dynamic>));
+      parts.add(
+        geminiInlineDataToPart(p['inlineData'] as Map<String, dynamic>),
+      );
     } else if (p['fileData'] is Map<String, dynamic>) {
       final fd = p['fileData'] as Map<String, dynamic>;
       parts.add(LLMImagePart.url((fd['fileUri'] ?? '').toString()));
@@ -270,28 +286,17 @@ LLMCompletionResponse _parseGeminiResponse(Map<String, dynamic> data) {
   );
 }
 
-LLMContentPart _geminiInlineToPart(Map<String, dynamic> blob) {
-  final mime = (blob['mimeType'] ?? '').toString();
-  final b64 = (blob['data'] ?? '').toString();
-  if (mime.startsWith('audio/')) {
-    return LLMAudioPart.base64(b64, mimeType: mime);
-  }
-  if (mime.startsWith('image/')) {
-    return LLMImagePart.bytes(base64Decode(b64), mimeType: mime);
-  }
-  return LLMFilePart.bytes(base64Decode(b64), mimeType: mime);
-}
+const _baseUrl = 'https://generativelanguage.googleapis.com/v1beta';
 
 Future<Map<String, dynamic>> _postGemini({
   required String apiKey,
   required String model,
   required Map<String, dynamic> body,
 }) {
-  const baseUrl = 'https://generativelanguage.googleapis.com/v1beta';
   return GeminiCore.requestJson(
     () => ac.Api.post(
       requestAcc: ac.PostRequestAcc(
-        url: '$baseUrl/models/$model:generateContent',
+        url: '$_baseUrl/models/$model:generateContent',
         queryParameters: {'key': apiKey},
         body: ac.JsonRequestBody(body),
       ),

--- a/pkgs/gemini_box/lib/src/gemini_api/gemini_stream.dart
+++ b/pkgs/gemini_box/lib/src/gemini_api/gemini_stream.dart
@@ -1,0 +1,121 @@
+/// Gemini（`streamGenerateContent` + `alt=sse`）のストリーミング解析。
+///
+/// 各プロバイダーパッケージの内部実装向けで、アプリから直接使う想定ではない。
+library;
+
+import 'dart:convert';
+
+import 'package:ai_box/ai_box.dart';
+
+/// Gemini のストリーミングレスポンス（各イベントが
+/// `GenerateContentResponse` 形の JSON）列を [LLMStreamChunk] 列へ変換する。
+///
+/// テキストは `delta`、thought パーツは `reasoningDelta` として増分で流れ、
+/// 関数呼び出し・生成画像などは最終チャンクの `parts` に入る。
+Stream<LLMStreamChunk> geminiChunksFromEvents(
+  Stream<Map<String, dynamic>> events,
+) async* {
+  final text = StringBuffer();
+  final reasoning = StringBuffer();
+  final collected = <LLMContentPart>[];
+  String? rawFinishReason;
+  Map<String, dynamic>? usageMetadata;
+
+  await for (final event in events) {
+    final metadata = event['usageMetadata'];
+    if (metadata is Map<String, dynamic>) usageMetadata = metadata;
+
+    final candidates = event['candidates'];
+    if (candidates is! List || candidates.isEmpty) continue;
+    final candidate = candidates.first;
+    if (candidate is! Map<String, dynamic>) continue;
+
+    final finish = candidate['finishReason'];
+    if (finish is String && finish.isNotEmpty) rawFinishReason = finish;
+
+    final content = candidate['content'];
+    final rawParts = content is Map<String, dynamic> ? content['parts'] : null;
+    if (rawParts is! List) continue;
+    for (final p in rawParts) {
+      if (p is! Map<String, dynamic>) continue;
+      if (p['thought'] == true) {
+        final t = p['text'];
+        if (t is String && t.isNotEmpty) {
+          reasoning.write(t);
+          yield LLMStreamChunk(reasoningDelta: t);
+        }
+        continue;
+      }
+      if (p['text'] is String) {
+        final t = p['text'] as String;
+        if (t.isNotEmpty) {
+          text.write(t);
+          yield LLMStreamChunk(delta: t);
+        }
+      } else if (p['inlineData'] is Map<String, dynamic>) {
+        collected.add(
+          geminiInlineDataToPart(p['inlineData'] as Map<String, dynamic>),
+        );
+      } else if (p['fileData'] is Map<String, dynamic>) {
+        final fd = p['fileData'] as Map<String, dynamic>;
+        collected.add(LLMImagePart.url((fd['fileUri'] ?? '').toString()));
+      } else if (p['functionCall'] is Map<String, dynamic>) {
+        final fc = p['functionCall'] as Map<String, dynamic>;
+        collected.add(
+          LLMToolCallPart(
+            id: (fc['id'] ?? fc['name'] ?? '').toString(),
+            name: (fc['name'] ?? '').toString(),
+            arguments:
+                (fc['args'] as Map<String, dynamic>?) ?? <String, dynamic>{},
+          ),
+        );
+      } else if (p['executableCode'] is Map<String, dynamic>) {
+        final ec = p['executableCode'] as Map<String, dynamic>;
+        collected.add(
+          LLMCodeExecutionPart(
+            code: (ec['code'] ?? '').toString(),
+            language: (ec['language'] ?? '').toString(),
+          ),
+        );
+      } else if (p['codeExecutionResult'] is Map<String, dynamic>) {
+        final cer = p['codeExecutionResult'] as Map<String, dynamic>;
+        collected.add(
+          LLMCodeExecutionResultPart(
+            outcome: (cer['outcome'] ?? '').toString(),
+            output: cer['output'] as String?,
+          ),
+        );
+      }
+    }
+  }
+
+  yield LLMStreamChunk(
+    parts: [
+      if (reasoning.isNotEmpty) LLMReasoningPart(reasoning.toString()),
+      if (text.isNotEmpty) LLMTextPart(text.toString()),
+      ...collected,
+    ],
+    finishReason: LLMFinishReason.parse(rawFinishReason),
+    usage: usageMetadata == null ? null : _parseGeminiUsage(usageMetadata),
+  );
+}
+
+/// Gemini の `inlineData`（base64）を MIME タイプに応じたパーツへ変換する。
+LLMContentPart geminiInlineDataToPart(Map<String, dynamic> blob) {
+  final mime = (blob['mimeType'] ?? '').toString();
+  final b64 = (blob['data'] ?? '').toString();
+  if (mime.startsWith('audio/')) {
+    return LLMAudioPart.base64(b64, mimeType: mime);
+  }
+  if (mime.startsWith('image/')) {
+    return LLMImagePart.bytes(base64Decode(b64), mimeType: mime);
+  }
+  return LLMFilePart.bytes(base64Decode(b64), mimeType: mime);
+}
+
+LLMUsage _parseGeminiUsage(Map<String, dynamic> usage) => LLMUsage(
+      inputTokens: (usage['promptTokenCount'] as num?)?.toInt() ?? 0,
+      outputTokens: (usage['candidatesTokenCount'] as num?)?.toInt() ?? 0,
+      cachedInputTokens: (usage['cachedContentTokenCount'] as num?)?.toInt(),
+      reasoningTokens: (usage['thoughtsTokenCount'] as num?)?.toInt(),
+    );

--- a/pkgs/gemini_box/pubspec.yaml
+++ b/pkgs/gemini_box/pubspec.yaml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  ai_box: ^0.2.0
+  ai_box: ^0.3.0
   api_http: ^0.0.1
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
@@ -23,4 +23,4 @@ topics:
   - ai-box
   - llm
   - google
-version: 0.0.3
+version: 0.0.4

--- a/pkgs/gemini_box/test/gemini_stream_test.dart
+++ b/pkgs/gemini_box/test/gemini_stream_test.dart
@@ -1,0 +1,129 @@
+import 'package:ai_box/ai_box.dart';
+import 'package:gemini_box/gemini_box.dart';
+import 'package:test/test.dart';
+
+/// Gemini の SSE ストリーミング解析（gemini_stream.dart）の検証。
+void main() {
+  Map<String, dynamic> event(
+    List<Map<String, dynamic>> parts, {
+    String? finishReason,
+    Map<String, dynamic>? usage,
+  }) =>
+      {
+        'candidates': [
+          {
+            'content': {'parts': parts, 'role': 'model'},
+            if (finishReason != null) 'finishReason': finishReason,
+          },
+        ],
+        if (usage != null) 'usageMetadata': usage,
+      };
+
+  group('geminiChunksFromEvents', () {
+    test('streams text deltas and assembles the final chunk', () async {
+      final chunks = await geminiChunksFromEvents(
+        Stream.fromIterable([
+          event([
+            {'text': 'Hel'},
+          ]),
+          event(
+            [
+              {'text': 'lo'},
+            ],
+            finishReason: 'STOP',
+            usage: {
+              'promptTokenCount': 4,
+              'candidatesTokenCount': 6,
+              'thoughtsTokenCount': 2,
+            },
+          ),
+        ]),
+      ).toList();
+
+      expect(chunks.map((c) => c.delta).join(), 'Hello');
+      final last = chunks.last;
+      expect(last.isDone, isTrue);
+      expect(last.finishReason, LLMFinishReason.stop);
+      expect((last.parts!.single as LLMTextPart).text, 'Hello');
+      expect(last.usage!.inputTokens, 4);
+      expect(last.usage!.outputTokens, 6);
+      expect(last.usage!.reasoningTokens, 2);
+    });
+
+    test('separates thought parts as reasoning deltas', () async {
+      final chunks = await geminiChunksFromEvents(
+        Stream.fromIterable([
+          event([
+            {'text': 'plan', 'thought': true},
+          ]),
+          event(
+            [
+              {'text': 'answer'},
+            ],
+            finishReason: 'STOP',
+          ),
+        ]),
+      ).toList();
+
+      expect(chunks.map((c) => c.reasoningDelta).join(), 'plan');
+      expect(chunks.map((c) => c.delta).join(), 'answer');
+      final parts = chunks.last.parts!;
+      expect((parts[0] as LLMReasoningPart).text, 'plan');
+      expect((parts[1] as LLMTextPart).text, 'answer');
+    });
+
+    test('collects function calls into the final chunk', () async {
+      final chunks = await geminiChunksFromEvents(
+        Stream.fromIterable([
+          event(
+            [
+              {
+                'functionCall': {
+                  'name': 'get_weather',
+                  'args': {'city': 'Kyoto'},
+                },
+              },
+            ],
+            finishReason: 'STOP',
+          ),
+        ]),
+      ).toList();
+
+      final call = chunks.last.parts!.whereType<LLMToolCallPart>().single;
+      expect(call.name, 'get_weather');
+      expect(call.arguments, {'city': 'Kyoto'});
+    });
+
+    test('falls back to other when no finishReason arrives', () async {
+      final chunks = await geminiChunksFromEvents(
+        Stream.fromIterable([
+          event([
+            {'text': 'x'},
+          ]),
+        ]),
+      ).toList();
+      expect(chunks.last.finishReason, LLMFinishReason.other);
+      expect(chunks.last.usage, isNull);
+    });
+  });
+
+  group('geminiInlineDataToPart', () {
+    test('maps MIME types to image / audio / file parts', () {
+      // 'aGk=' は 'hi' の base64。
+      expect(
+        geminiInlineDataToPart({'mimeType': 'image/png', 'data': 'aGk='}),
+        isA<LLMImagePart>(),
+      );
+      expect(
+        geminiInlineDataToPart({'mimeType': 'audio/wav', 'data': 'aGk='}),
+        isA<LLMAudioPart>(),
+      );
+      expect(
+        geminiInlineDataToPart(
+          {'mimeType': 'application/pdf', 'data': 'aGk='},
+        ),
+        isA<LLMFilePart>(),
+      );
+    });
+  });
+}

--- a/pkgs/grok_box/CHANGELOG.md
+++ b/pkgs/grok_box/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.4
+
+- `completionsStream()` now uses real SSE streaming (incremental text
+  deltas, cross-chunk tool-call assembly) instead of the single-chunk
+  fallback.
+
 ## 0.0.3
 
 - Use the OpenAI-compat layer and HTTP error normalization shared via

--- a/pkgs/grok_box/lib/src/grok.dart
+++ b/pkgs/grok_box/lib/src/grok.dart
@@ -22,6 +22,19 @@ class Grok extends LLMAIBase {
     return parseOpenAiResponse(data);
   }
 
+  /// 真の SSE ストリーミング。テキストは増分で流れ、最終チャンクに
+  /// 完全なパーツ・完了理由が入る。
+  @override
+  Stream<LLMStreamChunk> completionsStream(LLMCompletionRequest request) {
+    return streamOpenAiCompletions(
+      url: _url,
+      apiKey: apiKey,
+      provider: _provider,
+      request: request,
+      maxTokensKey: 'max_tokens',
+    );
+  }
+
   @override
   Future<List<AIModel>> getModels() async {
     final modelList = await GrokCore.listModels(apiKey: apiKey);

--- a/pkgs/grok_box/pubspec.yaml
+++ b/pkgs/grok_box/pubspec.yaml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  ai_box: ^0.2.0
+  ai_box: ^0.3.0
   api_http: ^0.0.1
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
@@ -22,4 +22,4 @@ topics:
   - ai-box
   - llm
   - xai
-version: 0.0.3
+version: 0.0.4

--- a/pkgs/minimax_box/CHANGELOG.md
+++ b/pkgs/minimax_box/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.4
+
+- `completionsStream()` now uses real SSE streaming (incremental text
+  deltas, cross-chunk tool-call assembly) instead of the single-chunk
+  fallback.
+
 ## 0.0.3
 
 - Use the OpenAI-compat layer and HTTP error normalization shared via

--- a/pkgs/minimax_box/lib/src/minimax.dart
+++ b/pkgs/minimax_box/lib/src/minimax.dart
@@ -22,6 +22,19 @@ class MiniMax extends LLMAIBase {
     return parseOpenAiResponse(data);
   }
 
+  /// 真の SSE ストリーミング。テキストは増分で流れ、最終チャンクに
+  /// 完全なパーツ・完了理由が入る。
+  @override
+  Stream<LLMStreamChunk> completionsStream(LLMCompletionRequest request) {
+    return streamOpenAiCompletions(
+      url: _url,
+      apiKey: apiKey,
+      provider: _provider,
+      request: request,
+      maxTokensKey: 'max_tokens',
+    );
+  }
+
   @override
   Future<List<AIModel>> getModels() async {
     final modelList = await MiniMaxCore.listModels(apiKey: apiKey);

--- a/pkgs/minimax_box/pubspec.yaml
+++ b/pkgs/minimax_box/pubspec.yaml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  ai_box: ^0.2.0
+  ai_box: ^0.3.0
   api_http: ^0.0.1
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
@@ -21,4 +21,4 @@ topics:
   - minimax
   - ai-box
   - llm
-version: 0.0.3
+version: 0.0.4

--- a/pkgs/openrouter_box/CHANGELOG.md
+++ b/pkgs/openrouter_box/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.4
+
+- `completionsStream()` now uses real SSE streaming (incremental text /
+  reasoning deltas, cross-chunk tool-call assembly, usage from the final
+  chunk when OpenRouter provides it) instead of the single-chunk fallback.
+
 ## 0.0.3
 
 - Fix: network failures in `getModels()` / `listOpenRouterModels()` /

--- a/pkgs/openrouter_box/lib/src/openrouter.dart
+++ b/pkgs/openrouter_box/lib/src/openrouter.dart
@@ -47,6 +47,21 @@ class OpenRouter extends LLMAIBase {
     return parseOpenAiResponse(data);
   }
 
+  /// 真の SSE ストリーミング。テキストは増分で流れ、最終チャンクに
+  /// 完全なパーツ・完了理由・トークン使用量（OpenRouter は最終チャンクで
+  /// 自動付与）が入る。
+  @override
+  Stream<LLMStreamChunk> completionsStream(LLMCompletionRequest request) {
+    return streamOpenAiCompletions(
+      url: _url,
+      apiKey: apiKey,
+      provider: _provider,
+      request: request,
+      maxTokensKey: 'max_tokens',
+      extraHeaders: _rankingHeaders(),
+    );
+  }
+
   @override
   Future<List<AIModel>> getModels() async {
     final models = await OpenRouterCore.listModels(apiKey: apiKey);

--- a/pkgs/openrouter_box/pubspec.yaml
+++ b/pkgs/openrouter_box/pubspec.yaml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  ai_box: ^0.2.0
+  ai_box: ^0.3.0
   api_http: ^0.0.1
 description: An OpenRouter AI provider based on ai_box.
 dev_dependencies:
@@ -17,4 +17,4 @@ topics:
   - openrouter
   - ai-box
   - llm
-version: 0.0.3
+version: 0.0.4


### PR DESCRIPTION
# 概要

リポジトリ全体を調査し、**最大の機能ギャップだった「真のストリーミング」**を実装しました。

これまで `completionsStream()` は基底クラスのフォールバック（`completions()` の完了を待って全文を 1 チャンクで返す）しかなく、どのプロバイダーも真のストリーミングを実装していませんでした（基底クラスの doc コメント自身が「プロバイダーは真の SSE ストリーミングでオーバーライドできる」と述べている状態）。本 PR で **全 7 プロバイダーがトークン単位の SSE ストリーミング**に対応します。

```dart
await for (final chunk in ai.chatStream(model: '...', messages: [...])) {
  stdout.write(chunk.delta);          // テキスト増分
  log(chunk.reasoningDelta);          // thinking 増分（対応モデルのみ）
  if (chunk.isDone) print(chunk.usage); // 最終チャンク: 完全な parts / finishReason / usage
}
```

## ai_box（0.2.0 → 0.3.0）

- **`provider_http.dart`**: `postSseData()`（SSE POST。`requestJson()` と同じ sealed `LLMException` への正規化 — 非 2xx は `fromHttp`、通信失敗・切断は `LLMNetworkException`）と `decodeSseJson()`（`[DONE]` 等の読み飛ばし）を追加
- **`openai_compat.dart`**: `streamOpenAiCompletions()` / `openAiChunksFromEvents()` を追加
  - テキスト・reasoning（DeepSeek `reasoning_content` / OpenRouter `reasoning`）の増分配信
  - チャンクをまたぐツール呼び出し引数の組み立て
  - ストリーム中 `error` イベントの型付き例外への正規化
- **`LLMStreamChunk`**: `reasoningDelta` を追加。「最終チャンクの `parts` には完全な応答パーツが入る」契約を明文化（最終チャンクだけで応答全体を復元可能）
- **`LLMAIBase`**: `chatStream()`（`chat()` のストリーミング版）を追加
- 小修正: `_audioFormat()` がパラメータ付き MIME（`audio/ogg;codecs=opus` 等）を正しく処理
- 依存に `http: ^1.0.0` を追加（`api_http` が既に内部で使用しているもの）

## プロバイダー

| パッケージ | 実装 |
|---|---|
| chatgpt_box 0.0.5 / deepseek_box 0.0.4 | 共有 SSE + `stream_options.include_usage`（usage も取得） |
| grok_box 0.0.4 / minimax_box 0.0.4 | 共有 SSE（`stream_options` 非対応の可能性を考慮し送信しない保守的構成） |
| openrouter_box 0.0.4 | 共有 SSE + ランキングヘッダ。最終チャンクの usage を解析 |
| claude_box 0.1.3 | Messages API のイベント（`message_start` / `content_block_delta` / `message_delta` / `error`）を解析。thinking・署名・`input_json_delta` のツール組み立て・usage 集計・`error` イベントの型付き例外化。リクエスト構築を `_buildClaudeBody()` に共通化 |
| gemini_box 0.0.4 | `streamGenerateContent` + `alt=sse`。thought パーツ・`functionCall`・生成メディア（`inlineData`）対応。`inlineData` 解析を `geminiInlineDataToPart()` に共通化 |

## テスト（+23 件、すべてネットワーク不要）

- `ai_box/test/sse_test.dart`: SSE トランスポートを**ローカル HTTP サーバー**で検証（複数行 data の連結・CRLF・コメント行・エラーステータスの正規化・接続失敗）
- `ai_box/test/openai_stream_test.dart`: チャンク解析（テキスト/reasoning 増分・ツール組み立て・usage チャンク・error イベント）+ エンドツーエンド（`stream: true` 送信確認）
- `claude_box/test/claude_stream_test.dart` / `gemini_box/test/gemini_stream_test.dart`: 各イベント列の解析検証

## ドキュメント

- README のストリーミング節を更新（「単一チャンクのフォールバック」注記を削除し、`chatStream()` の使い方を追加）
- README の古い記述を修正: 「Required Methods」が実際のインターフェース（`completions()` / `getModels()` / `validateKey()`）と不一致だった点、および**リポジトリに存在しない** `runLLMAIBaseCommonTests()` / `test_utils.dart` のセクションを削除

## 設計メモ

- SSE ヘルパーは `io.dart` / `provider_http.dart` と同じく opt-in import で、`package:ai_box/ai_box.dart`（アプリ向け公開 API）からはエクスポートされません
- `claude_stream.dart` / `gemini_stream.dart` の barrel 追加は auto_exporter の生成結果と一致することを build_runner 実行で確認済み
- 公開時は ai_box 0.3.0 を先に publish してください（各プロバイダーは `ai_box: ^0.3.0` に依存）

## 検証

- 全 8 パッケージで `dart analyze`: issues なし
- 全テスト pass（ai_box 47 / claude_box 4 / gemini_box 5 / openrouter_box 9）
- `dart format --set-exit-if-changed .`: クリーン

https://claude.ai/code/session_019gCqjRKBEbDyJWbM6PcA6b

---
_Generated by [Claude Code](https://claude.ai/code/session_019gCqjRKBEbDyJWbM6PcA6b)_