### PR TITLE
improve: gemini ファイル API のエラー処理修正・README 刷新・テスト追加・pubspec 整備

### DIFF
--- a/pkgs/ai_box/pubspec.yaml
+++ b/pkgs/ai_box/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
   sdk: ^3.0.0
 name: ai_box
 homepage: https://github.com/normidar/ai_box
+repository: https://github.com/normidar/ai_box
 topics:
   - ai
   - chatgpt

--- a/pkgs/chatgpt_box/README.md
+++ b/pkgs/chatgpt_box/README.md
@@ -1,103 +1,63 @@
-# ai_box
+# chatgpt_box
 
 [![GitHub](https://img.shields.io/github/license/normidar/ai_box.svg)](https://github.com/normidar/ai_box/blob/main/LICENSE)
-[![pub package](https://img.shields.io/pub/v/ai_box.svg)](https://pub.dartlang.org/packages/ai_box)
+[![pub package](https://img.shields.io/pub/v/chatgpt_box.svg)](https://pub.dev/packages/chatgpt_box)
 [![GitHub Stars](https://img.shields.io/github/stars/normidar/ai_box.svg)](https://github.com/normidar/ai_box/stargazers)
-[![Twitter](https://img.shields.io/twitter/url/https/twitter.com/normidar.svg?style=social&label=Follow%20%40normidar)](https://twitter.com/normidar)
 [![Github-sponsors](https://img.shields.io/badge/sponsor-30363D?logo=GitHub-Sponsors&logoColor=#EA4AAA)](https://github.com/sponsors/normidar)
 
-This package provides a base class and test utilities for all AI provider classes that inherit from `LLMAIBase`.
+An OpenAI (ChatGPT) provider based on [ai_box](https://github.com/normidar/ai_box).
 
-## LLMAIBase
-
-An abstract class that all AI providers (such as ChatGPT, Claude, Gemini, etc.) should inherit from.
-
-### Required Methods
-
-- `chat()`: Chat functionality
-- `getModelIds()`: Get a list of available model IDs
-- `validateKey()`: Validate the API key
-
-### Provided Utility Methods
-
-- `chatWithStrings()`: Chat with an array of strings
-- `generateText()`: Simple text generation
-
-## Common Tests
-
-By using the `runLLMAIBaseCommonTests()` function, you can ensure that all `LLMAIBase` implementation classes are tested to the same standard.
-
-### Usage Example
+## Usage
 
 ```dart
-import 'package:test/test.dart';
-import 'package:your_ai_package/your_ai_package.dart';
+import 'package:ai_box/ai_box.dart';
+import 'package:chatgpt_box/chatgpt_box.dart';
 
-// Import the test utilities from ai_box
-import '../ai_box/test/test_utils.dart';
+Future<void> main() async {
+  final ai = ChatGPT(apiKey: 'sk-...');
 
-void main() {
-  // Run the common tests
-  runLLMAIBaseCommonTests(
-    createInstance: () => YourAIClass(apiKey: 'your-api-key'),
-    instanceName: 'YourAI',
-    testModel: 'your-model-name',
-    skipApiTests: false, // Set to false to perform actual API calls
+  // One-shot text generation.
+  final answer = await ai.generateText(
+    model: 'gpt-4o-mini',
+    message: 'Say hello in one short sentence.',
   );
+  print(answer);
 
-  // Add any additional specific tests here
-  group('YourAI Specific Tests', () {
-    // ...
-  });
+  // Multi-turn chat.
+  final res = await ai.chat(
+    model: 'gpt-4o-mini',
+    messages: [
+      LLMContent.system('You are concise.'),
+      LLMContent.user('What is the capital of Japan?'),
+    ],
+    maxTokens: 32,
+  );
+  print(res.text);
+  print(res.usage); // token usage
 }
 ```
 
-### Parameters
+## Streaming
 
-- `createInstance`: A function that creates an instance of the LLMAIBase to be tested.
-- `instanceName`: The name of the class being tested (for display purposes in tests).
-- `testModel`: The name of the model to be used for testing.
-- `skipApiTests`: Whether to skip tests that involve API calls (default: false).
+True SSE streaming — text arrives incrementally and the final chunk carries
+the finish reason and token usage:
 
-### Test Contents
+```dart
+await for (final text in ai.generateTextStream(
+  model: 'gpt-4o-mini',
+  message: 'Write a haiku about Dart.',
+)) {
+  stdout.write(text);
+}
+```
 
-The common tests include the following:
+## Models and key validation
 
-#### Basic Tests
+```dart
+final models = await ai.getModels();
+final ok = await ai.validateKey();
+```
 
-- The instance is created correctly.
-- The API key is set.
-
-#### API Functionality Tests (if skipApiTests=false)
-
-- The API key can be validated.
-- Available model IDs can be retrieved.
-- The chat functionality works.
-- The chat functionality with strings works.
-- The text generation functionality works.
-- The `maxTokens` parameter is applied.
-
-#### Class Tests
-
-- `LLMContent` is created correctly.
-- The values of `LLMRole` are correct.
-
-#### Error Handling Tests
-
-- An error occurs with an empty message list.
-- An error occurs with an invalid model name.
-
-## Adding a New AI Provider
-
-1. Create a class that inherits from `LLMAIBase`.
-2. Implement the required methods.
-3. Import `../ai_box/test/test_utils.dart` in the test file.
-4. Call `runLLMAIBaseCommonTests()`.
-5. Add specific tests as needed.
-
-This ensures that all AI providers maintain consistent quality.
-
-### Notes
-
-- The test utilities are located in the `test` folder and are not included in the main `lib` folder.
-- This prevents the `test` package dependency from being included in the production code.
+Multimodal input (images, audio, files), tool calling, structured output
+(JSON Schema) and the sealed `LLMException` error hierarchy are all provided
+by [ai_box](https://pub.dev/packages/ai_box) — see its README for details.

--- a/pkgs/chatgpt_box/pubspec.yaml
+++ b/pkgs/chatgpt_box/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
   json_annotation: ^4.9.0
 description: A chatgpt AI provider based on ai_box.
 dev_dependencies:
-  auto_exporter: any
+  auto_exporter: ^4.0.0
   build_runner: ^2.5.4
   freezed: ^3.0.6
   json_serializable: ^6.9.5
@@ -15,6 +15,7 @@ dev_dependencies:
 environment:
   sdk: ^3.7.0
 homepage: https://github.com/normidar/ai_box
+repository: https://github.com/normidar/ai_box
 name: chatgpt_box
 topics:
   - ai

--- a/pkgs/chatgpt_box/test/chatgpt_box_test.dart
+++ b/pkgs/chatgpt_box/test/chatgpt_box_test.dart
@@ -1,0 +1,114 @@
+import 'package:ai_box/ai_box.dart';
+import 'package:chatgpt_box/chatgpt_box.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ChatCompletionObject.fromJson', () {
+    final json = <String, dynamic>{
+      'id': 'chatcmpl-123',
+      'object': 'chat.completion',
+      'created': 1721260800,
+      'model': 'gpt-4o-mini',
+      'system_fingerprint': 'fp_abc',
+      'service_tier': 'default',
+      'choices': [
+        {
+          'index': 0,
+          'finish_reason': 'stop',
+          'message': {
+            'role': 'assistant',
+            'content': 'Hello!',
+          },
+        },
+      ],
+      'usage': {
+        'prompt_tokens': 10,
+        'completion_tokens': 5,
+        'total_tokens': 15,
+        'completion_tokens_details': {
+          'accepted_prediction_tokens': 0,
+          'audio_tokens': 0,
+          'reasoning_tokens': 0,
+          'rejected_prediction_tokens': 0,
+        },
+        'prompt_tokens_details': {
+          'audio_tokens': 0,
+          'cached_tokens': 2,
+        },
+      },
+    };
+
+    test('parses a full response', () {
+      final res = ChatCompletionObject.fromJson(json);
+      expect(res.id, 'chatcmpl-123');
+      expect(res.model, 'gpt-4o-mini');
+      expect(res.systemFingerprint, 'fp_abc');
+      expect(res.serviceTier, 'default');
+      expect(res.choices, hasLength(1));
+      expect(res.choices.first.message.content, 'Hello!');
+      expect(res.choices.first.finishReason, 'stop');
+      expect(res.usage.promptTokens, 10);
+      expect(res.usage.completionTokens, 5);
+      expect(res.usage.totalTokens, 15);
+      expect(res.usage.promptTokensDetails.cachedTokens, 2);
+    });
+
+    test('parses a tool-call message', () {
+      final res = ChatCompletionObject.fromJson({
+        ...json,
+        'choices': [
+          {
+            'index': 0,
+            'finish_reason': 'tool_calls',
+            'message': {
+              'role': 'assistant',
+              'content': null,
+              'tool_calls': [
+                {
+                  'id': 'call_1',
+                  'type': 'function',
+                  'function': {
+                    'name': 'get_weather',
+                    'arguments': '{"city":"Tokyo"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+      final message = res.choices.first.message;
+      expect(res.choices.first.finishReason, 'tool_calls');
+      expect(message.content, isNull);
+      expect(message.toolCalls, hasLength(1));
+      expect(message.toolCalls?.first['id'], 'call_1');
+    });
+  });
+
+  group('ModelList.fromJson', () {
+    test('parses the model list', () {
+      final list = ModelList.fromJson({
+        'object': 'list',
+        'data': [
+          {
+            'id': 'gpt-4o-mini',
+            'object': 'model',
+            'created': 1721260800,
+            'owned_by': 'openai',
+          },
+        ],
+      });
+      expect(list.data, hasLength(1));
+      expect(list.data.first.id, 'gpt-4o-mini');
+      expect(list.data.first.ownedBy, 'openai');
+    });
+  });
+
+  group('ChatGPT client', () {
+    test('is an LLMAIBase with the api key set', () {
+      final ai = ChatGPT(apiKey: 'sk-test');
+      expect(ai.apiKey, 'sk-test');
+      expect(ai, isA<LLMAIBase>());
+    });
+  });
+}

--- a/pkgs/claude_box/README.md
+++ b/pkgs/claude_box/README.md
@@ -1,103 +1,63 @@
-# ai_box
+# claude_box
 
 [![GitHub](https://img.shields.io/github/license/normidar/ai_box.svg)](https://github.com/normidar/ai_box/blob/main/LICENSE)
-[![pub package](https://img.shields.io/pub/v/ai_box.svg)](https://pub.dartlang.org/packages/ai_box)
+[![pub package](https://img.shields.io/pub/v/claude_box.svg)](https://pub.dev/packages/claude_box)
 [![GitHub Stars](https://img.shields.io/github/stars/normidar/ai_box.svg)](https://github.com/normidar/ai_box/stargazers)
-[![Twitter](https://img.shields.io/twitter/url/https/twitter.com/normidar.svg?style=social&label=Follow%20%40normidar)](https://twitter.com/normidar)
 [![Github-sponsors](https://img.shields.io/badge/sponsor-30363D?logo=GitHub-Sponsors&logoColor=#EA4AAA)](https://github.com/sponsors/normidar)
 
-This package provides a base class and test utilities for all AI provider classes that inherit from `LLMAIBase`.
+An Anthropic (Claude) provider based on [ai_box](https://github.com/normidar/ai_box).
 
-## LLMAIBase
-
-An abstract class that all AI providers (such as ChatGPT, Claude, Gemini, etc.) should inherit from.
-
-### Required Methods
-
-- `chat()`: Chat functionality
-- `getModelIds()`: Get a list of available model IDs
-- `validateKey()`: Validate the API key
-
-### Provided Utility Methods
-
-- `chatWithStrings()`: Chat with an array of strings
-- `generateText()`: Simple text generation
-
-## Common Tests
-
-By using the `runLLMAIBaseCommonTests()` function, you can ensure that all `LLMAIBase` implementation classes are tested to the same standard.
-
-### Usage Example
+## Usage
 
 ```dart
-import 'package:test/test.dart';
-import 'package:your_ai_package/your_ai_package.dart';
+import 'package:ai_box/ai_box.dart';
+import 'package:claude_box/claude_box.dart';
 
-// Import the test utilities from ai_box
-import '../ai_box/test/test_utils.dart';
+Future<void> main() async {
+  final ai = Claude(apiKey: 'sk-ant-...');
 
-void main() {
-  // Run the common tests
-  runLLMAIBaseCommonTests(
-    createInstance: () => YourAIClass(apiKey: 'your-api-key'),
-    instanceName: 'YourAI',
-    testModel: 'your-model-name',
-    skipApiTests: false, // Set to false to perform actual API calls
+  // One-shot text generation.
+  final answer = await ai.generateText(
+    model: 'claude-sonnet-4-6',
+    message: 'Say hello in one short sentence.',
   );
+  print(answer);
 
-  // Add any additional specific tests here
-  group('YourAI Specific Tests', () {
-    // ...
-  });
+  // Multi-turn chat.
+  final res = await ai.chat(
+    model: 'claude-sonnet-4-6',
+    messages: [
+      LLMContent.system('You are concise.'),
+      LLMContent.user('What is the capital of Japan?'),
+    ],
+    maxTokens: 32,
+  );
+  print(res.text);
+  print(res.usage); // token usage
 }
 ```
 
-### Parameters
+## Streaming
 
-- `createInstance`: A function that creates an instance of the LLMAIBase to be tested.
-- `instanceName`: The name of the class being tested (for display purposes in tests).
-- `testModel`: The name of the model to be used for testing.
-- `skipApiTests`: Whether to skip tests that involve API calls (default: false).
+True SSE streaming — text arrives incrementally and the final chunk carries
+the finish reason and token usage:
 
-### Test Contents
+```dart
+await for (final text in ai.generateTextStream(
+  model: 'claude-sonnet-4-6',
+  message: 'Write a haiku about Dart.',
+)) {
+  stdout.write(text);
+}
+```
 
-The common tests include the following:
+## Models and key validation
 
-#### Basic Tests
+```dart
+final models = await ai.getModels();
+final ok = await ai.validateKey();
+```
 
-- The instance is created correctly.
-- The API key is set.
-
-#### API Functionality Tests (if skipApiTests=false)
-
-- The API key can be validated.
-- Available model IDs can be retrieved.
-- The chat functionality works.
-- The chat functionality with strings works.
-- The text generation functionality works.
-- The `maxTokens` parameter is applied.
-
-#### Class Tests
-
-- `LLMContent` is created correctly.
-- The values of `LLMRole` are correct.
-
-#### Error Handling Tests
-
-- An error occurs with an empty message list.
-- An error occurs with an invalid model name.
-
-## Adding a New AI Provider
-
-1. Create a class that inherits from `LLMAIBase`.
-2. Implement the required methods.
-3. Import `../ai_box/test/test_utils.dart` in the test file.
-4. Call `runLLMAIBaseCommonTests()`.
-5. Add specific tests as needed.
-
-This ensures that all AI providers maintain consistent quality.
-
-### Notes
-
-- The test utilities are located in the `test` folder and are not included in the main `lib` folder.
-- This prevents the `test` package dependency from being included in the production code.
+Multimodal input (images, files), tool calling, structured output and the
+sealed `LLMException` error hierarchy are all provided by
+[ai_box](https://pub.dev/packages/ai_box) — see its README for details.

--- a/pkgs/claude_box/pubspec.yaml
+++ b/pkgs/claude_box/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
   json_annotation: ^4.9.0
 description: A claude AI provider based on ai_box.
 dev_dependencies:
-  auto_exporter: any
+  auto_exporter: ^4.0.0
   build_runner: ^2.4.15
   freezed: ^3.0.6
   json_serializable: ^6.9.5
@@ -16,6 +16,7 @@ environment:
   sdk: ^3.2.0
 name: claude_box
 homepage: https://github.com/normidar/ai_box
+repository: https://github.com/normidar/ai_box
 topics:
   - ai
   - claude

--- a/pkgs/deepseek_box/README.md
+++ b/pkgs/deepseek_box/README.md
@@ -1,3 +1,77 @@
 # deepseek_box
 
+[![GitHub](https://img.shields.io/github/license/normidar/ai_box.svg)](https://github.com/normidar/ai_box/blob/main/LICENSE)
+[![pub package](https://img.shields.io/pub/v/deepseek_box.svg)](https://pub.dev/packages/deepseek_box)
+[![GitHub Stars](https://img.shields.io/github/stars/normidar/ai_box.svg)](https://github.com/normidar/ai_box/stargazers)
+[![Github-sponsors](https://img.shields.io/badge/sponsor-30363D?logo=GitHub-Sponsors&logoColor=#EA4AAA)](https://github.com/sponsors/normidar)
+
 A DeepSeek AI provider based on [ai_box](https://github.com/normidar/ai_box).
+
+## Usage
+
+```dart
+import 'package:ai_box/ai_box.dart';
+import 'package:deepseek_box/deepseek_box.dart';
+
+Future<void> main() async {
+  final ai = DeepSeek(apiKey: 'sk-...');
+
+  // One-shot text generation.
+  final answer = await ai.generateText(
+    model: 'deepseek-chat',
+    message: 'Say hello in one short sentence.',
+  );
+  print(answer);
+
+  // Multi-turn chat.
+  final res = await ai.chat(
+    model: 'deepseek-chat',
+    messages: [
+      LLMContent.system('You are concise.'),
+      LLMContent.user('What is the capital of Japan?'),
+    ],
+    maxTokens: 32,
+  );
+  print(res.text);
+  print(res.usage); // token usage
+}
+```
+
+## Reasoning model
+
+With `deepseek-reasoner`, the model's chain of thought is exposed through
+the common ai_box reasoning API:
+
+```dart
+final res = await ai.chat(
+  model: 'deepseek-reasoner',
+  messages: [LLMContent.user('What is 17 * 24?')],
+);
+print(res.content.reasoning); // thinking
+print(res.text); // final answer
+```
+
+## Streaming
+
+True SSE streaming — text arrives incrementally and the final chunk carries
+the finish reason and token usage:
+
+```dart
+await for (final text in ai.generateTextStream(
+  model: 'deepseek-chat',
+  message: 'Write a haiku about Dart.',
+)) {
+  stdout.write(text);
+}
+```
+
+## Models and key validation
+
+```dart
+final models = await ai.getModels();
+final ok = await ai.validateKey();
+```
+
+Tool calling, structured output and the sealed `LLMException` error
+hierarchy are all provided by [ai_box](https://pub.dev/packages/ai_box) —
+see its README for details.

--- a/pkgs/deepseek_box/pubspec.yaml
+++ b/pkgs/deepseek_box/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
   json_annotation: ^4.9.0
 description: A DeepSeek AI provider based on ai_box.
 dev_dependencies:
-  auto_exporter: any
+  auto_exporter: ^4.0.0
   build_runner: ^2.5.4
   freezed: ^3.0.6
   json_serializable: ^6.9.5
@@ -15,6 +15,7 @@ dev_dependencies:
 environment:
   sdk: ^3.2.0
 homepage: https://github.com/normidar/ai_box
+repository: https://github.com/normidar/ai_box
 name: deepseek_box
 topics:
   - ai

--- a/pkgs/deepseek_box/test/deepseek_box_test.dart
+++ b/pkgs/deepseek_box/test/deepseek_box_test.dart
@@ -1,0 +1,99 @@
+import 'package:ai_box/ai_box.dart';
+import 'package:deepseek_box/deepseek_box.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ChatCompletionResponse.fromJson', () {
+    final json = <String, dynamic>{
+      'id': 'chatcmpl-123',
+      'object': 'chat.completion',
+      'created': 1721260800,
+      'model': 'deepseek-chat',
+      'system_fingerprint': 'fp_abc',
+      'choices': [
+        {
+          'index': 0,
+          'message': {
+            'role': 'assistant',
+            'content': 'Hello!',
+            'reasoning_content': 'The user greeted me.',
+          },
+          'finish_reason': 'stop',
+        },
+      ],
+      'usage': {
+        'prompt_tokens': 10,
+        'completion_tokens': 5,
+        'total_tokens': 15,
+        'prompt_cache_hit_tokens': 2,
+        'prompt_cache_miss_tokens': 8,
+        'completion_tokens_details': {'reasoning_tokens': 3},
+      },
+    };
+
+    test('parses a full response', () {
+      final res = ChatCompletionResponse.fromJson(json);
+      expect(res.id, 'chatcmpl-123');
+      expect(res.model, 'deepseek-chat');
+      expect(res.systemFingerprint, 'fp_abc');
+      expect(res.choices, hasLength(1));
+      expect(res.choices.first.message.content, 'Hello!');
+      expect(
+        res.choices.first.message.reasoningContent,
+        'The user greeted me.',
+      );
+      expect(res.choices.first.finishReason, 'stop');
+      expect(res.usage?.promptTokens, 10);
+      expect(res.usage?.completionTokens, 5);
+      expect(res.usage?.totalTokens, 15);
+      expect(res.usage?.promptCacheHitTokens, 2);
+      expect(res.usage?.completionTokensDetails?.reasoningTokens, 3);
+    });
+
+    test('tolerates missing optional fields', () {
+      final res = ChatCompletionResponse.fromJson({
+        'id': 'chatcmpl-1',
+        'object': 'chat.completion',
+        'created': 1,
+        'model': 'deepseek-chat',
+        'choices': [
+          {
+            'index': 0,
+            'message': {'role': 'assistant'},
+          },
+        ],
+      });
+      expect(res.systemFingerprint, isNull);
+      expect(res.usage, isNull);
+      expect(res.choices.first.finishReason, isNull);
+      expect(res.choices.first.message.content, isNull);
+    });
+  });
+
+  group('ModelList.fromJson', () {
+    test('parses the model list', () {
+      final list = ModelList.fromJson({
+        'object': 'list',
+        'data': [
+          {'id': 'deepseek-chat', 'object': 'model', 'owned_by': 'deepseek'},
+          {
+            'id': 'deepseek-reasoner',
+            'object': 'model',
+            'owned_by': 'deepseek',
+          },
+        ],
+      });
+      expect(list.data, hasLength(2));
+      expect(list.data.first.id, 'deepseek-chat');
+      expect(list.data.first.ownedBy, 'deepseek');
+    });
+  });
+
+  group('DeepSeek client', () {
+    test('is an LLMAIBase with the api key set', () {
+      final ai = DeepSeek(apiKey: 'sk-test');
+      expect(ai.apiKey, 'sk-test');
+      expect(ai, isA<LLMAIBase>());
+    });
+  });
+}

--- a/pkgs/gemini_box/lib/src/gemini_api/gemini_files_core.dart
+++ b/pkgs/gemini_box/lib/src/gemini_api/gemini_files_core.dart
@@ -1,10 +1,13 @@
 import 'dart:io';
 
+import 'package:ai_box/ai_box.dart';
 import 'package:api_http/api_http.dart' as ac;
 import 'package:gemini_box/gemini_box.dart';
 import 'package:mime/mime.dart';
 
 class GeminiFilesCore {
+  static const _provider = 'gemini';
+
   static Future<List<GeminiFile>> getFiles({
     required String apiKey,
   }) async {
@@ -19,12 +22,27 @@ class GeminiFilesCore {
     final body = response.body;
     switch (body) {
       case ac.MapJsonResponseBody():
-        return (body.data['files'] as List)
+        // ファイルが 1 件もないとき、API は `files` キーなしの
+        // `{}` を返す。
+        final files = body.data['files'];
+        if (files == null) return const [];
+        if (files is! List) {
+          throw LLMUnknownException(
+            'Unexpected `files` field in response: $files',
+            provider: _provider,
+            raw: body.data,
+          );
+        }
+        return files
             .cast<Map<String, dynamic>>()
             .map(GeminiFile.fromJson)
             .toList();
       default:
-        throw Exception('Invalid response body: $body');
+        throw LLMUnknownException(
+          'Invalid response body: $body',
+          provider: _provider,
+          raw: body,
+        );
     }
   }
 
@@ -63,20 +81,28 @@ class GeminiFilesCore {
 
     final headers = response.headers.toJson();
 
-    return headers['x-goog-upload-url']!;
+    final uploadUrl = headers['x-goog-upload-url'];
+    if (uploadUrl == null) {
+      throw LLMUnknownException(
+        'Upload-start response did not include the x-goog-upload-url header',
+        provider: _provider,
+        raw: headers,
+      );
+    }
+    return uploadUrl;
   }
 
   static Future<GeminiFile> uploadFile({
     required String apiKey,
     required File file,
   }) async {
-    final mimeType = lookupMimeType(file.path);
+    final mimeType = lookupMimeType(file.path) ?? 'application/octet-stream';
     final contentLength = file.lengthSync();
     final displayName = file.path.split('/').last;
     final uploadUrl = await getUploadUrl(
       apiKey: apiKey,
       displayName: displayName,
-      mimeType: mimeType!,
+      mimeType: mimeType,
       contentLength: contentLength,
     );
 
@@ -108,9 +134,21 @@ class GeminiFilesCore {
     final body = response.body;
     switch (body) {
       case ac.MapJsonResponseBody():
-        return GeminiFile.fromJson(body.data['file'] as Map<String, dynamic>);
+        final fileJson = body.data['file'];
+        if (fileJson is! Map<String, dynamic>) {
+          throw LLMUnknownException(
+            'Upload response did not include a `file` object',
+            provider: _provider,
+            raw: body.data,
+          );
+        }
+        return GeminiFile.fromJson(fileJson);
       default:
-        throw Exception('Invalid response body: $body');
+        throw LLMUnknownException(
+          'Invalid response body: $body',
+          provider: _provider,
+          raw: body,
+        );
     }
   }
 }

--- a/pkgs/gemini_box/pubspec.yaml
+++ b/pkgs/gemini_box/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   mime: ^1.0.4
 description: A gemini AI provider based on ai_box.
 dev_dependencies:
-  auto_exporter: any
+  auto_exporter: ^4.0.0
   build_runner: ^2.4.15
   freezed: ^3.0.6
   json_serializable: ^6.9.5
@@ -16,6 +16,7 @@ dev_dependencies:
 environment:
   sdk: ^3.4.0
 homepage: https://github.com/normidar/ai_box
+repository: https://github.com/normidar/ai_box
 name: gemini_box
 topics:
   - ai

--- a/pkgs/grok_box/README.md
+++ b/pkgs/grok_box/README.md
@@ -1,103 +1,66 @@
-# ai_box
+# grok_box
 
 [![GitHub](https://img.shields.io/github/license/normidar/ai_box.svg)](https://github.com/normidar/ai_box/blob/main/LICENSE)
-[![pub package](https://img.shields.io/pub/v/ai_box.svg)](https://pub.dartlang.org/packages/ai_box)
+[![pub package](https://img.shields.io/pub/v/grok_box.svg)](https://pub.dev/packages/grok_box)
 [![GitHub Stars](https://img.shields.io/github/stars/normidar/ai_box.svg)](https://github.com/normidar/ai_box/stargazers)
-[![Twitter](https://img.shields.io/twitter/url/https/twitter.com/normidar.svg?style=social&label=Follow%20%40normidar)](https://twitter.com/normidar)
 [![Github-sponsors](https://img.shields.io/badge/sponsor-30363D?logo=GitHub-Sponsors&logoColor=#EA4AAA)](https://github.com/sponsors/normidar)
 
-This package provides a base class and test utilities for all AI provider classes that inherit from `LLMAIBase`.
+An xAI (Grok) provider based on [ai_box](https://github.com/normidar/ai_box).
 
-## LLMAIBase
-
-An abstract class that all AI providers (such as ChatGPT, Claude, Gemini, etc.) should inherit from.
-
-### Required Methods
-
-- `chat()`: Chat functionality
-- `getModelIds()`: Get a list of available model IDs
-- `validateKey()`: Validate the API key
-
-### Provided Utility Methods
-
-- `chatWithStrings()`: Chat with an array of strings
-- `generateText()`: Simple text generation
-
-## Common Tests
-
-By using the `runLLMAIBaseCommonTests()` function, you can ensure that all `LLMAIBase` implementation classes are tested to the same standard.
-
-### Usage Example
+## Usage
 
 ```dart
-import 'package:test/test.dart';
-import 'package:your_ai_package/your_ai_package.dart';
+import 'package:ai_box/ai_box.dart';
+import 'package:grok_box/grok_box.dart';
 
-// Import the test utilities from ai_box
-import '../ai_box/test/test_utils.dart';
+Future<void> main() async {
+  final ai = Grok(apiKey: 'xai-...');
 
-void main() {
-  // Run the common tests
-  runLLMAIBaseCommonTests(
-    createInstance: () => YourAIClass(apiKey: 'your-api-key'),
-    instanceName: 'YourAI',
-    testModel: 'your-model-name',
-    skipApiTests: false, // Set to false to perform actual API calls
+  // One-shot text generation.
+  final answer = await ai.generateText(
+    model: 'grok-3',
+    message: 'Say hello in one short sentence.',
   );
+  print(answer);
 
-  // Add any additional specific tests here
-  group('YourAI Specific Tests', () {
-    // ...
-  });
+  // Multi-turn chat.
+  final res = await ai.chat(
+    model: 'grok-3',
+    messages: [
+      LLMContent.system('You are concise.'),
+      LLMContent.user('What is the capital of Japan?'),
+    ],
+    maxTokens: 32,
+  );
+  print(res.text);
+  print(res.usage); // token usage
 }
 ```
 
-### Parameters
+## Streaming
 
-- `createInstance`: A function that creates an instance of the LLMAIBase to be tested.
-- `instanceName`: The name of the class being tested (for display purposes in tests).
-- `testModel`: The name of the model to be used for testing.
-- `skipApiTests`: Whether to skip tests that involve API calls (default: false).
+True SSE streaming — text arrives incrementally and the final chunk carries
+the finish reason:
 
-### Test Contents
+```dart
+await for (final text in ai.generateTextStream(
+  model: 'grok-3',
+  message: 'Write a haiku about Dart.',
+)) {
+  stdout.write(text);
+}
+```
 
-The common tests include the following:
+## Models and key validation
 
-#### Basic Tests
+```dart
+final models = await ai.getModels();
 
-- The instance is created correctly.
-- The API key is set.
+// validateKey() checks the key against xAI's api-key endpoint and also
+// verifies the key/team is not blocked or disabled.
+final ok = await ai.validateKey();
+```
 
-#### API Functionality Tests (if skipApiTests=false)
-
-- The API key can be validated.
-- Available model IDs can be retrieved.
-- The chat functionality works.
-- The chat functionality with strings works.
-- The text generation functionality works.
-- The `maxTokens` parameter is applied.
-
-#### Class Tests
-
-- `LLMContent` is created correctly.
-- The values of `LLMRole` are correct.
-
-#### Error Handling Tests
-
-- An error occurs with an empty message list.
-- An error occurs with an invalid model name.
-
-## Adding a New AI Provider
-
-1. Create a class that inherits from `LLMAIBase`.
-2. Implement the required methods.
-3. Import `../ai_box/test/test_utils.dart` in the test file.
-4. Call `runLLMAIBaseCommonTests()`.
-5. Add specific tests as needed.
-
-This ensures that all AI providers maintain consistent quality.
-
-### Notes
-
-- The test utilities are located in the `test` folder and are not included in the main `lib` folder.
-- This prevents the `test` package dependency from being included in the production code.
+Multimodal input, tool calling, structured output and the sealed
+`LLMException` error hierarchy are all provided by
+[ai_box](https://pub.dev/packages/ai_box) — see its README for details.

--- a/pkgs/grok_box/pubspec.yaml
+++ b/pkgs/grok_box/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
   json_annotation: ^4.9.0
 description: A grok AI provider based on ai_box.
 dev_dependencies:
-  auto_exporter: any
+  auto_exporter: ^4.0.0
   build_runner: ^2.5.4
   freezed: ^3.0.6
   json_serializable: ^6.9.5
@@ -15,6 +15,7 @@ dev_dependencies:
 environment:
   sdk: ^3.2.0
 homepage: https://github.com/normidar/ai_box
+repository: https://github.com/normidar/ai_box
 name: grok_box
 topics:
   - ai

--- a/pkgs/grok_box/test/grok_box_test.dart
+++ b/pkgs/grok_box/test/grok_box_test.dart
@@ -1,0 +1,124 @@
+import 'package:ai_box/ai_box.dart';
+import 'package:grok_box/grok_box.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ChatCompletionResponse.fromJson', () {
+    final json = <String, dynamic>{
+      'id': 'chatcmpl-123',
+      'object': 'chat.completion',
+      'created': 1721260800,
+      'model': 'grok-3',
+      'choices': [
+        {
+          'index': 0,
+          'message': {
+            'role': 'assistant',
+            'content': 'Hello!',
+          },
+          'finish_reason': 'stop',
+        },
+      ],
+      'usage': {
+        'prompt_tokens': 10,
+        'completion_tokens': 5,
+        'total_tokens': 15,
+        'number_searches': 0,
+        'prompt_tokens_details': {
+          'audio_tokens': 0,
+          'cached_tokens': 2,
+          'image_tokens': 0,
+          'text_tokens': 10,
+        },
+        'completion_tokens_details': {
+          'accepted_prediction_tokens': 0,
+          'audio_tokens': 0,
+          'reasoning_tokens': 3,
+          'rejected_prediction_tokens': 0,
+        },
+      },
+    };
+
+    test('parses a full response', () {
+      final res = ChatCompletionResponse.fromJson(json);
+      expect(res.id, 'chatcmpl-123');
+      expect(res.model, 'grok-3');
+      expect(res.choices, hasLength(1));
+      expect(res.choices.first.message.content, 'Hello!');
+      expect(res.choices.first.finishReason, 'stop');
+      expect(res.usage?.promptTokens, 10);
+      expect(res.usage?.totalTokens, 15);
+      expect(res.usage?.promptTokensDetails?.cachedTokens, 2);
+      expect(res.usage?.completionTokensDetails?.reasoningTokens, 3);
+    });
+
+    test('tolerates missing optional fields', () {
+      final res = ChatCompletionResponse.fromJson({
+        'id': 'chatcmpl-1',
+        'object': 'chat.completion',
+        'created': 1,
+        'model': 'grok-3',
+        'choices': [
+          {
+            'index': 0,
+            'message': {'role': 'assistant'},
+          },
+        ],
+      });
+      expect(res.usage, isNull);
+      expect(res.citations, isNull);
+      expect(res.choices.first.finishReason, isNull);
+    });
+  });
+
+  group('ModelList.fromJson', () {
+    test('parses the model list', () {
+      final list = ModelList.fromJson({
+        'object': 'list',
+        'data': [
+          {
+            'id': 'grok-3',
+            'created': 1721260800,
+            'object': 'model',
+            'owned_by': 'xai',
+          },
+        ],
+      });
+      expect(list.data, hasLength(1));
+      expect(list.data.first.id, 'grok-3');
+      expect(list.data.first.created, 1721260800);
+    });
+  });
+
+  group('ApiKeyInfo.fromJson', () {
+    test('parses the api-key endpoint response', () {
+      final info = ApiKeyInfo.fromJson({
+        'acls': ['api-key:model:*', 'api-key:endpoint:*'],
+        'api_key_blocked': false,
+        'api_key_disabled': false,
+        'api_key_id': 'key-id',
+        'create_time': '2024-01-01T00:00:00Z',
+        'modified_by': 'user-1',
+        'modify_time': '2024-01-02T00:00:00Z',
+        'name': 'my key',
+        'redacted_api_key': 'xai-...abc',
+        'team_blocked': false,
+        'team_id': 'team-1',
+        'user_id': 'user-1',
+      });
+      expect(info.apiKeyBlocked, isFalse);
+      expect(info.apiKeyDisabled, isFalse);
+      expect(info.teamBlocked, isFalse);
+      expect(info.acls, hasLength(2));
+      expect(info.name, 'my key');
+    });
+  });
+
+  group('Grok client', () {
+    test('is an LLMAIBase with the api key set', () {
+      final ai = Grok(apiKey: 'xai-test');
+      expect(ai.apiKey, 'xai-test');
+      expect(ai, isA<LLMAIBase>());
+    });
+  });
+}

--- a/pkgs/minimax_box/README.md
+++ b/pkgs/minimax_box/README.md
@@ -1,3 +1,63 @@
 # minimax_box
 
+[![GitHub](https://img.shields.io/github/license/normidar/ai_box.svg)](https://github.com/normidar/ai_box/blob/main/LICENSE)
+[![pub package](https://img.shields.io/pub/v/minimax_box.svg)](https://pub.dev/packages/minimax_box)
+[![GitHub Stars](https://img.shields.io/github/stars/normidar/ai_box.svg)](https://github.com/normidar/ai_box/stargazers)
+[![Github-sponsors](https://img.shields.io/badge/sponsor-30363D?logo=GitHub-Sponsors&logoColor=#EA4AAA)](https://github.com/sponsors/normidar)
+
 A MiniMax AI provider based on [ai_box](https://github.com/normidar/ai_box).
+
+## Usage
+
+```dart
+import 'package:ai_box/ai_box.dart';
+import 'package:minimax_box/minimax_box.dart';
+
+Future<void> main() async {
+  final ai = MiniMax(apiKey: '...');
+
+  // One-shot text generation.
+  final answer = await ai.generateText(
+    model: 'MiniMax-Text-01',
+    message: 'Say hello in one short sentence.',
+  );
+  print(answer);
+
+  // Multi-turn chat.
+  final res = await ai.chat(
+    model: 'MiniMax-Text-01',
+    messages: [
+      LLMContent.system('You are concise.'),
+      LLMContent.user('What is the capital of Japan?'),
+    ],
+    maxTokens: 32,
+  );
+  print(res.text);
+  print(res.usage); // token usage
+}
+```
+
+## Streaming
+
+True SSE streaming — text arrives incrementally and the final chunk carries
+the finish reason:
+
+```dart
+await for (final text in ai.generateTextStream(
+  model: 'MiniMax-Text-01',
+  message: 'Write a haiku about Dart.',
+)) {
+  stdout.write(text);
+}
+```
+
+## Models and key validation
+
+```dart
+final models = await ai.getModels();
+final ok = await ai.validateKey();
+```
+
+Tool calling, structured output and the sealed `LLMException` error
+hierarchy are all provided by [ai_box](https://pub.dev/packages/ai_box) —
+see its README for details.

--- a/pkgs/minimax_box/pubspec.yaml
+++ b/pkgs/minimax_box/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
   json_annotation: ^4.9.0
 description: A MiniMax AI provider based on ai_box.
 dev_dependencies:
-  auto_exporter: any
+  auto_exporter: ^4.0.0
   build_runner: ^2.5.4
   freezed: ^3.0.6
   json_serializable: ^6.9.5
@@ -15,6 +15,7 @@ dev_dependencies:
 environment:
   sdk: ^3.2.0
 homepage: https://github.com/normidar/ai_box
+repository: https://github.com/normidar/ai_box
 name: minimax_box
 topics:
   - ai

--- a/pkgs/minimax_box/test/minimax_box_test.dart
+++ b/pkgs/minimax_box/test/minimax_box_test.dart
@@ -1,0 +1,91 @@
+import 'package:ai_box/ai_box.dart';
+import 'package:minimax_box/minimax_box.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ChatCompletionResponse.fromJson', () {
+    final json = <String, dynamic>{
+      'id': 'chatcmpl-123',
+      'object': 'chat.completion',
+      'created': 1721260800,
+      'model': 'MiniMax-Text-01',
+      'input_sensitive': false,
+      'output_sensitive': false,
+      'choices': [
+        {
+          'index': 0,
+          'message': {
+            'role': 'assistant',
+            'content': 'Hello!',
+            'reasoning_content': 'The user greeted me.',
+          },
+          'finish_reason': 'stop',
+        },
+      ],
+      'usage': {
+        'prompt_tokens': 10,
+        'completion_tokens': 5,
+        'total_tokens': 15,
+      },
+    };
+
+    test('parses a full response', () {
+      final res = ChatCompletionResponse.fromJson(json);
+      expect(res.id, 'chatcmpl-123');
+      expect(res.model, 'MiniMax-Text-01');
+      expect(res.inputSensitive, isFalse);
+      expect(res.outputSensitive, isFalse);
+      expect(res.choices, hasLength(1));
+      expect(res.choices.first.message.content, 'Hello!');
+      expect(
+        res.choices.first.message.reasoningContent,
+        'The user greeted me.',
+      );
+      expect(res.choices.first.finishReason, 'stop');
+      expect(res.usage?.promptTokens, 10);
+      expect(res.usage?.completionTokens, 5);
+      expect(res.usage?.totalTokens, 15);
+    });
+
+    test('tolerates missing optional fields', () {
+      final res = ChatCompletionResponse.fromJson({
+        'id': 'chatcmpl-1',
+        'object': 'chat.completion',
+        'created': 1,
+        'model': 'MiniMax-Text-01',
+        'choices': [
+          {
+            'index': 0,
+            'message': {'role': 'assistant'},
+          },
+        ],
+      });
+      expect(res.inputSensitive, isNull);
+      expect(res.usage, isNull);
+      expect(res.choices.first.finishReason, isNull);
+      expect(res.choices.first.message.content, isNull);
+    });
+  });
+
+  group('ModelList.fromJson', () {
+    test('parses the model list', () {
+      final list = ModelList.fromJson({
+        'object': 'list',
+        'data': [
+          {'id': 'MiniMax-Text-01', 'object': 'model', 'owned_by': 'minimax'},
+        ],
+      });
+      expect(list.data, hasLength(1));
+      expect(list.data.first.id, 'MiniMax-Text-01');
+      expect(list.data.first.ownedBy, 'minimax');
+    });
+  });
+
+  group('MiniMax client', () {
+    test('is an LLMAIBase with the api key set', () {
+      final ai = MiniMax(apiKey: 'test-key');
+      expect(ai.apiKey, 'test-key');
+      expect(ai, isA<LLMAIBase>());
+    });
+  });
+}

--- a/pkgs/openrouter_box/README.md
+++ b/pkgs/openrouter_box/README.md
@@ -9,6 +9,7 @@ with the `provider/model` form, e.g. `openai/gpt-4o-mini`.
 ## Usage
 
 ```dart
+import 'package:ai_box/ai_box.dart';
 import 'package:openrouter_box/openrouter_box.dart';
 
 Future<void> main() async {

--- a/pkgs/openrouter_box/pubspec.yaml
+++ b/pkgs/openrouter_box/pubspec.yaml
@@ -4,13 +4,14 @@ dependencies:
   api_http: ^0.0.1
 description: An OpenRouter AI provider based on ai_box.
 dev_dependencies:
-  auto_exporter: any
+  auto_exporter: ^4.0.0
   build_runner: ^2.5.4
   test: ^1.26.0
   very_good_analysis: any
 environment:
   sdk: ^3.7.0
 homepage: https://github.com/normidar/ai_box
+repository: https://github.com/normidar/ai_box
 name: openrouter_box
 topics:
   - ai


### PR DESCRIPTION
## 概要

リポジトリ全体を調査し、見つかった改善点をまとめて修正しました。

### 1. gemini_box: ファイル API のバグ修正 (`gemini_files_core.dart`)

- 生の `Exception` を ai_box の sealed な `LLMUnknownException` に統一（呼び出し側が `on LLMException` で網羅的に処理できるように）
- `headers['x-goog-upload-url']!` の unsafe な `!` を null チェックに変更し、ヘッダー欠落時に適切な例外を投げるように
- ファイルが 0 件のとき API が `files` キーなしの `{}` を返すため cast エラーで落ちていた問題を修正（空リストを返す）
- `lookupMimeType()` が null を返すファイル（拡張子不明など）で `!` により落ちていた問題を `application/octet-stream` フォールバックで修正
- アップロードレスポンスの `file` オブジェクト欠落も検証するように

### 2. README の刷新

- **chatgpt_box / claude_box / grok_box**: タイトルが「ai_box」のままで、内容も古い ai_box の説明（現存しない `chat()` / `getModelIds()` API やテストユーティリティの説明）のコピーだったため、各プロバイダー向けの使用例付き README に書き直し
- **deepseek_box / minimax_box**: 3 行のみのスタブだったため、使用例・ストリーミング・モデル取得を含む内容に拡充
- **openrouter_box**: コード例で `LLMContent` を使用しているのに `ai_box` の import が抜けていたのを修正
- pub バッジが全パッケージで `ai_box` を指していたのを各パッケージに修正

### 3. テスト追加（テストゼロだった 4 パッケージ）

chatgpt_box / deepseek_box / grok_box / minimax_box に、レスポンス・モデルリスト・（grok は APIキー情報）の JSON パーステストとクライアント基本テストを追加。CI の `test_all` は `test/` ディレクトリの有無で実行を判定するため、これらのパッケージも CI でテストされるようになります。

### 4. pubspec の整備

- 全 8 パッケージに `repository:` フィールドを追加（pub.dev のスコアリング対象）
- `auto_exporter: any` を ai_box と同じ `^4.0.0` に固定（7 パッケージ）

## 修正していない点（参考）

- deepseek/minimax/grok の実装は構造が似ていますが、レスポンスモデルにプロバイダー固有フィールド（MiniMax の `input_sensitive`、Grok の `citations` など）があるため、共通基底クラス化は今回見送りました
- `very_good_analysis: any` の固定は、バージョンによって lint セットが変わり analyze が壊れる可能性があるため見送りました

https://claude.ai/code/session_01GpqK57hCM8W1ZLe9naa32P

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpqK57hCM8W1ZLe9naa32P)_