### PR TITLE
improve: 廃止間近の Claude モデルを置き換え、ドキュメントのモデル ID を現行モデルに更新

### DIFF
--- a/pkgs/ai_box/README.md
+++ b/pkgs/ai_box/README.md
@@ -38,7 +38,7 @@ import 'dart:typed_data';
 import 'package:ai_box/ai_box.dart';
 
 final res = await ai.chat(
-  model: 'gpt-4o',
+  model: 'gpt-5.5',
   messages: [
     LLMContent.user('Describe these', attachments: [
       LLMImagePart.bytes(pngBytes, mimeType: 'image/png'),
@@ -117,7 +117,7 @@ try {
 
 ```dart
 final res = await ai.chat(
-  model: 'gpt-4o',
+  model: 'gpt-5.5',
   messages: [LLMContent.user('Weather in Tokyo?')],
   tools: [
     LLMTool(
@@ -146,7 +146,7 @@ for (final call in res.toolCalls) {
 
 ```dart
 final res = await ai.chat(
-  model: 'gpt-4o',
+  model: 'gpt-5.5',
   messages: [LLMContent.user('Extract name and age')],
   responseFormat: LLMResponseFormat.jsonSchema(
     schema: {

--- a/pkgs/ai_box/lib/src/exceptions.dart
+++ b/pkgs/ai_box/lib/src/exceptions.dart
@@ -5,7 +5,7 @@
 ///
 /// ```dart
 /// try {
-///   await ai.generateText(model: 'gpt-4o', message: 'hi');
+///   await ai.generateText(model: 'gpt-5.5', message: 'hi');
 /// } on LLMException catch (e) {
 ///   final msg = switch (e) {
 ///     LLMAuthException() => 'APIキーが無効です',

--- a/pkgs/ai_box/lib/src/llm_ai_base.dart
+++ b/pkgs/ai_box/lib/src/llm_ai_base.dart
@@ -131,7 +131,7 @@ abstract class LLMAIBase extends AIBase implements LLMAIInterface {
   ///
   /// ```dart
   /// final answer = await ai.askWithImages(
-  ///   model: 'gpt-4o',
+  ///   model: 'gpt-5.5',
   ///   prompt: 'この画像を説明して',
   ///   images: [LLMImagePart.bytes(bytes, mimeType: 'image/png')],
   /// );

--- a/pkgs/chatgpt_box/README.md
+++ b/pkgs/chatgpt_box/README.md
@@ -18,14 +18,14 @@ Future<void> main() async {
 
   // One-shot text generation.
   final answer = await ai.generateText(
-    model: 'gpt-4o-mini',
+    model: 'gpt-5.4-mini',
     message: 'Say hello in one short sentence.',
   );
   print(answer);
 
   // Multi-turn chat.
   final res = await ai.chat(
-    model: 'gpt-4o-mini',
+    model: 'gpt-5.4-mini',
     messages: [
       LLMContent.system('You are concise.'),
       LLMContent.user('What is the capital of Japan?'),
@@ -44,7 +44,7 @@ the finish reason and token usage:
 
 ```dart
 await for (final text in ai.generateTextStream(
-  model: 'gpt-4o-mini',
+  model: 'gpt-5.4-mini',
   message: 'Write a haiku about Dart.',
 )) {
   stdout.write(text);

--- a/pkgs/claude_box/CHANGELOG.md
+++ b/pkgs/claude_box/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.4
+
+- `easyTalk()` now uses `claude-sonnet-4-6` instead of
+  `claude-sonnet-4-20250514`, which Anthropic retires on June 15, 2026.
+
 ## 0.1.3
 
 - `completionsStream()` now uses real SSE streaming of the Messages API

--- a/pkgs/claude_box/lib/src/claude.dart
+++ b/pkgs/claude_box/lib/src/claude.dart
@@ -65,7 +65,7 @@ class Claude extends LLMAIBase {
     try {
       final res = await completions(
         LLMCompletionRequest(
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-6',
           messages: [LLMContent.user(message)],
           maxTokens: maxTokens ?? defaultMaxTokens,
         ),

--- a/pkgs/claude_box/pubspec.yaml
+++ b/pkgs/claude_box/pubspec.yaml
@@ -23,4 +23,4 @@ topics:
   - ai-box
   - llm
   - anthropic
-version: 0.1.3
+version: 0.1.4

--- a/pkgs/gemini_box/README.md
+++ b/pkgs/gemini_box/README.md
@@ -1,117 +1,113 @@
-# Gemini Box
+# gemini_box
 
-## Overview
+[![GitHub](https://img.shields.io/github/license/normidar/ai_box.svg)](https://github.com/normidar/ai_box/blob/main/LICENSE)
+[![pub package](https://img.shields.io/pub/v/gemini_box.svg)](https://pub.dev/packages/gemini_box)
+[![GitHub Stars](https://img.shields.io/github/stars/normidar/ai_box.svg)](https://github.com/normidar/ai_box/stargazers)
+[![Github-sponsors](https://img.shields.io/badge/sponsor-30363D?logo=GitHub-Sponsors&logoColor=#EA4AAA)](https://github.com/sponsors/normidar)
 
-Gemini Box is a wrapper library for easily using the Gemini API, Google Cloud Platform (GCP)'s Generative AI API, in Dart. This package is used within the Coin Galaxy project and enables efficient communication with Gemini AI models.
-
-## Features
-
-- Support for the latest Gemini AI models (Gemini 1.0, 1.5, 2.0, 2.5, etc.)
-- Text generation, image understanding, embedding generation, and other capabilities
-- File upload and file management support
-- Compatible with various Gemini model versions
-- Flexible request configuration options
+A Google Gemini provider based on [ai_box](https://github.com/normidar/ai_box).
 
 ## Usage
 
 ```dart
+import 'package:ai_box/ai_box.dart';
 import 'package:gemini_box/gemini_box.dart';
 
-void main() async {
-  // Initialize Gemini instance with API key
-  final gemini = Gemini(apiKey: 'YOUR_API_KEY');
+Future<void> main() async {
+  final ai = Gemini(apiKey: 'YOUR_API_KEY');
 
-  // Create request
-  final requestBody = RequestBody(
+  // One-shot text generation.
+  final answer = await ai.generateText(
+    model: 'gemini-3.5-flash',
+    message: 'Say hello in one short sentence.',
+  );
+  print(answer);
+
+  // Multi-turn chat.
+  final res = await ai.chat(
+    model: 'gemini-3.5-flash',
+    messages: [
+      LLMContent.system('You are concise.'),
+      LLMContent.user('What is the capital of Japan?'),
+    ],
+    maxTokens: 32,
+  );
+  print(res.text);
+  print(res.usage); // token usage
+}
+```
+
+## Streaming
+
+True SSE streaming — text arrives incrementally and the final chunk carries
+the finish reason and token usage:
+
+```dart
+await for (final text in ai.generateTextStream(
+  model: 'gemini-3.5-flash',
+  message: 'Write a haiku about Dart.',
+)) {
+  stdout.write(text);
+}
+```
+
+## Working with images
+
+Pass images as `LLMContentPart`s on any message — `ai_box` converts them to
+Gemini `inlineData` / `fileData` automatically:
+
+```dart
+final res = await ai.chat(
+  model: 'gemini-3.5-flash',
+  messages: [
+    LLMContent.user('Please describe this image.', attachments: [
+      LLMImagePart.bytes(jpegBytes, mimeType: 'image/jpeg'),
+    ]),
+  ],
+);
+print(res.text);
+```
+
+## Low-level typed API
+
+For full control over the request body, use `generateContent` with the typed
+request/response classes:
+
+```dart
+final response = await ai.generateContent(
+  model: 'gemini-3.5-flash',
+  requestBody: RequestBody(
     contents: [
-      Content(
-        parts: [
-          Part(text: 'Hello, Gemini!'),
-        ],
-      ),
+      Content(parts: [Part(text: 'Hello, Gemini!')]),
     ],
     generationConfig: GenerationConfig(
       temperature: 0.7,
       maxOutputTokens: 1000,
     ),
-  );
-
-  // Generate content
-  final response = await gemini.generateContent(
-    model: GeminiVersions.gemini15Pro.version,
-    requestBody: requestBody,
-  );
-
-  // Handle response
-  print(response.candidates?.first.content?.parts?.first);
-}
+  ),
+);
+print(response.candidates?.first.content?.parts?.first);
 ```
 
-## Working with Images
+## Files API
+
+Upload and manage files via `ai.files` (the Gemini Files API):
 
 ```dart
-import 'dart:convert';
-import 'dart:io';
-import 'package:gemini_box/gemini_box.dart';
-
-void main() async {
-  // Load image file
-  final imageFile = File('path/to/image.jpg');
-  final imageBytes = await imageFile.readAsBytes();
-  final base64Image = base64Encode(imageBytes);
-
-  // Initialize Gemini instance
-  final gemini = Gemini(apiKey: 'YOUR_API_KEY');
-
-  // Generate content with inline image
-  final response = await gemini.generateContent(
-    model: GeminiVersions.gemini20FlashLite.version,
-    requestBody: RequestBody(
-      contents: [
-        Content(
-          parts: [
-            Part(inlineData: Blob(
-              mimeType: 'image/jpeg',
-              data: base64Image,
-            )),
-            Part(text: 'Please describe this image.'),
-          ],
-        ),
-      ],
-    ),
-  );
-
-  // Display result
-  print(response.candidates?.first.content?.parts?.first);
-}
+final file = await ai.files.uploadFile(file: File('path/to/image.jpg'));
+final files = await ai.files.getFiles();
 ```
 
-## Supported Models
+## Models and key validation
 
-This library supports numerous Gemini model versions, including:
-
-- Gemini 1.0 Pro Vision
-- Gemini 1.5 Pro
-- Gemini 1.5 Flash
-- Gemini 2.0 Flash
-- Gemini 2.5 Flash Preview
-- And many others
-
-## Installation
-
-Add the dependency to your `pubspec.yaml` file:
-
-```yaml
-dependencies:
-  gemini_box: ^1.0.0
+```dart
+final models = await ai.getModels(); // live model list from the API
+final ok = await ai.validateKey();
 ```
 
-Then install the package:
+Pass any model ID the API serves (see `getModels()`), e.g.
+`gemini-3.5-flash` or other current Gemini 3.x models.
 
-```bash
-dart pub get
-```
-
-## License
-
-This project is provided under the MIT License.
+Multimodal input (images, files), tool calling, structured output and the
+sealed `LLMException` error hierarchy are all provided by
+[ai_box](https://pub.dev/packages/ai_box) — see its README for details.

--- a/pkgs/grok_box/README.md
+++ b/pkgs/grok_box/README.md
@@ -18,14 +18,14 @@ Future<void> main() async {
 
   // One-shot text generation.
   final answer = await ai.generateText(
-    model: 'grok-3',
+    model: 'grok-4.3',
     message: 'Say hello in one short sentence.',
   );
   print(answer);
 
   // Multi-turn chat.
   final res = await ai.chat(
-    model: 'grok-3',
+    model: 'grok-4.3',
     messages: [
       LLMContent.system('You are concise.'),
       LLMContent.user('What is the capital of Japan?'),
@@ -44,7 +44,7 @@ the finish reason:
 
 ```dart
 await for (final text in ai.generateTextStream(
-  model: 'grok-3',
+  model: 'grok-4.3',
   message: 'Write a haiku about Dart.',
 )) {
   stdout.write(text);

--- a/pkgs/minimax_box/README.md
+++ b/pkgs/minimax_box/README.md
@@ -18,14 +18,14 @@ Future<void> main() async {
 
   // One-shot text generation.
   final answer = await ai.generateText(
-    model: 'MiniMax-Text-01',
+    model: 'MiniMax-M3',
     message: 'Say hello in one short sentence.',
   );
   print(answer);
 
   // Multi-turn chat.
   final res = await ai.chat(
-    model: 'MiniMax-Text-01',
+    model: 'MiniMax-M3',
     messages: [
       LLMContent.system('You are concise.'),
       LLMContent.user('What is the capital of Japan?'),
@@ -44,7 +44,7 @@ the finish reason:
 
 ```dart
 await for (final text in ai.generateTextStream(
-  model: 'MiniMax-Text-01',
+  model: 'MiniMax-M3',
   message: 'Write a haiku about Dart.',
 )) {
   stdout.write(text);

--- a/pkgs/openrouter_box/README.md
+++ b/pkgs/openrouter_box/README.md
@@ -4,7 +4,7 @@ An [OpenRouter](https://openrouter.ai) AI provider based on [ai_box](https://git
 
 OpenRouter exposes a single OpenAI-compatible endpoint that routes to many
 underlying models (OpenAI, Anthropic, Google, Meta, and more). Specify a model
-with the `provider/model` form, e.g. `openai/gpt-4o-mini`.
+with the `provider/model` form, e.g. `openai/gpt-5.4-mini`.
 
 ## Usage
 
@@ -17,14 +17,14 @@ Future<void> main() async {
 
   // One-shot text generation.
   final answer = await ai.generateText(
-    model: 'openai/gpt-4o-mini',
+    model: 'openai/gpt-5.4-mini',
     message: 'Say hello in one short sentence.',
   );
   print(answer);
 
   // Multi-turn chat.
   final res = await ai.chat(
-    model: 'openai/gpt-4o-mini',
+    model: 'openai/gpt-5.4-mini',
     messages: [
       LLMContent.system('You are concise.'),
       LLMContent.user('What is the capital of Japan?'),

--- a/pkgs/openrouter_box/lib/src/models/openrouter_model.dart
+++ b/pkgs/openrouter_box/lib/src/models/openrouter_model.dart
@@ -49,7 +49,7 @@ class OpenRouterModel {
     );
   }
 
-  /// モデル ID（例: `openai/gpt-4o-mini`）。
+  /// モデル ID（例: `openai/gpt-5.4-mini`）。
   final String id;
 
   /// 人間可読のモデル名。

--- a/pkgs/openrouter_box/lib/src/openrouter.dart
+++ b/pkgs/openrouter_box/lib/src/openrouter.dart
@@ -8,12 +8,12 @@ import 'package:openrouter_box/src/models/openrouter_model.dart';
 ///
 /// OpenRouter は OpenAI 互換の単一エンドポイントから、OpenAI・Anthropic・
 /// Google・Meta など多数のモデルへアクセスできるルーターサービス。
-/// モデル ID は `openai/gpt-4o-mini` のように `provider/model` 形式で指定する。
+/// モデル ID は `openai/gpt-5.4-mini` のように `provider/model` 形式で指定する。
 ///
 /// ```dart
 /// final ai = OpenRouter(apiKey: 'sk-or-...');
 /// final answer = await ai.generateText(
-///   model: 'openai/gpt-4o-mini',
+///   model: 'openai/gpt-5.4-mini',
 ///   message: 'こんにちは',
 /// );
 /// ```


### PR DESCRIPTION
## 概要

リポジトリ内の古い LLM モデル ID を 2026 年 6 月時点の現行モデルに更新しました。

## 変更内容

### 🔴 重要: claude_box のコード修正（0.1.3 → 0.1.4）

- `Claude.easyTalk()` がハードコードしていた `claude-sonnet-4-20250514` は **2026-06-15（3 日後）に Anthropic が廃止予定**で、以降 404 になります。後継の `claude-sonnet-4-6` に置き換えました。

### 📝 ドキュメントのモデル ID 更新

各パッケージの README / doc コメントの例を現行モデルに更新:

| パッケージ | 旧 | 新 |
|---|---|---|
| ai_box | `gpt-4o` | `gpt-5.5` |
| chatgpt_box | `gpt-4o-mini` | `gpt-5.4-mini` |
| grok_box | `grok-3` | `grok-4.3` |
| minimax_box | `MiniMax-Text-01` | `MiniMax-M3` |
| openrouter_box | `openai/gpt-4o-mini` | `openai/gpt-5.4-mini` |
| gemini_box | `GeminiVersions.gemini15Pro` 等 | `gemini-3.5-flash` |

### 🔧 gemini_box README の書き直し

旧 README はコードに存在しない `GeminiVersions` enum を参照しており、`LLMAIBase` ベースの実際の API とも乖離していました。他パッケージと同じ構成（generateText / chat / ストリーミング / 画像 / 低レベル typed API / Files API）に合わせて書き直しました。記載した API はすべて実装に存在することを確認済みです。

## 備考

- テストのモック内のモデル文字列（fixture）は実 API を呼ばないため変更していません。
- 各プロバイダの `getModels()` は API から動的に取得するため、コード側にモデルカタログの追加は不要です。
- この環境に Dart SDK がないため `dart analyze` / `dart test` は未実行です（コード変更は文字列定数 1 行のみ）。

https://claude.ai/code/session_01JGUQ5uip7iRdVkPZeXSpqf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGUQ5uip7iRdVkPZeXSpqf)_